### PR TITLE
Use only unique usernames when creating new customers

### DIFF
--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -20,6 +20,12 @@ class Customer extends Generator {
 	 */
 	public static function generate( $save = true ) {
 		$faker       = \Faker\Factory::create();
+
+		// Make sure a unique username is used.
+		do {
+			$username = $faker->userName();
+		} while ( username_exists( $username ) );
+
 		$email       = $faker->safeEmail();
 		$firstname   = $faker->firstName( $faker->randomElement( array( 'male', 'female' ) ) );
 		$lastname    = $faker->lastName();
@@ -41,7 +47,7 @@ class Customer extends Generator {
 			'last_name'           => $lastname,
 			'display_name'        => $firstname,
 			'role'                => 'customer',
-			'username'            => $faker->userName(),
+			'username'            => $username,
 			'password'            => $faker->password(),
 			'billing_first_name'  => $firstname,
 			'billing_last_name'   => $lastname,


### PR DESCRIPTION
This commit adds a check to verify if the username supplied by Faker already exists. If it does, the code will call Faker again until a username that doesn't exist is returned. This way we avoid the following PHP fatal error:

[27-Jul-2018 17:24:37 UTC] PHP Fatal error:  Uncaught WC_Data_Exception: An account is already registered with that username. Please choose another. in wp-content/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store.php:109

Fixes #10