### PR TITLE
Add ability to create orders with random dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,26 @@ WooCommerce Smooth Generator requires Composer and WP-CLI to function.
 5. You now have access to a couple of new WP-CLI commands under the main `wp wc generate` command.
 
 ## Commands
-- `wp wc generate products <nr of products>` Generate products based on the number of products paramater.
-- `wp wc generate orders <nr of orders>` Generate orders from existing products based on the number of orders paramater, customers will also be generated to mimic guest checkout.
-- `wp wc generate customers <nr of customers>` Generate customers based on the number of customers paramater.
+
+### Products
+
+Generate products based on the number of products paramater.
+- `wp wc generate products <nr of products>`
+
+### Orders
+
+Generate orders from existing products based on the number of orders paramater, customers will also be generated to mimic guest checkout.
+
+Generate orders for the current date
+- `wp wc generate orders <nr of orders>`
+
+Generate orders with random dates between `--date-start` and the current date.
+- `wp wc generate orders <nr of orders> --date-start=2018-04-01`
+
+Generate orders with random dates between `--date-start` and `--date-end`.
+- `wp wc generate orders <nr of orders> --date-start=2018-04-01 --date-end=2018-04-24`
+
+### Customers
+
+Generate customers based on the number of customers paramater.
+- `wp wc generate customers <nr of customers>`

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -64,7 +64,7 @@ class CLI extends WP_CLI_Command {
 
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating orders', $amount );
 		for ( $i = 1; $i <= $amount; $i++ ) {
-			Generator\Order::generate();
+			Generator\Order::generate( true, $assoc_args );
 			$progress->tick();
 		}
 		$progress->finish();
@@ -100,4 +100,25 @@ class CLI extends WP_CLI_Command {
 		WP_CLI::success( $amount . ' customers generated.' );
 	}
 }
-WP_CLI::add_command( 'wc generate', 'WC\SmoothGenerator\CLI' );
+WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'products' ) );
+WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'orders' ), array(
+	'synopsis' => array(
+		array(
+			'name'     => 'id',
+			'type'     => 'positional',
+			'optional' => false,
+		),
+		array(
+			'name'     => 'date-start',
+			'type'     => 'assoc',
+			'optional' => true,
+		),
+		array(
+			'name'     => 'date-end',
+			'type'     => 'assoc',
+			'optional' => true,
+		),
+	),
+) );
+WP_CLI::add_command( 'wc generate customers', array( 'WC\SmoothGenerator\CLI', 'customers' ) );
+


### PR DESCRIPTION
This PR adds some new functionality to the order generator. You can pass in `start-date` and `end-date` arguments and a random date will be selected for each order. If you pass no arguments, the current date is used (which is the current behavior).

This makes testing things like report functionality in `wc-admin` much easier.

To Test:
* Run combinations of the `generate orders` command and verify random dates are selected. See the README changes in this branch for examples.