### PR TITLE
Add in a random time to the order date

### DIFF
--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -59,7 +59,10 @@ class Order extends Generator {
 		) ) );
 		$order->calculate_totals( true );
 
-		$order->set_date_created( self::get_date_created( $assoc_args ) );
+		$date = self::get_date_created( $assoc_args );
+		$date .= ' ' . rand( 0, 23 ) . ':00:00';
+
+		$order->set_date_created( $date );
 
 		if ( $save ) {
 			$order->save();


### PR DESCRIPTION
This PR adds a random time to each order. This will make it easier to test reports that are broken down by hour (otherwise all orders are made at `00:00:00`).

To Test:
* Generate some orders for a single day (i.e. `wp wc generate orders 10 --date-start=2018-04-01 --date-end=2018-04-1`)
* Open the created orders and verify an hour is set.