### PR TITLE
Use full file path to include vendor/autoload.php

### DIFF
--- a/wc-smooth-generator.php
+++ b/wc-smooth-generator.php
@@ -13,7 +13,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // autoloader.
-require 'vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
 
 /**
  * Fetch instance of plugin.


### PR DESCRIPTION
At present, `vendor/autoload.php` is included in `wc-smooth-generator.php` with this code,
```php
require 'vendor/autoload.php';
```
Now suppose, we have a plugin name, `my-plugin` and that plugin also uses composer to autoload its classes. If we run any wc command while our terminal current working directory is `my-plugin`, then the above code will try to include autoload.php from my-plugin directory, not from `wc-smooth-generator` directory. This PR fixes this issue.