### PR TITLE
Move dependency fzaninotto/faker from dev packages to regular packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,13 @@
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
-    "composer/installers": "~1.2"
+    "composer/installers": "~1.2",
+    "fzaninotto/faker": "^1.8"
   },
   "autoload": {
     "psr-4": {"WC\\SmoothGenerator\\": "includes/"}
   },
   "require-dev": {
-    "fzaninotto/faker": "^1.8",
     "squizlabs/php_codesniffer": "*",
     "wp-coding-standards/wpcs": "^0.14",
     "woocommerce/woocommerce-git-hooks": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -125,6 +125,56 @@
                 "zikula"
             ],
             "time": "2017-12-29T09:13:20+00:00"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "f72816b43e74063c8b10357394b6bba8cb1c10de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/f72816b43e74063c8b10357394b6bba8cb1c10de",
+                "reference": "f72816b43e74063c8b10357394b6bba8cb1c10de",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7",
+                "squizlabs/php_codesniffer": "^1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2018-07-12T10:23:15+00:00"
         }
     ],
     "packages-dev": [
@@ -195,56 +245,6 @@
                 "tests"
             ],
             "time": "2017-12-06T16:27:17+00:00"
-        },
-        {
-            "name": "fzaninotto/faker",
-            "version": "v1.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "f72816b43e74063c8b10357394b6bba8cb1c10de"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/f72816b43e74063c8b10357394b6bba8cb1c10de",
-                "reference": "f72816b43e74063c8b10357394b6bba8cb1c10de",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "ext-intl": "*",
-                "phpunit/phpunit": "^4.8.35 || ^5.7",
-                "squizlabs/php_codesniffer": "^1.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.8-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Faker\\": "src/Faker/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "François Zaninotto"
-                }
-            ],
-            "description": "Faker is a PHP library that generates fake data for you.",
-            "keywords": [
-                "data",
-                "faker",
-                "fixtures"
-            ],
-            "time": "2018-07-12T10:23:15+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",


### PR DESCRIPTION
The `fzaninotto/faker`dependency is declared as a development package on `composer.json` but it seems that it should live among regular dependencies, given that doing `composer install --no-dev` (after this plugin is cloned/downloaded), ends up with a missing runtime dependency.

#### Changes proposed in this Pull Request:

* Moves the dependency `fzaninotto/faker` from the section `require-dev` to `require` in composer.json
* Moves the matching block for `fzaninotto/faker` in `composer.lock` from `pacakges-dev` to  `packages`.

#### Testing instructions>


* Checkout this branch.
* To verify this changeset is proper, remove your local `vendor` directory in case it's present.
* Run `composer install --no-dev` from inside the `wc-smooth-generator` directory.
* Confirm you can run this plugin properly with the installed packages. 
* To rollback this changeset, remove the `vendor` directory, checkout to `master` and run `composer install`. 