### PR TITLE
Performance tweaks

### DIFF
--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -13,13 +13,6 @@ namespace WC\SmoothGenerator\Generator;
 class Customer extends Generator {
 
 	/**
-	 * Holds the faker factory object.
-	 *
-	 * @var \Faker\Factory Factory object.
-	 */
-	protected static $faker;
-
-	/**
 	 * Return a new customer.
 	 *
 	 * @param bool $save Save the object before returning or not.

--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -13,33 +13,42 @@ namespace WC\SmoothGenerator\Generator;
 class Customer extends Generator {
 
 	/**
+	 * Holds the faker factory object.
+	 *
+	 * @var \Faker\Factory Factory object.
+	 */
+	protected static $faker;
+
+	/**
 	 * Return a new customer.
 	 *
 	 * @param bool $save Save the object before returning or not.
 	 * @return \WC_Customer Customer object with data populated.
 	 */
 	public static function generate( $save = true ) {
-		$faker       = \Faker\Factory::create();
+		if ( ! self::$faker ) {
+			self::$faker = \Faker\Factory::create();
+		}
 
 		// Make sure a unique username and e-mail are used.
 		do {
-			$username = $faker->userName();
+			$username = self::$faker->userName();
 		} while ( username_exists( $username ) );
 
 		do {
-			$email = $faker->safeEmail();
+			$email = self::$faker->safeEmail();
 		} while ( email_exists( $email ) );
 
-		$firstname   = $faker->firstName( $faker->randomElement( array( 'male', 'female' ) ) );
-		$lastname    = $faker->lastName();
-		$company     = $faker->company();
-		$address1    = $faker->buildingNumber() . ' ' . $faker->streetName();
-		$address2    = $faker->streetAddress();
-		$city        = $faker->city();
-		$state       = $faker->stateAbbr();
-		$postcode    = $faker->postcode();
-		$countrycode = $faker->countryCode();
-		$phone       = $faker->e164PhoneNumber();
+		$firstname   = self::$faker->firstName( self::$faker->randomElement( array( 'male', 'female' ) ) );
+		$lastname    = self::$faker->lastName();
+		$company     = self::$faker->company();
+		$address1    = self::$faker->buildingNumber() . ' ' . self::$faker->streetName();
+		$address2    = self::$faker->streetAddress();
+		$city        = self::$faker->city();
+		$state       = self::$faker->stateAbbr();
+		$postcode    = self::$faker->postcode();
+		$countrycode = self::$faker->countryCode();
+		$phone       = self::$faker->e164PhoneNumber();
 		$customer    = new \WC_Customer();
 
 		$customer->set_props( array(
@@ -51,7 +60,7 @@ class Customer extends Generator {
 			'display_name'        => $firstname,
 			'role'                => 'customer',
 			'username'            => $username,
-			'password'            => $faker->password(),
+			'password'            => self::$faker->password(),
 			'billing_first_name'  => $firstname,
 			'billing_last_name'   => $lastname,
 			'billing_company'     => $company,

--- a/includes/Generator/Generator.php
+++ b/includes/Generator/Generator.php
@@ -16,6 +16,13 @@ abstract class Generator {
 	const IMAGE_HEIGHT = 400;
 
 	/**
+	 * Holds the faker factory object.
+	 *
+	 * @var \Faker\Factory Factory object.
+	 */
+	protected static $faker;
+
+	/**
 	 * Return a new object of this object type.
 	 *
 	 * @param bool $save Save the object before returning or not.
@@ -31,8 +38,11 @@ abstract class Generator {
 	 * @return array
 	 */
 	protected static function generate_term_ids( $limit, $taxonomy ) {
-		$faker    = \Faker\Factory::create();
-		$terms    = $faker->words( $limit );
+		if ( ! self::$faker ) {
+			self::$faker = \Faker\Factory::create();
+		}
+
+		$terms    = self::$faker->words( $limit );
 		$term_ids = array();
 
 		foreach ( $terms as $term ) {
@@ -60,15 +70,16 @@ abstract class Generator {
 	 * @return int The attachment id of the image (0 on failure).
 	 */
 	protected static function generate_image( int $parent = 0 ) {
+		if ( ! self::$faker ) {
+			self::$faker = \Faker\Factory::create();
+		}
 
-		// Build the image.
-		$faker            = \Faker\Factory::create();
 		$image            = @imagecreatetruecolor( self::IMAGE_WIDTH, self::IMAGE_HEIGHT );
-		$background_rgb   = $faker->rgbColorAsArray;
+		$background_rgb   = self::$faker->rgbColorAsArray;
 		$background_color = imagecolorallocate( $image, $background_rgb[0], $background_rgb[1], $background_rgb[2] );
 		imagefill( $image, 0, 0, $background_color );
 		$text_color = imagecolorallocate( $image, 0, 0, 0 );
-		imagestring( $image, 5, 0, 0, $faker->emoji, $text_color );
+		imagestring( $image, 5, 0, 0, self::$faker->emoji, $text_color );
 		ob_start();
 		imagepng( $image );
 		$file = ob_get_clean();

--- a/includes/Generator/Generator.php
+++ b/includes/Generator/Generator.php
@@ -78,8 +78,6 @@ abstract class Generator {
 		$background_rgb   = self::$faker->rgbColorAsArray;
 		$background_color = imagecolorallocate( $image, $background_rgb[0], $background_rgb[1], $background_rgb[2] );
 		imagefill( $image, 0, 0, $background_color );
-		$text_color = imagecolorallocate( $image, 0, 0, 0 );
-		imagestring( $image, 5, 0, 0, self::$faker->emoji, $text_color );
 		ob_start();
 		imagepng( $image );
 		$file = ob_get_clean();

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -11,6 +11,14 @@ namespace WC\SmoothGenerator\Generator;
  * Order data generator.
  */
 class Order extends Generator {
+
+	/**
+	 * Holds the faker factory object.
+	 *
+	 * @var \Faker\Factory Factory object.
+	 */
+	protected static $faker;
+
 	/**
 	 * Return a new order.
 	 *
@@ -23,7 +31,11 @@ class Order extends Generator {
 		if ( ! isset( $_SERVER['SERVER_NAME'] ) ) {
 			$_SERVER['SERVER_NAME'] = 'localhost';
 		}
-		$faker    = \Faker\Factory::create( 'en_US' );
+
+		if ( ! self::$faker ) {
+			self::$faker = \Faker\Factory::create( 'en_US' );
+		}
+
 		$order    = new \WC_Order();
 		$customer = self::get_customer();
 		if ( ! $customer instanceof \WC_Customer ) {
@@ -32,7 +44,7 @@ class Order extends Generator {
 		$products = self::get_random_products( 1, 10 );
 
 		foreach ( $products as $product ) {
-			$quantity = $faker->numberBetween( 1, 10 );
+			$quantity = self::$faker->numberBetween( 1, 10 );
 			$order->add_product( $product, $quantity );
 		}
 

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -13,13 +13,6 @@ namespace WC\SmoothGenerator\Generator;
 class Order extends Generator {
 
 	/**
-	 * Holds the faker factory object.
-	 *
-	 * @var \Faker\Factory Factory object.
-	 */
-	protected static $faker;
-
-	/**
 	 * Return a new order.
 	 *
 	 * @param bool  $save Save the object before returning or not.

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -13,16 +13,25 @@ namespace WC\SmoothGenerator\Generator;
 class Product extends Generator {
 
 	/**
+	 * Holds the faker factory object.
+	 *
+	 * @var \Faker\Factory Factory object.
+	 */
+	protected static $faker;
+
+	/**
 	 * Return a new product.
 	 *
 	 * @param bool $save Save the object before returning or not.
 	 * @return \WC_Product The product object consisting of random data.
 	 */
 	public static function generate( $save = true ) {
-		$faker = \Faker\Factory::create();
+		if ( ! self::$faker ) {
+			self::$faker = \Faker\Factory::create();
+		}
 
 		// 30% chance of a variable product.
-		$is_variable = $faker->boolean( 30 );
+		$is_variable = self::$faker->boolean( 30 );
 
 		if ( $is_variable ) {
 			$product = self::generate_variable_product();
@@ -43,11 +52,10 @@ class Product extends Generator {
 	 * @return \WC_Product_Variable
 	 */
 	protected static function generate_variable_product() {
-		$faker             = \Faker\Factory::create();
-		$name              = $faker->words( $faker->numberBetween( 1, 5 ), true );
-		$will_manage_stock = $faker->boolean();
+		$name              = self::$faker->words( self::$faker->numberBetween( 1, 5 ), true );
+		$will_manage_stock = self::$faker->boolean();
 		$product           = new \WC_Product_Variable();
-		$nr_attributes     = $faker->numberBetween( 1, 3 );
+		$nr_attributes     = self::$faker->numberBetween( 1, 3 );
 		$attributes        = array();
 
 		$image_id = self::generate_image();
@@ -56,8 +64,8 @@ class Product extends Generator {
 		for ( $i = 0; $i < $nr_attributes; $i++ ) {
 			$attribute = new \WC_Product_Attribute();
 			$attribute->set_id( 0 );
-			$attribute->set_name( ucfirst( $faker->words( $faker->numberBetween( 1, 3 ), true ) ) );
-			$attribute->set_options( array_filter( $faker->words( $faker->numberBetween( 2, 4 ), false ) ), 'ucfirst' );
+			$attribute->set_name( ucfirst( self::$faker->words( self::$faker->numberBetween( 1, 3 ), true ) ) );
+			$attribute->set_options( array_filter( self::$faker->words( self::$faker->numberBetween( 2, 4 ), false ) ), 'ucfirst' );
 			$attribute->set_position( 0 );
 			$attribute->set_visible( true );
 			$attribute->set_variation( true );
@@ -66,24 +74,24 @@ class Product extends Generator {
 
 		$product->set_props( array(
 			'name'              => $name,
-			'featured'          => $faker->boolean( 10 ),
+			'featured'          => self::$faker->boolean( 10 ),
 			'attributes'        => $attributes,
 			'tax_status'        => 'taxable',
 			'tax_class'         => '',
 			'manage_stock'      => $will_manage_stock,
-			'stock_quantity'    => $will_manage_stock ? $faker->numberBetween( -100, 100 ) : null,
+			'stock_quantity'    => $will_manage_stock ? self::$faker->numberBetween( -100, 100 ) : null,
 			'stock_status'      => 'instock',
-			'backorders'        => $faker->randomElement( array( 'yes', 'no', 'notify' ) ),
-			'sold_individually' => $faker->boolean( 20 ),
+			'backorders'        => self::$faker->randomElement( array( 'yes', 'no', 'notify' ) ),
+			'sold_individually' => self::$faker->boolean( 20 ),
 			'upsell_ids'        => self::get_existing_product_ids(),
 			'cross_sell_ids'    => self::get_existing_product_ids(),
 			'image_id'          => $image_id,
-			'category_ids'      => self::generate_term_ids( $faker->numberBetween( 1, 10 ), 'product_cat' ),
-			'tag_ids'           => self::generate_term_ids( $faker->numberBetween( 1, 10 ), 'product_tag' ),
+			'category_ids'      => self::generate_term_ids( self::$faker->numberBetween( 1, 10 ), 'product_cat' ),
+			'tag_ids'           => self::generate_term_ids( self::$faker->numberBetween( 1, 10 ), 'product_tag' ),
 			'gallery_image_ids' => $gallery,
-			'reviews_allowed'   => $faker->boolean(),
-			'purchase_note'     => $faker->boolean() ? $faker->text() : '',
-			'menu_order'        => $faker->numberBetween( 0, 10000 ),
+			'reviews_allowed'   => self::$faker->boolean(),
+			'purchase_note'     => self::$faker->boolean() ? self::$faker->text() : '',
+			'menu_order'        => self::$faker->numberBetween( 0, 10000 ),
 		) );
 		// Need to save to get an ID for variations.
 		$product->save();
@@ -92,10 +100,10 @@ class Product extends Generator {
 		$variation_attributes = wc_list_pluck( array_filter( $product->get_attributes(), 'wc_attributes_array_filter_variation' ), 'get_slugs' );
 		$possible_attributes  = array_reverse( wc_array_cartesian( $variation_attributes ) );
 		foreach ( $possible_attributes as $possible_attribute ) {
-			$price      = $faker->randomFloat( 2, 1, 1000 );
-			$is_on_sale = $faker->boolean( 30 );
-			$sale_price = $is_on_sale ? $faker->randomFloat( 2, 0, $price ) : '';
-			$is_virtual = $faker->boolean( 20 );
+			$price      = self::$faker->randomFloat( 2, 1, 1000 );
+			$is_on_sale = self::$faker->boolean( 30 );
+			$sale_price = $is_on_sale ? self::$faker->randomFloat( 2, 0, $price ) : '';
+			$is_virtual = self::$faker->boolean( 20 );
 			$variation  = new \WC_Product_Variation();
 			$variation->set_props( array(
 				'parent_id'         => $product->get_id(),
@@ -103,16 +111,16 @@ class Product extends Generator {
 				'regular_price'     => $price,
 				'sale_price'        => $sale_price,
 				'date_on_sale_from' => '',
-				'date_on_sale_to'   => $faker->iso8601( date( 'c', strtotime( '+1 month' ) ) ),
+				'date_on_sale_to'   => self::$faker->iso8601( date( 'c', strtotime( '+1 month' ) ) ),
 				'tax_status'        => 'taxable',
 				'tax_class'         => '',
 				'manage_stock'      => $will_manage_stock,
-				'stock_quantity'    => $will_manage_stock ? $faker->numberBetween( -100, 100 ) : null,
+				'stock_quantity'    => $will_manage_stock ? self::$faker->numberBetween( -100, 100 ) : null,
 				'stock_status'      => 'instock',
-				'weight'            => $is_virtual ? '' : $faker->numberBetween( 1, 200 ),
-				'length'            => $is_virtual ? '' : $faker->numberBetween( 1, 200 ),
-				'width'             => $is_virtual ? '' : $faker->numberBetween( 1, 200 ),
-				'height'            => $is_virtual ? '' : $faker->numberBetween( 1, 200 ),
+				'weight'            => $is_virtual ? '' : self::$faker->numberBetween( 1, 200 ),
+				'length'            => $is_virtual ? '' : self::$faker->numberBetween( 1, 200 ),
+				'width'             => $is_virtual ? '' : self::$faker->numberBetween( 1, 200 ),
+				'height'            => $is_virtual ? '' : self::$faker->numberBetween( 1, 200 ),
 				'virtual'           => $is_virtual,
 				'downloadable'      => false,
 				'image_id'          => self::generate_image(),
@@ -131,13 +139,12 @@ class Product extends Generator {
 	 * @return \WC_Product
 	 */
 	protected static function generate_simple_product() {
-		$faker             = \Faker\Factory::create();
-		$name              = $faker->words( $faker->numberBetween( 1, 5 ), true );
-		$will_manage_stock = $faker->boolean();
-		$is_virtual        = $faker->boolean();
-		$price             = $faker->randomFloat( 2, 1, 1000 );
-		$is_on_sale        = $faker->boolean( 30 );
-		$sale_price        = $is_on_sale ? $faker->randomFloat( 2, 0, $price ) : '';
+		$name              = self::$faker->words( self::$faker->numberBetween( 1, 5 ), true );
+		$will_manage_stock = self::$faker->boolean();
+		$is_virtual        = self::$faker->boolean();
+		$price             = self::$faker->randomFloat( 2, 1, 1000 );
+		$is_on_sale        = self::$faker->boolean( 30 );
+		$sale_price        = $is_on_sale ? self::$faker->randomFloat( 2, 0, $price ) : '';
 		$product           = new \WC_Product();
 
 		$image_id = self::generate_image();
@@ -145,37 +152,37 @@ class Product extends Generator {
 
 		$product->set_props( array(
 			'name'               => $name,
-			'featured'           => $faker->boolean(),
+			'featured'           => self::$faker->boolean(),
 			'catalog_visibility' => 'visible',
-			'description'        => $faker->paragraphs( $faker->numberBetween( 1, 5 ), true ),
-			'short_description'  => $faker->text(),
-			'sku'                => sanitize_title( $name ) . '-' . $faker->ean8,
+			'description'        => self::$faker->paragraphs( self::$faker->numberBetween( 1, 5 ), true ),
+			'short_description'  => self::$faker->text(),
+			'sku'                => sanitize_title( $name ) . '-' . self::$faker->ean8,
 			'regular_price'      => $price,
 			'sale_price'         => $sale_price,
 			'date_on_sale_from'  => '',
-			'date_on_sale_to'    => $faker->iso8601( date( 'c', strtotime( '+1 month' ) ) ),
-			'total_sales'        => $faker->numberBetween( 0, 10000 ),
+			'date_on_sale_to'    => self::$faker->iso8601( date( 'c', strtotime( '+1 month' ) ) ),
+			'total_sales'        => self::$faker->numberBetween( 0, 10000 ),
 			'tax_status'         => 'taxable',
 			'tax_class'          => '',
 			'manage_stock'       => $will_manage_stock,
-			'stock_quantity'     => $will_manage_stock ? $faker->numberBetween( -100, 100 ) : null,
+			'stock_quantity'     => $will_manage_stock ? self::$faker->numberBetween( -100, 100 ) : null,
 			'stock_status'       => 'instock',
-			'backorders'         => $faker->randomElement( array( 'yes', 'no', 'notify' ) ),
-			'sold_individually'  => $faker->boolean( 20 ),
-			'weight'             => $is_virtual ? '' : $faker->numberBetween( 1, 200 ),
-			'length'             => $is_virtual ? '' : $faker->numberBetween( 1, 200 ),
-			'width'              => $is_virtual ? '' : $faker->numberBetween( 1, 200 ),
-			'height'             => $is_virtual ? '' : $faker->numberBetween( 1, 200 ),
+			'backorders'         => self::$faker->randomElement( array( 'yes', 'no', 'notify' ) ),
+			'sold_individually'  => self::$faker->boolean( 20 ),
+			'weight'             => $is_virtual ? '' : self::$faker->numberBetween( 1, 200 ),
+			'length'             => $is_virtual ? '' : self::$faker->numberBetween( 1, 200 ),
+			'width'              => $is_virtual ? '' : self::$faker->numberBetween( 1, 200 ),
+			'height'             => $is_virtual ? '' : self::$faker->numberBetween( 1, 200 ),
 			'upsell_ids'         => self::get_existing_product_ids(),
 			'cross_sell_ids'     => self::get_existing_product_ids(),
 			'parent_id'          => 0,
-			'reviews_allowed'    => $faker->boolean(),
-			'purchase_note'      => $faker->boolean() ? $faker->text() : '',
-			'menu_order'         => $faker->numberBetween( 0, 10000 ),
+			'reviews_allowed'    => self::$faker->boolean(),
+			'purchase_note'      => self::$faker->boolean() ? self::$faker->text() : '',
+			'menu_order'         => self::$faker->numberBetween( 0, 10000 ),
 			'virtual'            => $is_virtual,
 			'downloadable'       => false,
-			'category_ids'       => self::generate_term_ids( $faker->numberBetween( 1, 10 ), 'product_cat' ),
-			'tag_ids'            => self::generate_term_ids( $faker->numberBetween( 1, 10 ), 'product_tag' ),
+			'category_ids'       => self::generate_term_ids( self::$faker->numberBetween( 1, 10 ), 'product_cat' ),
+			'tag_ids'            => self::generate_term_ids( self::$faker->numberBetween( 1, 10 ), 'product_tag' ),
 			'shipping_class_id'  => 0,
 			'image_id'           => $image_id,
 			'gallery_image_ids'  => $gallery,
@@ -190,10 +197,9 @@ class Product extends Generator {
 	 * @return array
 	 */
 	protected static function maybe_get_gallery_image_ids() {
-		$faker   = \Faker\Factory::create();
 		$gallery = array();
 
-		$create_gallery = $faker->boolean( 10 );
+		$create_gallery = self::$faker->boolean( 10 );
 
 		if ( ! $create_gallery ) {
 			return;

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -31,11 +31,13 @@ class Product extends Generator {
 		}
 
 		if ( empty( self::$product_ids ) ) {
-			self::$product_ids = get_posts( array(
-				'posts_per_page' => -1,
-				'post_type'      => 'product',
-				'fields'         => 'ids',
-			) );
+			self::$product_ids = wc_get_products(
+				array(
+					'limit'  => 200,
+					'return' => 'ids',
+					'status' => 'publish',
+				)
+			);
 		}
 
 		// 30% chance of a variable product.

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -13,6 +13,13 @@ namespace WC\SmoothGenerator\Generator;
 class Product extends Generator {
 
 	/**
+	 * Holds array of product IDs for generating relationships.
+	 *
+	 * @var array Array of IDs.
+	 */
+	protected static $product_ids = array();
+
+	/**
 	 * Return a new product.
 	 *
 	 * @param bool $save Save the object before returning or not.
@@ -21,6 +28,14 @@ class Product extends Generator {
 	public static function generate( $save = true ) {
 		if ( ! self::$faker ) {
 			self::$faker = \Faker\Factory::create();
+		}
+
+		if ( empty( self::$product_ids ) ) {
+			self::$product_ids = get_posts( array(
+				'posts_per_page' => -1,
+				'post_type'      => 'product',
+				'fields'         => 'ids',
+			) );
 		}
 
 		// 30% chance of a variable product.
@@ -35,6 +50,8 @@ class Product extends Generator {
 		if ( $product ) {
 			$product->save();
 		}
+
+		self::$product_ids[] = $product->get_id();
 
 		return $product;
 	}
@@ -214,19 +231,12 @@ class Product extends Generator {
 	 * @return array
 	 */
 	protected static function get_existing_product_ids( $limit = 5 ) {
-		$post_ids = get_posts( array(
-			'numberposts' => $limit * 2,
-			'orderby'     => 'date',
-			'post_type'   => 'product',
-			'fields'      => 'ids',
-		) );
-
-		if ( ! $post_ids ) {
+		if ( ! self::$product_ids ) {
 			return array();
 		}
 
-		shuffle( $post_ids );
+		shuffle( self::$product_ids );
 
-		return array_slice( $post_ids, 0, max( count( $post_ids ), $limit ) );
+		return array_slice( self::$product_ids, 0, max( count( self::$product_ids ), $limit ) );
 	}
 }

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -13,13 +13,6 @@ namespace WC\SmoothGenerator\Generator;
 class Product extends Generator {
 
 	/**
-	 * Holds the faker factory object.
-	 *
-	 * @var \Faker\Factory Factory object.
-	 */
-	protected static $faker;
-
-	/**
 	 * Return a new product.
 	 *
 	 * @param bool $save Save the object before returning or not.

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -239,6 +239,6 @@ class Product extends Generator {
 
 		shuffle( self::$product_ids );
 
-		return array_slice( self::$product_ids, 0, max( count( self::$product_ids ), $limit ) );
+		return array_slice( self::$product_ids, 0, min( count( self::$product_ids ), $limit ) );
 	}
 }

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -45,7 +45,7 @@ class Product extends Generator {
 	 * @return \WC_Product_Variable
 	 */
 	protected static function generate_variable_product() {
-		$name              = self::$faker->words( self::$faker->numberBetween( 1, 5 ), true );
+		$name              = ucwords( self::$faker->words( self::$faker->numberBetween( 1, 5 ), true ) );
 		$will_manage_stock = self::$faker->boolean();
 		$product           = new \WC_Product_Variable();
 		$nr_attributes     = self::$faker->numberBetween( 1, 3 );
@@ -132,7 +132,7 @@ class Product extends Generator {
 	 * @return \WC_Product
 	 */
 	protected static function generate_simple_product() {
-		$name              = self::$faker->words( self::$faker->numberBetween( 1, 5 ), true );
+		$name              = ucwords( self::$faker->words( self::$faker->numberBetween( 1, 5 ), true ) );
 		$will_manage_stock = self::$faker->boolean();
 		$is_virtual        = self::$faker->boolean();
 		$price             = self::$faker->randomFloat( 2, 1, 1000 );
@@ -198,7 +198,9 @@ class Product extends Generator {
 			return;
 		}
 
-		for ( $i = 0; $i < rand( 1, 3 ); $i ++ ) {
+		$image_count = rand( 1, 3 );
+
+		for ( $i = 0; $i < $image_count; $i ++ ) {
 			$gallery[] = self::generate_image();
 		}
 


### PR DESCRIPTION
These are the issues I found and fixed in testing:

- We can reuse the Faker lib instead of calling the factory in all methods
- Product names lacked ucname
- Instead of multiple get_posts calls, we can do a single query at the beginning and store the ids in memory
- We should avoid get_posts and use helped functions
- Get related IDs was returning the max, not the limit of 5.

@kloon 