### PR TITLE
Set SKU when creating variable products

### DIFF
--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -237,6 +237,7 @@ class Product extends Generator {
 		$product->set_props( array(
 			'name'              => $name,
 			'featured'          => self::$faker->boolean( 10 ),
+			'sku'               => sanitize_title( $name ) . '-' . self::$faker->ean8,
 			'attributes'        => $attributes,
 			'tax_status'        => 'taxable',
 			'tax_class'         => '',


### PR DESCRIPTION
Probably due to a mistake, when creating products, `wc-smooth-generator` was setting an SKU when creating for simple products but not for variable products. This PR changes this behavior and sets an SKU when creating a variable product.

cc @mikejolley 