### PR TITLE
Variations: use available variable instead of parent product

### DIFF
--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -162,7 +162,15 @@ class Order extends Generator {
 		) );
 
 		foreach ( $query->get_products() as $product_id ) {
-			$products[] = new \WC_Product( $product_id );
+			$product = wc_get_product( $product_id );
+
+			if ( $product->is_type( 'variable' ) ) {
+				$available_variations = $product->get_available_variations();
+				$index = self::$faker->numberBetween( 0, count( $available_variations ) - 1 );
+				$products[] = new \WC_Product_Variation( $available_variations[ $index ]['variation_id'] );
+			} else {
+				$products[] = new \WC_Product( $product_id );
+			}
 		}
 
 		return $products;


### PR DESCRIPTION
When creating orders, a parent variable product is added to an order instead of one available variation. This results in oddness in wc-admin's Product Report.

### Test

1. Make sure you have a variable product with variations.
2. Create sufficient orders such that the variable product is likely to have been used.
3. Check the orders, somehow?
4. Or, use wc-admin's Product Report > Single Product > variable product. Then check to see if order data is reflected for a variation of the product.