### PR TITLE
skip variable products that have no variations

### DIFF
--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -166,6 +166,9 @@ class Order extends Generator {
 
 			if ( $product->is_type( 'variable' ) ) {
 				$available_variations = $product->get_available_variations();
+				if ( empty( $available_variations ) ) {
+					continue;
+				}
 				$index = self::$faker->numberBetween( 0, count( $available_variations ) - 1 );
 				$products[] = new \WC_Product_Variation( $available_variations[ $index ]['variation_id'] );
 			} else {


### PR DESCRIPTION
This PR fixes a warning in WP CLI when generating orders and a selected product is a variable product with no variations.