### PR TITLE
Fix function call with deprecated argument

### DIFF
--- a/includes/Generator/Generator.php
+++ b/includes/Generator/Generator.php
@@ -158,7 +158,7 @@ abstract class Generator {
 		imagepng( $image );
 		$file = ob_get_clean();
 		imagedestroy( $image );
-		$upload = wp_upload_bits( 'img-' . $seed . '.png', '', $file );
+		$upload = wp_upload_bits( 'img-' . $seed . '.png', null, $file );
 
 		if ( empty( $upload['error'] ) ) {
 			$attachment_id = (int) wp_insert_attachment(


### PR DESCRIPTION
The second parameter of `wp_upload_bits()` has been deprecated since WP 2.0.0.
`null` should be passed instead of a string.

Ref: https://developer.wordpress.org/reference/functions/wp_upload_bits/