### PR TITLE
Bug fix: jumbled incrementors

### DIFF
--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -194,7 +194,7 @@ class Product extends Generator {
 				$values          = array();
 				$existing_values = self::$global_attributes[ $raw_name ];
 
-				for ( $i = 0; $i < $num_values; $i++ ) {
+				for ( $j = 0; $j < $num_values; $j++ ) {
 					$value = '';
 
 					if ( self::$faker->boolean( 80 ) && ! empty( $existing_values ) ) {


### PR DESCRIPTION
The `Product::generate_attributes()` may not generate the required number of attributes as `$i` was being overwritten from within the loop.

Changing the inner loop to use `$j` fixes that.