### PR TITLE
Check for autoload in various locations.

### DIFF
--- a/wc-smooth-generator.php
+++ b/wc-smooth-generator.php
@@ -13,7 +13,24 @@
 defined( 'ABSPATH' ) || exit;
 
 // autoloader.
-require __DIR__ . '/vendor/autoload.php';
+
+// Checks for vendor directory in the following order:
+// 1. COMPOSER_VENDOR_DIR.
+// 2. WP_CONTENT_DIR.
+// 3. Two directories up, assuming this gets installed in wp-content/plugins vendor may be in the project root.
+// 4. One directory up, assuming this gets installed in wp-content/plugins vendor may be in wp-content.
+// 5. Defaults to the current directory.
+if ( getenv( 'COMPOSER_VENDOR_DIR' ) && is_file( getenv( 'COMPOSER_VENDOR_DIR' ) . '/autoload.php' ) ) {
+	require getenv( 'COMPOSER_VENDOR_DIR' ) . '/autoload.php';
+} elseif ( defined( 'WP_CONTENT_DIR' ) && is_file( WP_CONTENT_DIR . '/vendor/autoload.php' ) ) {
+	require WP_CONTENT_DIR . '/vendor/autoload.php';
+} elseif ( is_file( __DIR__ . '/../../vendor/autoload.php' ) ) {
+	require __DIR__ . '/../../vendor/autoload.php';
+} elseif ( is_file( __DIR__ . '/../vendor/autoload.php' ) ) {
+	require __DIR__ . '/../vendor/autoload.php';
+} else {
+	require __DIR__ . '/vendor/autoload.php';
+}
 
 /**
  * Fetch instance of plugin.


### PR DESCRIPTION
Currently the assumption is that the vendor library will be installed
relative to the main plugin file, i.e. $plugin_dir/vendor, however there
are lots of instances where this may not be the case.

One common use case is for `vendor` to be relative to `wp-content` such
as is the case when following a composer in wordpress recipe such as
this one: https://composer.rarst.net/recipe/site-stack/ therefore it
makes sense to check if the vendor and thus autoload file is in here
first.

Taking this a bit further, there's a (mostly) unwritten convention which
is to use an env var to mark the composer vendor dir (see discussion
here: https://github.com/composer/composer/issues/2904) so it makes
sense to check if that exists first.

There may also be cases where developers are storing vendors in the
project root or one level above but not using WP_CONTENT_DIR constant so
makes sense to check there too.

So this will check all of the above and can be summed up as thus:

 Check for vendor directory in the following:

1. COMPOSER_VENDOR_DIR.
2. WP_CONTENT_DIR.
3. Two directories up, assuming this gets installed in wp-content/plugins vendor may be in the project root.
4. One directory up, assuming this gets installed in wp-content/plugins vendor may be in wp-content.
5. Defaults to the current directory.