### PR TITLE
[PHP 8] Make the methods in the CLI class static

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -30,7 +30,7 @@ class CLI extends WP_CLI_Command {
 	 * @param array $args Argumens specified.
 	 * @param arrat $assoc_args Associative arguments specified.
 	 */
-	public function products( $args, $assoc_args ) {
+	public static function products( $args, $assoc_args ) {
 		list( $amount ) = $args;
 
 		$time_start = microtime( true );
@@ -73,7 +73,7 @@ class CLI extends WP_CLI_Command {
 	 * @param array $args Argumens specified.
 	 * @param array $assoc_args Associative arguments specified.
 	 */
-	public function orders( $args, $assoc_args ) {
+	public static function orders( $args, $assoc_args ) {
 		list( $amount ) = $args;
 
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating orders', $amount );
@@ -102,7 +102,7 @@ class CLI extends WP_CLI_Command {
 	 * @param array $args Argumens specified.
 	 * @param arrat $assoc_args Associative arguments specified.
 	 */
-	public function customers( $args, $assoc_args ) {
+	public static function customers( $args, $assoc_args ) {
 		list( $amount ) = $args;
 
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating customers', $amount );


### PR DESCRIPTION
Methods in the `CLI` class are registered using `WP_CLI::add_command`, passing `array('WC\SmoothGenerator\CLI', 'method')` as callbacks. This kind of callback is not supported in PHP 8 when the method is not static, as per [the upgrading guide](https://github.com/php/php-src/blob/PHP-8.0/UPGRADING):

> Removed ability to call non-static methods statically. Thus `is_callable` will fail when checking for a non-static method with a    classname (must check with an object instance).

The fix consists of simply making these methods static, which semantically they are already anyway.