### PR TITLE
Only require autoload.php if the package isn't already autoloaded

### DIFF
--- a/wc-smooth-generator.php
+++ b/wc-smooth-generator.php
@@ -13,7 +13,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // autoloader.
-if( !class_exists( \WC\SmoothGenerator\Plugin::class ) ){
+if( ! class_exists( \WC\SmoothGenerator\Plugin::class ) ){
 	require __DIR__ . '/vendor/autoload.php';
 }
 

--- a/wc-smooth-generator.php
+++ b/wc-smooth-generator.php
@@ -13,7 +13,9 @@
 defined( 'ABSPATH' ) || exit;
 
 // autoloader.
-require __DIR__ . '/vendor/autoload.php';
+if( !class_exists( \WC\SmoothGenerator\Plugin::class ) ){
+	require __DIR__ . '/vendor/autoload.php';
+}
 
 /**
  * Fetch instance of plugin.


### PR DESCRIPTION
This plugin might be required by a website repository that uses composer to bootstrap the entire WordPress installation. In this scenario, the `autoload.php` is not located where you expect it to be (because the autloader now lives in the website root). Also, there would be no need to require the file even if it was, since the existing autoloader already knows how to locate the needed classes.
This actually results in an error on plugin activation - rendering it unusable.

So I propose to add this simple `class_exists` check to make the plugin work in composer-based website projects