### PR TITLE
Add --status argument for Orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Generate orders with random dates between `--date-start` and the current date.
 Generate orders with random dates between `--date-start` and `--date-end`.
 - `wp wc generate orders <nr of orders> --date-start=2018-04-01 --date-end=2018-04-24`
 
+Generate orders with a specific status.
+- `wp wc generate orders <nr of orders> --status=completed`
+
 ### Customers
 
 Generate customers based on the number of customers paramater.

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -81,6 +81,14 @@ class CLI extends WP_CLI_Command {
 			$amount = 100;
 		}
 
+		if ( ! empty( $assoc_args['status'] ) ) {
+			$status = $assoc_args['status'];
+			if ( ! wc_is_order_status( 'wc-' . $status ) ) {
+				WP_CLI::log( "The argument \"$status\" is not a valid order status." );
+				return;
+			}
+		}
+
 		if ( $amount > 0 ) {
 			$progress = \WP_CLI\Utils\make_progress_bar( 'Generating orders', $amount );
 			for ( $i = 1; $i <= $amount; $i++ ) {

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -140,6 +140,11 @@ WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'ord
 			'type'     => 'assoc',
 			'optional' => true,
 		),
+		array(
+			'name'     => 'status',
+			'type'     => 'assoc',
+			'optional' => true,
+		),
 	),
 ) );
 WP_CLI::add_command( 'wc generate customers', array( 'WC\SmoothGenerator\CLI', 'customers' ) );

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -82,9 +82,9 @@ class CLI extends WP_CLI_Command {
 		}
 
 		if ( $amount > 0 ) {
-			$progress = \WP_CLI\Utils\make_progress_bar('Generating orders', $amount);
-			for ($i = 1; $i <= $amount; $i++) {
-				Generator\Order::generate(true, $assoc_args);
+			$progress = \WP_CLI\Utils\make_progress_bar( 'Generating orders', $amount );
+			for ( $i = 1; $i <= $amount; $i++ ) {
+				Generator\Order::generate( true, $assoc_args );
 				$progress->tick();
 			}
 			$progress->finish();
@@ -128,7 +128,7 @@ WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'ord
 			'name'     => 'amount',
 			'type'     => 'positional',
 			'optional' => true,
-			'default'  => 100
+			'default'  => 100,
 		),
 		array(
 			'name'     => 'date-start',

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -58,12 +58,7 @@ class Order extends Generator {
 		$order->set_shipping_postcode( $customer->get_shipping_postcode() );
 		$order->set_shipping_state( $customer->get_shipping_state() );
 		$order->set_shipping_country( $customer->get_shipping_country() );
-		$order->set_status( self::random_weighted_element( array(
-			'completed'  => 70,
-			'processing' => 15,
-			'on-hold'    => 5,
-			'failed'     => 10,
-		) ) );
+		$order->set_status( self::get_status( $assoc_args ) );
 		$order->calculate_totals( true );
 
 		$date = self::get_date_created( $assoc_args );
@@ -127,6 +122,26 @@ class Order extends Generator {
 		}
 
 		return $dates[ array_rand( $dates ) ];
+	}
+
+	/**
+	 * Returns a status to use as the order's status. If no status argument has been passed, this will
+	 * return a random status.
+	 *
+	 * @param array $assoc_args CLI arguments.
+	 * @return string An order status.
+	 */
+	private static function get_status( $assoc_args ) {
+		if ( ! empty( $assoc_args['status'] ) ) {
+			return $assoc_args['status'];
+		} else {
+			return self::random_weighted_element(array(
+				'completed'  => 70,
+				'processing' => 15,
+				'on-hold'    => 5,
+				'failed'     => 10,
+			) );
+		}
 	}
 
 	/**

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -135,7 +135,7 @@ class Order extends Generator {
 		if ( ! empty( $assoc_args['status'] ) ) {
 			return $assoc_args['status'];
 		} else {
-			return self::random_weighted_element(array(
+			return self::random_weighted_element( array(
 				'completed'  => 70,
 				'processing' => 15,
 				'on-hold'    => 5,


### PR DESCRIPTION

## Why

I want to use this generator in a cron job to periodically create orders for a test site. And I want to be able to receive push notifications on the [WooCommerce iOS app](https://github.com/woocommerce/woocommerce-ios) every time an order is created. I'm mainly using this for dog-fooding the iOS app. 

The problem is that, the iOS app will only receive push notifications if the Order's status is `processing`. And this generator randomizes the order status so it can be tricky to rely on. It'd be great if I can specify what status to use for the generated orders. 

## Changes

This adds a `--status` argument to generate orders with a specific status. For example, running this command would generate orders with the `processing` status:

```
wp wc generate orders 10 --status=processing
```

### Error Handling

If the user enters an invalid status, the order will be set to `pending` instead. This is done automatically by `WC_Order.set_status()`. 

## Testing

1. Run this command:

    ```
    wp wc generate orders 10 --status=completed
    ```
2. Confirm that 10 orders were created with the “Completed” status. 
3. Run this command:

    ```
    wp wc generate orders 10 
    ```
4. Confirm that 10 orders were created with random statuses.

