### PR TITLE
Limit attribute terms to 5 on variable products

### DIFF
--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -149,9 +149,10 @@ class Product extends Generator {
 	 * Generate attributes for a product.
 	 *
 	 * @param integer $qty Number of attributes to generate.
+	 * @param integer $maximum_terms Maximum number of terms per attribute to generate.
 	 * @return array Array of attributes.
 	 */
-	protected static function generate_attributes( $qty = 1 ) {
+	protected static function generate_attributes( $qty = 1, $maximum_terms = 10 ) {
 		$used_names = array();
 		$attributes = array();
 
@@ -190,7 +191,7 @@ class Product extends Generator {
 
 				$used_names[] = $raw_name;
 
-				$num_values      = self::$faker->numberBetween( 1, 10 );
+				$num_values      = self::$faker->numberBetween( 1, $maximum_terms );
 				$values          = array();
 				$existing_values = self::$global_attributes[ $raw_name ];
 
@@ -232,7 +233,7 @@ class Product extends Generator {
 		$product           = new \WC_Product_Variable();
 
 		$gallery    = self::maybe_get_gallery_image_ids();
-		$attributes = self::generate_attributes( self::$faker->numberBetween( 1, 3 ) );
+		$attributes = self::generate_attributes( self::$faker->numberBetween( 1, 3 ), 5 );
 
 		$product->set_props( array(
 			'name'              => $name,


### PR DESCRIPTION
This PR reduces the maximum number of generated attribute terms on variable products from 10 to 5. 

With an even distribution of 1-3 attributes with 1 - 10 terms the average number of variations would be 115. With the range of terms lowered to 1 - 5, the average number is 19. Testing this locally reduced the average time to generate 100 products by a little over 50%. An estimate of the new time to generate 40K products in my dev environment would be 2 - 2.5 hours.

Closes #14

### Testing 

1- Do a few test runs of `wp wc generate products N` where N is between 100 & 1000. Compare the time to the ranges suggested above.