### PR TITLE
release version 1.0.3

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Changelog ***
 
-= 1.0.3 - xxxx-xx-x =
+= 1.0.3 - 2021-08-12 =
 * Add - --status argument to `generate orders` command
 * Add - UI support for generating products and orders
 * Dev - update Composer support for V2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-smooth-generator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wc-smooth-generator",
   "title": "WooCommerce Smooth Generator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "https://github.com/woocommerce/wc-smooth-generator",
   "repository": {
     "type": "git",

--- a/wc-smooth-generator.php
+++ b/wc-smooth-generator.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Smooth Generator
  * Plugin URI: https://woocommerce.com/
  * Description: A smooth customer, order and product generator for WooCommerce.
- * Version: 1.0.1
+ * Version: 1.0.3
  * Author: Automattic
  * Author URI: https://woocommerce.com
  *


### PR DESCRIPTION
This PR bumps versions for plugin release.

Draft release is https://github.com/woocommerce/wc-smooth-generator/releases/tag/untagged-07cee72e6f708d68ef05.

Closes #53

### Testing

1. Install the plugin from the release page and test generation.