### PR TITLE
include jdenticon package in generated zip

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
       "!vendor/autoload.php",
       "!vendor/composer",
       "!vendor/fzaninotto",
+      "!vendor/jdenticon",
       "!vendor/mbezhanov"
     ]
   }


### PR DESCRIPTION
Closes #63 

This PR updates the composer archive inclusion list to include the `jdenticon/jdenticon` package which is used in generating products.

### Testing Instructions

1. Run `npm run build`
2. Extract `wc-smooth-generator.zip` into a different WP install
3. Run
```
wp wc generate customers 10
wp wc generate products 10
wp wc generate orders 10
```
4. Log into the dashboard and generate 10 products and orders using the dashboard interface
5. Go to Tools -> Scheduled actions
6. Verify that scheduled actions were created to create the products/orders
7. Allow a minute for these to run or run manually
8. Verify that the products/orders were created.

