### PR TITLE
Add coupon generator and option to orders to add a coupon to each order

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -134,8 +134,7 @@ class CLI extends WP_CLI_Command {
 	/**
 	 * Disable sending WooCommerce emails when generating objects.
 	 */
-	protected static function disable_emails()
-	{
+	protected static function disable_emails() {
 		$email_actions = array(
 			'woocommerce_low_stock',
 			'woocommerce_no_stock',
@@ -161,8 +160,8 @@ class CLI extends WP_CLI_Command {
 			'woocommerce_created_customer',
 		);
 
-		foreach ($email_actions as $action) {
-			remove_action($action, array('WC_Emails', 'send_transactional_email'), 10, 10);
+		foreach ( $email_actions as $action ) {
+			remove_action( $action, array( 'WC_Emails', 'send_transactional_email' ), 10, 10 );
 		}
 	}
 

--- a/includes/GenerateBackgroundProcess.php
+++ b/includes/GenerateBackgroundProcess.php
@@ -26,6 +26,9 @@ function wc_smooth_generate_object( $type ) {
 		case 'customer':
 			Generator\Customer::generate();
 			break;
+		case 'coupon':
+			Generator\Coupon::generate();
+			break;
 		default:
 			return false;
 	}

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -22,8 +22,6 @@ class Coupon extends Generator {
 	 * @return \WC_Customer Customer object with data populated.
 	 */
 	public static function generate( $save = true, $min = 5, $max = 100 ) {
-		self::init_faker();
-
 		$amount    = random_int( $min, $max );
 		$coupon_id = "discount$amount";
 		$coupon    = new \WC_Coupon( $coupon_id );

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Customer data generation.
+ *
+ * @package SmoothGenerator\Classes
+ */
+
+namespace WC\SmoothGenerator\Generator;
+
+/**
+ * Customer data generator.
+ */
+class Coupon extends Generator {
+
+
+	/**
+	 * Return a new customer.
+	 *
+	 * @param bool $save Save the object before returning or not.
+	 * @param int  $min minimum coupon amount.
+	 * @param int  $max maximum coupon amount.
+	 * @return \WC_Customer Customer object with data populated.
+	 */
+	public static function generate( $save = true, $min = 5, $max = 100 ) {
+		self::init_faker();
+
+		$amount = random_int( $min, $max );
+		$coupon = new \WC_Coupon();
+		$coupon->set_props( array(
+			'code'   => "discount$amount",
+			'amount' => $amount,
+		) );
+		$coupon->save();
+
+		return new \WC_Coupon( $coupon->get_id() );
+	}
+
+}
+

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -24,9 +24,9 @@ class Coupon extends Generator {
 	public static function generate( $save = true, $min = 5, $max = 100 ) {
 		self::init_faker();
 
-		$amount = random_int( $min, $max );
+		$amount    = random_int( $min, $max );
 		$coupon_id = "discount$amount";
-		$coupon = new \WC_Coupon( $coupon_id );
+		$coupon    = new \WC_Coupon( $coupon_id );
 		if ( $coupon->get_id() === 0 ) {
 			$coupon->set_props( array(
 				'code'   => "discount$amount",

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -25,14 +25,17 @@ class Coupon extends Generator {
 		self::init_faker();
 
 		$amount = random_int( $min, $max );
-		$coupon = new \WC_Coupon();
-		$coupon->set_props( array(
-			'code'   => "discount$amount",
-			'amount' => $amount,
-		) );
-		$coupon->save();
-
-		return new \WC_Coupon( $coupon->get_id() );
+		$coupon_id = "discount$amount";
+		$coupon = new \WC_Coupon( $coupon_id );
+		if ( $coupon->get_id() === 0 ) {
+			$coupon->set_props( array(
+				'code'   => "discount$amount",
+				'amount' => $amount,
+			) );
+			$coupon->save();
+			return new \WC_Coupon( $coupon->get_id() );
+		}
+		return $coupon;
 	}
 
 }

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -61,10 +61,16 @@ class Order extends Generator {
 		$order->set_status( self::get_status( $assoc_args ) );
 		$order->calculate_totals( true );
 
-		$date = self::get_date_created( $assoc_args );
+		$date  = self::get_date_created( $assoc_args );
 		$date .= ' ' . wp_rand( 0, 23 ) . ':00:00';
 
 		$order->set_date_created( $date );
+
+		$include_coupon = ! empty( $assoc_args['status'] );
+		if ( $include_coupon ) {
+			$coupon = Coupon::generate( true );
+			$order->apply_coupon( $coupon );
+		}
 
 		if ( $save ) {
 			$order->save();
@@ -184,7 +190,7 @@ class Order extends Generator {
 				if ( empty( $available_variations ) ) {
 					continue;
 				}
-				$index = self::$faker->numberBetween( 0, count( $available_variations ) - 1 );
+				$index      = self::$faker->numberBetween( 0, count( $available_variations ) - 1 );
 				$products[] = new \WC_Product_Variation( $available_variations[ $index ]['variation_id'] );
 			} else {
 				$products[] = new \WC_Product( $product_id );

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -66,7 +66,7 @@ class Order extends Generator {
 
 		$order->set_date_created( $date );
 
-		$include_coupon = ! empty( $assoc_args['status'] );
+		$include_coupon = ! empty( $assoc_args['coupons'] );
 		if ( $include_coupon ) {
 			$coupon = Coupon::generate( true );
 			$order->apply_coupon( $coupon );


### PR DESCRIPTION
Fixes #68 

### Description

Added a Coupon generator with a min and max option for the `int_random` function.

I also added a `coupon` option to the order generator CLI command, which if set, it will auto generate a coupon for each order.

### Testing instructions

- Run `wp wc generate coupons 10 --min=10 --max=40`
- Go to **Marketing > Coupons** and see if there are 10 new coupons (no duplicates)
- Run `wp wc generate orders 10 --status=completed --coupons=true`
- Run `wp action-scheduler run`
- Go to **Analytics > Coupons** and see if there are 10 coupons listed with an order each

### Changelog entry

> Add: coupon generator and a new option for orders to allow for coupon generation.