### PR TITLE
prepare 1.0.4 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** Changelog ***
 
+2021-12-15 - version 1.0.4
+* Add - coupon generator and a new option for orders to allow for coupon generation.
+* Add - use product name to generate more realistic product term names.
+* Fix - include jdenticon package in generated zip.
+
 = 1.0.3 - 2021-08-12 =
 * Add - --status argument to `generate orders` command
 * Add - UI support for generating products and orders

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-smooth-generator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wc-smooth-generator",
   "title": "WooCommerce Smooth Generator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "homepage": "https://github.com/woocommerce/wc-smooth-generator",
   "repository": {
     "type": "git",

--- a/wc-smooth-generator.php
+++ b/wc-smooth-generator.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Smooth Generator
  * Plugin URI: https://woocommerce.com/
  * Description: A smooth customer, order and product generator for WooCommerce.
- * Version: 1.0.3
+ * Version: 1.0.4
  * Author: Automattic
  * Author URI: https://woocommerce.com
  *


### PR DESCRIPTION
This PR prepares for the release of version 1.0.4. The [draft release](https://github.com/woocommerce/wc-smooth-generator/releases/edit/untagged-14033fbafbb7bcc39c2d) has been created.

### Testing the release

- Review the changes
- Run `npm run build`
- Install the generated `wc-smooth-generator.zip` in a test install
- Test WP CLI
```
wp wc generate coupons --user=admin
wp wc generate products 10 --user=admin
wp wc generate customers 10 --user=admin
wp wc generate orders coupons=true --user=admin
```
- Verify there are no errors in the test site dashboard.

Once this PR is merged we can publish the release.