### PR TITLE
Add GitHub templates for issues and PRs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing ✨
+
+Your help will be greatly appreciated :)
+
+WooCommerce is licensed under the GPLv3+, and all contributions to the project will be released under the same license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv3+ license.
+
+## Coding Guidelines and Development 🛠
+
+- Ensure you stick to the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/)
+- Whenever possible please fix pre-existing code standards errors in the files that you change. It is ok to skip that for larger files or complex fixes.
+- Ensure you use LF line endings in your code editor. Use [EditorConfig](http://editorconfig.org/) if your editor supports it so that indentation, line endings and other settings are auto configured.
+- When committing, reference your issue number (#1234) and include a note about the fix.
+- Push the changes to your fork and submit a pull request on the trunk branch of the repository.
+- Make sure to write good and detailed commit messages (see [this post](https://chris.beams.io/posts/git-commit/) for more on this) and follow all the applicable sections of the pull request template.
+- Please avoid modifying the changelog directly or updating the .pot files. These will be updated by the team.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- This form is for other issue types specific to WooCommerce E2E Tests Boilerplate. This is not a support portal. -->
+<!-- This form is for other issue types specific to WooCommerce Smooth Generator. This is not a support portal. -->
 
 **Prerequisites (mark completed items with an [x]):**
 - [ ] I have checked that my issue type is not listed here https://github.com/woocommerce/wc-smooth-generator/issues/new/choose

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+<!-- This form is for other issue types specific to WooCommerce E2E Tests Boilerplate. This is not a support portal. -->
+
+**Prerequisites (mark completed items with an [x]):**
+- [ ] I have checked that my issue type is not listed here https://github.com/woocommerce/wc-smooth-generator/issues/new/choose
+- [ ] My issue is not a security issue, bug report, or enhancement (Please use the link above if it is).
+
+**Issue Description:**

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,56 @@
+name: 🐞 Bug Report
+description: Report a bug if something isn't working as expected in WooCommerce Smooth Generator.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thanks for contributing!
+
+        Please provide us with the information requested in this bug report. 
+        Without these details, we won't be able to fully evaluate this issue. 
+        Bug reports lacking detail, or for any other reason than to report a bug, may be closed without action.
+
+        Make sure to look through the [existing `bug` issues](https://github.com/woocommerce/wc-smooth-generator/issues?q=is%3Aopen+is%3Aissue+label%3Abug) to see whether your bug has already been submitted.
+        Feel free to contribute to any existing issues.
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      description: Please confirm these before submitting the issue.
+      options:
+        - label: I have carried out troubleshooting steps and I believe I have found a bug.
+        - label: I have searched for similar bugs in both open and closed issues and cannot find a duplicate.
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Describe the bug
+      description: |
+        A clear and concise description of what the bug is and what actually happens. Please be as descriptive as possible.
+        Please also include any error logs or output.
+        If applicable you can attach screenshot(s) or recording(s) directly by dragging & dropping.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: WordPress Environment
+      description: |
+        Please share the [WooCommerce System Status Report](https://woocommerce.com/document/understanding-the-woocommerce-system-status-report/) of your site to help us evaluate the issue. 
+      placeholder: |
+        The System Status Report is found in your WordPress admin under **WooCommerce > Status**. 
+        Please select “Get system report”, then “Copy for support”, and then paste it here.
+  - type: checkboxes
+    id: isolating
+    attributes:
+      label: Isolating the problem
+      description: |
+        Please try testing your site for theme and plugins conflict. 
+        To do that deactivate all plugins except for WooCommerce and WooCommerce Smooth Generator and switch to a default WordPress theme or [Storefront](https://en-gb.wordpress.org/themes/storefront/). Then test again. 
+        If the issue is resolved with the default theme and all plugins deactivated, it means that one of your plugins or a theme is causing the issue. 
+        You will then need to enable it one by one and test every time you do that in order to figure out which plugin is causing the issue.
+      options:
+        - label: I have deactivated other plugins and confirmed this bug occurs when only WooCommerce and WooCommerce Smooth Generator plugins are active.
+        - label: This bug happens with a default WordPress theme active, or [Storefront](https://woocommerce.com/storefront/).
+        - label: I can reproduce this bug consistently using the steps above.

--- a/.github/ISSUE_TEMPLATE/2-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/2-enhancement.yml
@@ -1,0 +1,30 @@
+name: ✨ Enhancement Request
+description: If you have an idea to improve WooCommerce E2E Tests Boilerplate or need something for development please let us know or submit a Pull Request!
+title: "[Enhancement]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thanks for contributing!
+
+        Please provide us with the information requested in this form. 
+
+        Make sure to look through [existing `enhancement` issues](https://github.com/woocommerce/wc-smooth-generator/issues?q=is%3Aissue+label%3Aenhancement+is%3Aopen) to see whether your idea is already being discussed.
+        Feel free to contribute to any existing issues.
+  - type: textarea
+    id: summary
+    attributes:
+        label: Describe the solution you'd like
+        description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternative
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/2-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/2-enhancement.yml
@@ -1,5 +1,5 @@
 name: ✨ Enhancement Request
-description: If you have an idea to improve WooCommerce E2E Tests Boilerplate or need something for development please let us know or submit a Pull Request!
+description: If you have an idea to improve WooCommerce Smooth Generator or need something for development please let us know or submit a Pull Request!
 title: "[Enhancement]: "
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🔒 Security issue
+    url: https://hackerone.com/automattic/
+    about: For security reasons, please report all security issues via HackerOne. Also, if the issue is valid, a bug bounty will be paid out to you. Please disclose responsibly and not via GitHub (which allows for exploiting issues in the wild before the patch is released).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,4 @@ contact_links:
   - name: 🔒 Security issue
     url: https://hackerone.com/automattic/
     about: For security reasons, please report all security issues via HackerOne. Also, if the issue is valid, a bug bounty will be paid out to you. Please disclose responsibly and not via GitHub (which allows for exploiting issues in the wild before the patch is released).
+    

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,4 +3,3 @@ contact_links:
   - name: 🔒 Security issue
     url: https://hackerone.com/automattic/
     about: For security reasons, please report all security issues via HackerOne. Also, if the issue is valid, a bug bounty will be paid out to you. Please disclose responsibly and not via GitHub (which allows for exploiting issues in the wild before the patch is released).
-    

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+### All Submissions:
+
+* [ ] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
+* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
+* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?
+
+<!-- Mark completed items with an [x] -->
+
+<!-- You can erase any parts of this template not applicable to your Pull Request. -->
+
+### Changes proposed in this Pull Request:
+
+<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
+
+Closes # .
+
+### How to test the changes in this Pull Request:
+
+1.
+2.
+3.
+
+### Other information:
+
+* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
+* [ ] Have you written new tests for your changes, as applicable?
+* [ ] Have you successfully run tests with your changes locally?
+
+<!-- Mark completed items with an [x] -->
+
+### Changelog entry
+
+> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
+
+### FOR PR REVIEWER ONLY:
+
+* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR adds GitHub issue forms templates, issue chooser, and a pull request template (and associated contribution guidelines) to the repository.

**Issue forms template files added:**
`1-bug-report.yml` - Bug Report template using issue forms
`2-enhancement.yml` - Enhancement template using issue forms
`config.yml` - Issue Chooser (what will be shown when clicking `/issues/new/choose`) config and additional links  
`ISSUE_TEMPLATE.md` - Template for "Blank" issues

**Pull Request template files added:**
`PULL_REQUEST_TEMPLATE.md` - Template for Pull Requests
`CONTRIBUTING.md` - Basic contributing guidelines referenced in the Pull Request template


## More details:

The proposed issue chooser will display all the `.yml` templates in `.github/ISSUE_TEMPLATE` and pulls the description for each from the template itself.
The order of the templates is determined by the alphabetical order of the file names of the templates.


The proposed additional `config.yml` file will control the content below the templates of the issue chooser and allows us to include external links. (These links can only be displayed after the templates).

More details on configuring `conifig.yml` here https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

## How to test the changes in this Pull Request:

- I don't know of a way to visually preview the issue chooser and the descriptions external links in `config.yml`
- To preview the issue templates view the file in the Files changed tab and GitHub will render a visual preview. (The section at the top is for the description that will be on the issue template chooser so it can be ignored).

