### PR TITLE
adding count parameter

### DIFF
--- a/includes/GenerateBackgroundProcess.php
+++ b/includes/GenerateBackgroundProcess.php
@@ -19,7 +19,7 @@ function wc_smooth_generate_object( $type, $count = 1) {
 
 	// Check what generation task to perform
 	$i = 0;
-       while($i++ < $count) {
+	while($i++ < $count) {
 		switch ( $type ) {
 				case 'order':
 						Generator\Order::generate();

--- a/includes/GenerateBackgroundProcess.php
+++ b/includes/GenerateBackgroundProcess.php
@@ -19,7 +19,7 @@ function wc_smooth_generate_object( $type, $count = 1 ) {
 
 	// Check what generation task to perform
 	$i = 0;
-	while( $i++ < intval( $count ) ) {
+	do {
 		switch ( $type ) {
 				case 'order':
 						Generator\Order::generate();
@@ -36,7 +36,7 @@ function wc_smooth_generate_object( $type, $count = 1 ) {
 				default:
 						return false;
 		}
-	}
+	} while( $i++ < intval( $count ) );
 	
 	return false;
 }

--- a/includes/GenerateBackgroundProcess.php
+++ b/includes/GenerateBackgroundProcess.php
@@ -19,7 +19,7 @@ function wc_smooth_generate_object( $type, $count = 1) {
 
 	// Check what generation task to perform
 	$i = 0;
-	while($i++ < $count) {
+	while( $i++ < intval( $count ) ) {
 		switch ( $type ) {
 				case 'order':
 						Generator\Order::generate();
@@ -41,7 +41,7 @@ function wc_smooth_generate_object( $type, $count = 1) {
 	return false;
 }
 
-add_action( 'wc_smooth_generate_object', 'wc_smooth_generate_object' , 10, 2);
+add_action( 'wc_smooth_generate_object', 'wc_smooth_generate_object' , 10, 2 );
 
 /**
  * Schedule async actions for generation of objects.

--- a/includes/GenerateBackgroundProcess.php
+++ b/includes/GenerateBackgroundProcess.php
@@ -15,7 +15,7 @@ use WC\SmoothGenerator\Generator;
  *
  * @return false If task was successful.
  */
-function wc_smooth_generate_object( $type, $count = 1) {
+function wc_smooth_generate_object( $type, $count = 1 ) {
 
 	// Check what generation task to perform
 	$i = 0;

--- a/includes/GenerateBackgroundProcess.php
+++ b/includes/GenerateBackgroundProcess.php
@@ -17,28 +17,28 @@ use WC\SmoothGenerator\Generator;
  */
 function wc_smooth_generate_object( $type, $count = 1) {
 
-        // Check what generation task to perform
-        $i = 0;
-        while($i++ < $count) {
-			switch ( $type ) {
-					case 'order':
-							Generator\Order::generate();
+	// Check what generation task to perform
+	$i = 0;
+       while($i++ < $count) {
+		switch ( $type ) {
+				case 'order':
+						Generator\Order::generate();
+						break;
+				case 'product':
+						Generator\Product::generate();
+						break;
+				case 'customer':
+						Generator\Customer::generate();
 							break;
-					case 'product':
-							Generator\Product::generate();
-							break;
-					case 'customer':
-							Generator\Customer::generate();
-							break;
-					case 'coupon':
-							Generator\Coupon::generate();
-							break;
-					default:
-							return false;
-			}
-        }
-
-        return false;
+				case 'coupon':
+						Generator\Coupon::generate();
+						break;
+				default:
+						return false;
+		}
+	}
+	
+	return false;
 }
 
 add_action( 'wc_smooth_generate_object', 'wc_smooth_generate_object' , 10, 2);

--- a/includes/GenerateBackgroundProcess.php
+++ b/includes/GenerateBackgroundProcess.php
@@ -10,33 +10,38 @@ use WC\SmoothGenerator\Generator;
 /**
  * Calls generator for object type.
  *
- * @param string $type Type of object to generate.
+ * @param string $type  Type of object to generate.
+ * @param int    $count Number of objects to generate.
  *
  * @return false If task was successful.
  */
-function wc_smooth_generate_object( $type ) {
-	// Check what generation task to perform.
-	switch ( $type ) {
-		case 'order':
-			Generator\Order::generate();
-			break;
-		case 'product':
-			Generator\Product::generate();
-			break;
-		case 'customer':
-			Generator\Customer::generate();
-			break;
-		case 'coupon':
-			Generator\Coupon::generate();
-			break;
-		default:
-			return false;
-	}
+function wc_smooth_generate_object( $type, $count = 1) {
 
-	return false;
+        // Check what generation task to perform
+        $i = 0;
+        while($i++ < $count) {
+			switch ( $type ) {
+					case 'order':
+							Generator\Order::generate();
+							break;
+					case 'product':
+							Generator\Product::generate();
+							break;
+					case 'customer':
+							Generator\Customer::generate();
+							break;
+					case 'coupon':
+							Generator\Coupon::generate();
+							break;
+					default:
+							return false;
+			}
+        }
+
+        return false;
 }
 
-add_action( 'wc_smooth_generate_object', 'wc_smooth_generate_object' );
+add_action( 'wc_smooth_generate_object', 'wc_smooth_generate_object' , 10, 2);
 
 /**
  * Schedule async actions for generation of objects.


### PR DESCRIPTION
As detailed in issue https://github.com/woocommerce/wc-smooth-generator/issues/76 , a count parameter would be beneficial so that scalable import events could be run from the WordPress cron infrastructure.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #76 .

### How to test the changes in this Pull Request:

1. Merge PR
2. Schedule an event from console 
```
wp cron event schedule wc_smooth_generate_object now --type=order --count=10
```
3. Check that 10 orders have been created

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added `count` parameter to the `wc_smooth_generate_object` method

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
