### PR TITLE
[Enhacement]: Improve getting a random user

### DIFF
--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -90,7 +90,9 @@ class Order extends Generator {
 		$existing = (bool) wp_rand( 0, 1 );
 
 		if ( $existing ) {
-			$user_id = (int) $wpdb->get_var( "SELECT ID FROM {$wpdb->users} ORDER BY rand() LIMIT 1" ); // phpcs:ignore
+			$total_users = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->users}" );	
+			$offset      = wp_rand(0, $total_users);	
+			$user_id     = (int) $wpdb->get_var( "SELECT ID FROM {$wpdb->users} ORDER BY rand() LIMIT $offset, 1" ); // phpcs:ignore
 			return new \WC_Customer( $user_id );
 		}
 

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -91,7 +91,7 @@ class Order extends Generator {
 
 		if ( $existing ) {
 			$total_users = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->users}" );	
-			$offset      = wp_rand(0, $total_users);	
+			$offset      = wp_rand( 0, $total_users );	
 			$user_id     = (int) $wpdb->get_var( "SELECT ID FROM {$wpdb->users} ORDER BY rand() LIMIT $offset, 1" ); // phpcs:ignore
 			return new \WC_Customer( $user_id );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #78 . 

This PR will simply replace the expensive query generated by the `ORDER BY rand() LIMIT 1` and instead, it computes the offset from the user's tables and uses that along with wp_rand to get a record using the `LIMIT offset, 1` query which proves to be less expensive on sites with a large number of users.

### How to test the changes in this Pull Request:

1. merge the PR
2. ideally, a large set of over 100K records in wp_users table should exist
3. measure the time for `time wp wc generate orders 10` before and after the change

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Improves order generate for sites that have a large user base.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
