### PR TITLE
Improve random customers data

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -121,10 +121,16 @@ class CLI extends WP_CLI_Command {
 	public static function customers( $args, $assoc_args ) {
 		list( $amount ) = $args;
 
+		$domain = '';
+
+		if ( ! empty( $assoc_args['email-domain'] ) ) {
+			$domain = $assoc_args['email-domain'];
+		}
+
 		static::disable_emails();
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating customers', $amount );
 		for ( $i = 1; $i <= $amount; $i++ ) {
-			Generator\Customer::generate();
+			Generator\Customer::generate( true, $domain );
 			$progress->tick();
 		}
 		$progress->finish();
@@ -242,7 +248,21 @@ WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'ord
 		),
 	),
 ) );
-WP_CLI::add_command( 'wc generate customers', array( 'WC\SmoothGenerator\CLI', 'customers' ) );
+WP_CLI::add_command( 'wc generate customers', array( 'WC\SmoothGenerator\CLI', 'customers' ), array(
+	'synopsis' => array(
+		array(
+			'name'     => 'amount',
+			'type'     => 'positional',
+			'optional' => true,
+			'default'  => 100,
+		),
+		array(
+			'name'     => 'email-domain',
+			'type'     => 'assoc',
+			'optional' => true,
+		),
+	),
+) );
 
 WP_CLI::add_command( 'wc generate coupons', array( 'WC\SmoothGenerator\CLI', 'coupons' ), array(
 	'synopsis' => array(

--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -15,23 +15,23 @@ class Customer extends Generator {
 	/**
 	 * Return a new customer.
 	 *
-	 * @param bool $save Save the object before returning or not.
+	 * @param bool   $save Save the object before returning or not.
+	 * @param string $emailDomain An optional domain to be used for all customers' email addresses.
 	 * @return \WC_Customer Customer object with data populated.
 	 */
-	public static function generate( $save = true ) {
+	public static function generate( $save = true, $emailDomain = '' ) {
 		self::init_faker();
+
+		$safeEmailDomain = $emailDomain ? $emailDomain : self::$faker->safeEmailDomain();
 
 		// Make sure a unique username and e-mail are used.
 		do {
-			$username = self::$faker->userName();
-		} while ( username_exists( $username ) );
+			$firstname = self::$faker->firstName( self::$faker->randomElement( array( 'male', 'female' ) ) );
+			$lastname  = self::$faker->lastName();
+			$username  = strtolower( "$firstname.$lastname" );
+			$email     = "$username@$safeEmailDomain";
+		} while ( username_exists( $username ) || email_exists( $email ) );
 
-		do {
-			$email = self::$faker->safeEmail();
-		} while ( email_exists( $email ) );
-
-		$firstname   = self::$faker->firstName( self::$faker->randomElement( array( 'male', 'female' ) ) );
-		$lastname    = self::$faker->lastName();
 		$company     = self::$faker->company();
 		$address1    = self::$faker->buildingNumber() . ' ' . self::$faker->streetName();
 		$address2    = self::$faker->streetAddress();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This Pull Request contains two main enhancements:
1. It will now be possible to pass the email domain name in the command line so that all the email addresses are generated with the same domain. For example, passing `--email-domain=passeddomain.com`, all the customers will have their email addresses in the format `first.last@passeddomain.com`. This is vital for email testing where, for example, an external server could be used to verify the delivery of test emails (e.g. email.ghostinspector.com). If no email domain name is passed, the customers' email addresses will have their domain name randomly generated by `$faker->safeEmailDomain()`
2. With the approach in place at the moment, first and last name, username, and email address are randomly and independently generated, which ends up with the customer details being completely unrelated to one another (e.g. first name `John`, last name `Doe`, username `karen.white`, email address `justin.brown@example.com`). This leads to a certain degree of confusion when it comes to testing certain features. With the proposed change, all the user data will be unequivocally matching (e.g. first name `John`, last name `Doe`, username `john.doe`, email address `john.doe@example.com` or `john.doe@passed-domain.com` when an email domain is passed).

### How to test the changes in this Pull Request:

1. Input the following command: `wp wc generate customers 10 --email-domain=passed-domain.com`
2. Verify that the 10 newly generated customers have their username and email addresses matching their first and last name and their email addresses have the email domain name passed in the `--email-domain` parameter.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Enhancement: The domain name of the email addresses of customers can now be passed in the command line.
> Enhancement: Usernames and email addresses of customers are now generated from the random first and last names.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
