### PR TITLE
Run PHPCS in CI

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,33 @@
+name: PHPCS check
+on:
+  push
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  phpcs:
+    name: PHPCS check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "7.4"
+          ini-values: "memory_limit=1G"
+          coverage: none
+          tools: cs2pr
+
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v2"
+
+      - name: Run PHPCS checks
+        continue-on-error: true
+        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
+
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![PHPCS](https://github.com/woocommerce/wc-smooth-generator/actions/workflows/phpcs.yml/badge.svg)](https://github.com/woocommerce/wc-smooth-generator/actions/workflows/phpcs.yml)
+
 # WooCommerce Smooth Generator
 A smooth products, customer and order generator using WP-CLI. Future versions will include scheduled auto generation functionality.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces a GitHub workflow to run PHPCS checks in CI on Push event.

### How to test the changes in this Pull Request:

1. Merge this PR to trunk
2. Push code to a remote branch
3. Assert it runs PHPCS in CI
4. Assert that the badge in README.md is as expected.

### Changelog entry

> Run PHPCS checks in CI

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
