### PR TITLE
Run PHPCS in CI

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,33 @@
+name: PHPCS check
+on:
+  push
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  phpcs:
+    name: PHPCS check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "7.4"
+          ini-values: "memory_limit=1G"
+          coverage: none
+          tools: cs2pr
+
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v2"
+
+      - name: Run PHPCS checks
+        continue-on-error: true
+        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
+
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![PHPCS](https://github.com/woocommerce/wc-smooth-generator/actions/workflows/phpcs.yml/badge.svg)](https://github.com/woocommerce/wc-smooth-generator/actions/workflows/phpcs.yml)
+
 # WooCommerce Smooth Generator
 A smooth products, customer and order generator using WP-CLI. Future versions will include scheduled auto generation functionality.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+2022-06-30 - version 1.0.5
+* Dev - Run PHPCS checks in CI.
+
 2021-12-15 - version 1.0.4
 * Add - coupon generator and a new option for orders to allow for coupon generation.
 * Add - use product name to generate more realistic product term names.

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -70,12 +70,12 @@ class Settings {
 			$num_to_generate = absint( $_POST['num_products_to_generate'] );
 			wc_smooth_generate_schedule( 'product', $num_to_generate );
 			add_action( 'admin_notices', array( __CLASS__, 'product_generating_notice' ) );
-		} else if ( ! empty( $_POST['generate_orders'] ) && ! empty( $_POST['num_orders_to_generate'] ) ) {
+		} elseif ( ! empty( $_POST['generate_orders'] ) && ! empty( $_POST['num_orders_to_generate'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_orders_to_generate'] );
 			wc_smooth_generate_schedule( 'order', $num_to_generate );
 			add_action( 'admin_notices', array( __CLASS__, 'order_generating_notice' ) );
-		} else if ( ! empty( $_POST['cancel_all_generations'] ) ) {
+		} elseif ( ! empty( $_POST['cancel_all_generations'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			wc_smooth_generate_cancel_all();
 		}

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -126,8 +126,8 @@ class Product extends Generator {
 		$taxonomy_name = wc_attribute_taxonomy_name( $slug );
 		register_taxonomy(
 			$taxonomy_name,
-			apply_filters( 'woocommerce_taxonomy_objects_' . $taxonomy_name, array( 'product' ) ),
-			apply_filters( 'woocommerce_taxonomy_args_' . $taxonomy_name, array(
+			apply_filters( 'woocommerce_taxonomy_objects_' . $taxonomy_name, array( 'product' ) ), // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+			apply_filters( 'woocommerce_taxonomy_args_' . $taxonomy_name, array( // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 				'labels'       => array(
 					'name' => $raw_name,
 				),

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,6 +10,7 @@
 	<!-- Exclude paths -->
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>Gruntfile\.js</exclude-pattern>
 
 	<!-- Show progress, show the error codes for each message (source). -->
 	<arg value="ps"/>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces a GitHub workflow to run PHPCS checks in CI on Push event. This is interesting to have, **as PHPCS tests the PHP compatibility with the minimum PHP version required by the project.**

### How to test the changes in this Pull Request:

1. Merge this PR to trunk
2. Push code to a remote branch
3. Assert it runs PHPCS in CI
4. Assert that the badge in README.md is as expected.

### Changelog entry

> Run PHPCS checks in CI

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
