### PR TITLE
Fix emails sent out on generation

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -90,7 +90,7 @@ class CLI extends WP_CLI_Command {
 		}
 
 		if ( $amount > 0 ) {
-			static::disable_emails();
+			Generator\Order::disable_emails();
 			$progress = \WP_CLI\Utils\make_progress_bar( 'Generating orders', $amount );
 			for ( $i = 1; $i <= $amount; $i++ ) {
 				Generator\Order::generate( true, $assoc_args );
@@ -121,7 +121,7 @@ class CLI extends WP_CLI_Command {
 	public static function customers( $args, $assoc_args ) {
 		list( $amount ) = $args;
 
-		static::disable_emails();
+		Generator\Customer::disable_emails();
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating customers', $amount );
 		for ( $i = 1; $i <= $amount; $i++ ) {
 			Generator\Customer::generate();
@@ -129,40 +129,6 @@ class CLI extends WP_CLI_Command {
 		}
 		$progress->finish();
 		WP_CLI::success( $amount . ' customers generated.' );
-	}
-
-	/**
-	 * Disable sending WooCommerce emails when generating objects.
-	 */
-	protected static function disable_emails() {
-		$email_actions = array(
-			'woocommerce_low_stock',
-			'woocommerce_no_stock',
-			'woocommerce_product_on_backorder',
-			'woocommerce_order_status_pending_to_processing',
-			'woocommerce_order_status_pending_to_completed',
-			'woocommerce_order_status_processing_to_cancelled',
-			'woocommerce_order_status_pending_to_failed',
-			'woocommerce_order_status_pending_to_on-hold',
-			'woocommerce_order_status_failed_to_processing',
-			'woocommerce_order_status_failed_to_completed',
-			'woocommerce_order_status_failed_to_on-hold',
-			'woocommerce_order_status_cancelled_to_processing',
-			'woocommerce_order_status_cancelled_to_completed',
-			'woocommerce_order_status_cancelled_to_on-hold',
-			'woocommerce_order_status_on-hold_to_processing',
-			'woocommerce_order_status_on-hold_to_cancelled',
-			'woocommerce_order_status_on-hold_to_failed',
-			'woocommerce_order_status_completed',
-			'woocommerce_order_fully_refunded',
-			'woocommerce_order_partially_refunded',
-			'woocommerce_new_customer_note',
-			'woocommerce_created_customer',
-		);
-
-		foreach ( $email_actions as $action ) {
-			remove_action( $action, array( 'WC_Emails', 'send_transactional_email' ), 10, 10 );
-		}
 	}
 
 	/**

--- a/includes/GenerateBackgroundProcess.php
+++ b/includes/GenerateBackgroundProcess.php
@@ -18,12 +18,14 @@ function wc_smooth_generate_object( $type ) {
 	// Check what generation task to perform.
 	switch ( $type ) {
 		case 'order':
+			Generator\Order::disable_emails();
 			Generator\Order::generate();
 			break;
 		case 'product':
 			Generator\Product::generate();
 			break;
 		case 'customer':
+			Generator\Customer::disable_emails();
 			Generator\Customer::generate();
 			break;
 		case 'coupon':

--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -82,4 +82,18 @@ class Customer extends Generator {
 		return $customer;
 	}
 
+
+	/**
+	 * Disable sending WooCommerce emails when generating objects.
+	 */
+	public static function disable_emails() {
+		$email_actions = array(
+			'woocommerce_new_customer_note',
+			'woocommerce_created_customer',
+		);
+
+		foreach ( $email_actions as $action ) {
+			remove_action( $action, array( 'WC_Emails', 'send_transactional_email' ), 10, 10 );
+		}
+	}
 }

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -94,6 +94,7 @@ class Order extends Generator {
 			return new \WC_Customer( $user_id );
 		}
 
+		Customer::disable_emails();
 		$customer = Customer::generate( ! $guest );
 
 		return $customer;

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -100,6 +100,38 @@ class Order extends Generator {
 	}
 
 	/**
+	 * Disable sending WooCommerce emails when generating objects.
+	 */
+	public static function disable_emails() {
+		$email_actions = array(
+			'woocommerce_low_stock',
+			'woocommerce_no_stock',
+			'woocommerce_product_on_backorder',
+			'woocommerce_order_status_pending_to_processing',
+			'woocommerce_order_status_pending_to_completed',
+			'woocommerce_order_status_processing_to_cancelled',
+			'woocommerce_order_status_pending_to_failed',
+			'woocommerce_order_status_pending_to_on-hold',
+			'woocommerce_order_status_failed_to_processing',
+			'woocommerce_order_status_failed_to_completed',
+			'woocommerce_order_status_failed_to_on-hold',
+			'woocommerce_order_status_cancelled_to_processing',
+			'woocommerce_order_status_cancelled_to_completed',
+			'woocommerce_order_status_cancelled_to_on-hold',
+			'woocommerce_order_status_on-hold_to_processing',
+			'woocommerce_order_status_on-hold_to_cancelled',
+			'woocommerce_order_status_on-hold_to_failed',
+			'woocommerce_order_status_completed',
+			'woocommerce_order_fully_refunded',
+			'woocommerce_order_partially_refunded',
+		);
+
+		foreach ( $email_actions as $action ) {
+			remove_action( $action, array( 'WC_Emails', 'send_transactional_email' ), 10, 10 );
+		}
+	}
+
+	/**
 	 * Returns a date to use as the order date. If no date arguments have been passed, this will
 	 * return the current date. If a `date-start` argument is provided, a random date will be chosen
 	 * between `date-start` and the current date. You can pass an `end-date` and a random date between start


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #97.

This PR disables the sending emails when generating objects via UI 

### How to test the changes in this Pull Request:

1. Use a site with PHP > 8.0 (require minimum php version) 
2. Install WooCommerce and wc-smooth-generator
3. Go to `Tools > WooCommerce Smooth Generator`
4. Generate some order 
5. Go to your email app and observe that no "New order..." emails received.

Please also test CLI

- Run `wp wc generate orders 1`
- Run `wp wc generate customers 1`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fix emails sent out on generation

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
