### PR TITLE
Companies without personal details and only allowed countries

### DIFF
--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -57,6 +57,16 @@ class Customer extends Generator {
 					$company['shipping']['company_name'] = $company['billing']['company_name'];
 				}
 
+				if (( (bool) wp_rand( 0, 1 ) )){
+					$person['billing']['firstname']  = '';
+					$person['billing']['lastname']  = '';
+				}
+
+				if (( (bool) wp_rand( 0, 1 ) )){
+					$person['shipping']['firstname']  = '';
+					$person['shipping']['lastname']  = '';
+				}
+
 				break;
 			case 'C2C':
 				$company['billing']['company_name']  = '';
@@ -65,6 +75,12 @@ class Customer extends Generator {
 			case 'B2C':
 				$company['billing']['company_name']  = self::$faker->company();
 				$company['shipping']['company_name'] = '';
+
+				if (( (bool) wp_rand( 0, 1 ) )){
+					$person['billing']['firstname']  = '';
+					$person['billing']['lastname']  = '';
+				}
+				
 				break;
 			case 'C2B':
 				$company['billing']['company_name']  = '';
@@ -159,3 +175,4 @@ class Customer extends Generator {
 		}
 	}
 }
+?>

--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -31,18 +31,6 @@ class Customer extends Generator {
 			$email = self::$faker->safeEmail();
 		} while ( email_exists( $email ) );
 
-		/*PERSON*/
-		$person['billing']['firstname'] = self::$faker->firstName( self::$faker->randomElement( array( 'male', 'female' ) ) );
-		$person['billing']['lastname']  = self::$faker->lastName();
-
-		// 50% chance
-		if ( (bool) wp_rand( 0, 1 ) ) {
-			$person['shipping']['firstname'] = self::$faker->firstName( self::$faker->randomElement( array( 'male', 'female' ) ) );
-			$person['shipping']['lastname']  = self::$faker->lastName();
-		} else {
-			$person['shipping']['firstname'] = $person['billing']['firstname'];
-			$person['shipping']['lastname']  = $person['billing']['lastname'];
-		}
 
 		/*COMPANY*/
 		$company_variations = array( 'B2B', 'C2C', 'C2B', 'B2C' );
@@ -57,16 +45,6 @@ class Customer extends Generator {
 					$company['shipping']['company_name'] = $company['billing']['company_name'];
 				}
 
-				if (( (bool) wp_rand( 0, 1 ) )){
-					$person['billing']['firstname']  = '';
-					$person['billing']['lastname']  = '';
-				}
-
-				if (( (bool) wp_rand( 0, 1 ) )){
-					$person['shipping']['firstname']  = '';
-					$person['shipping']['lastname']  = '';
-				}
-
 				break;
 			case 'C2C':
 				$company['billing']['company_name']  = '';
@@ -74,13 +52,7 @@ class Customer extends Generator {
 				break;
 			case 'B2C':
 				$company['billing']['company_name']  = self::$faker->company();
-				$company['shipping']['company_name'] = '';
-
-				if (( (bool) wp_rand( 0, 1 ) )){
-					$person['billing']['firstname']  = '';
-					$person['billing']['lastname']  = '';
-				}
-				
+				$company['shipping']['company_name'] = '';		
 				break;
 			case 'C2B':
 				$company['billing']['company_name']  = '';
@@ -89,6 +61,30 @@ class Customer extends Generator {
 			default:
 				break;
 		}
+
+
+		/*PERSON*/
+		if(strlen($company['billing']['company_name']) >= 1 && (bool) wp_rand( 0, 1 )){
+			$person['billing']['firstname'] = '';
+			$person['billing']['lastname'] = '';
+		} else {
+			$person['billing']['firstname'] = self::$faker->firstName( self::$faker->randomElement( array( 'male', 'female' ) ) );
+			$person['billing']['lastname']  = self::$faker->lastName();
+		}
+
+		if(strlen($company['shipping']['company_name']) >= 1 && (bool) wp_rand( 0, 1 )){
+			if(strlen($company['billing']['company_name']) >= 1 && (bool) wp_rand( 0, 1 )){
+				$person['shipping']['firstname'] = $person['billing']['firstname'];
+				$person['shipping']['lastname']  = $person['billing']['lastname'];
+			} else {
+				$person['shipping']['firstname'] = '';
+				$person['shipping']['lastname'] = '';
+			}
+		} else {
+				$person['shipping']['firstname'] = self::$faker->firstName( self::$faker->randomElement( array( 'male', 'female' ) ) );
+				$person['shipping']['lastname']  = self::$faker->lastName();
+		}
+
 		/*ADDRESS*/
 		$address['billing']['address0'] = self::$faker->buildingNumber() . ' ' . self::$faker->streetName();
 		$address['billing']['address1'] = self::$faker->streetAddress();
@@ -175,4 +171,3 @@ class Customer extends Generator {
 		}
 	}
 }
-?>

--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -52,7 +52,7 @@ class Customer extends Generator {
 				break;
 			case 'B2C':
 				$company['billing']['company_name']  = self::$faker->company();
-				$company['shipping']['company_name'] = '';		
+				$company['shipping']['company_name'] = '';
 				break;
 			case 'C2B':
 				$company['billing']['company_name']  = '';

--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -91,7 +91,7 @@ class Customer extends Generator {
 		$address['billing']['city']     = self::$faker->city();
 		$address['billing']['state']    = self::$faker->stateAbbr();
 		$address['billing']['postcode'] = self::$faker->postcode();
-		$address['billing']['country']  = self::$faker->countryCode();
+		$address['billing']['country'] = Customer::getAllowedCountry();
 		$address['billing']['phone']    = self::$faker->e164PhoneNumber();
 		$address['billing']['email']    = $email;
 
@@ -102,7 +102,7 @@ class Customer extends Generator {
 			$address['shipping']['city']     = self::$faker->city();
 			$address['shipping']['state']    = self::$faker->stateAbbr();
 			$address['shipping']['postcode'] = self::$faker->postcode();
-			$address['shipping']['country']  = self::$faker->countryCode();
+			$address['shipping']['country']  = Customer::getAllowedCountry();
 		} else {
 			$address['shipping']['address0'] = $address['billing']['address0'];
 			$address['shipping']['address1'] = $address['billing']['address1'];
@@ -154,6 +154,28 @@ class Customer extends Generator {
 		}
 
 		return $customer;
+	}
+
+	/**
+	 * returns allowed country based on the woocommerce settings
+	 */
+	public static function getAllowedCountry(){
+		$allowedCountries = get_option('woocommerce_allowed_countries');
+		$allowedOnes = get_option('woocommerce_specific_allowed_countries');
+		$restrictedOnes = get_option('woocommerce_all_except_countries');
+
+		if ($allowedCountries == 'specific'){
+			$country = self::$faker->randomElements( $allowedOnes, $count = 1 );
+			$country = $country[0];
+		} else if ($allowedCountries == 'all_except'){
+			do{
+				$country  = self::$faker->countryCode(); 
+			} while (in_array($country,$restrictedOnes));
+		} else {
+			$country =  self::$faker->countryCode(); 
+		}
+
+		return $country;
 	}
 
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/wc-smooth-generator/issues/108 and https://github.com/woocommerce/wc-smooth-generator/issues/66

### How to test the changes in this Pull Request:

1. use ```wp wc generate customers 10``` to generate 10 customers
2. Check the page ```/wp-admin/edit.php?post_type=shop_order orders```  for orders 

#### feature #108 
In 3/4 cases there is a business involved with an order. It can be shipping, billing, or both. If there is a business involved, there will be a 1/2 chance that the address will be assigned to only the business. The other 1/2 would be that the address will be assigned to a business with a person. That means that the fields firstname and lastname will be filled out.

with billing / shipping addresses wich do have a business (the field ```company``` with a value) but do not have personal details (```firstname``` and ```lastname``` empty)

#### feature #66 
There is the woocommerce option ```woocommerce_allowed_countries```, which can be set in the page ```/wp-admin/admin.php?page=wc-settings``` to three different options:
- all countries
- just a few specified ones
- all others than the ones specified

every option has its own logic added to the pull request.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
> Now, it is also possible to generate customers with businesses for orders, which are not assigned to a person. They do not have the fields first name and last name in shipping and billing.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
