### PR TITLE
Declare compatibility with HPOS

### DIFF
--- a/wc-smooth-generator.php
+++ b/wc-smooth-generator.php
@@ -50,3 +50,12 @@ function load_wc_smooth_generator() {
 if ( version_compare( PHP_VERSION, '5.3', '>' ) ) {
 	add_action( 'plugins_loaded', 'load_wc_smooth_generator', 20 );
 }
+
+/**
+ * Declare HPOS compatibility.
+ */
+add_action( 'before_woocommerce_init', function() {
+	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+	}
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Declares compatibility with High-Performance Order Storage (HPOS).

Fixes #109 

### How to test the changes in this Pull Request:

1. Activate the HPOS feature (WooCommerce > Settings > Features)
2. Go to the newly available Custom data stores settings screen (next link after "Features")
3. Choose the WooCommerce orders tables as the data store for orders and Save.
4. Generate some orders and make sure they look right.

### Changelog entry

> Declare compatibility with WooCommerce's high-performance order storage feature.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
