### PR TITLE
Add elapsed time measurement and reporting on other CLI commands

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -76,6 +76,8 @@ class CLI extends WP_CLI_Command {
 	public static function orders( $args, $assoc_args ) {
 		list( $amount ) = $args;
 
+		$time_start = microtime( true );
+
 		$amount = (int) $amount;
 		if ( empty( $amount ) ) {
 			$amount = 100;
@@ -98,7 +100,12 @@ class CLI extends WP_CLI_Command {
 			}
 			$progress->finish();
 		}
-		WP_CLI::success( $amount . ' orders generated.' );
+
+		$time_end       = microtime( true );
+		$execution_time = round( ( $time_end - $time_start ), 2 );
+		$display_time   = $execution_time < 60 ? $execution_time . ' seconds' : human_time_diff( $time_start, $time_end );
+
+		WP_CLI::success( $amount . ' orders generated in ' . $display_time );
 	}
 
 	/**
@@ -121,6 +128,8 @@ class CLI extends WP_CLI_Command {
 	public static function customers( $args, $assoc_args ) {
 		list( $amount ) = $args;
 
+		$time_start = microtime( true );
+
 		Generator\Customer::disable_emails();
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating customers', $amount );
 		for ( $i = 1; $i <= $amount; $i++ ) {
@@ -128,7 +137,12 @@ class CLI extends WP_CLI_Command {
 			$progress->tick();
 		}
 		$progress->finish();
-		WP_CLI::success( $amount . ' customers generated.' );
+
+		$time_end       = microtime( true );
+		$execution_time = round( ( $time_end - $time_start ), 2 );
+		$display_time   = $execution_time < 60 ? $execution_time . ' seconds' : human_time_diff( $time_start, $time_end );
+
+		WP_CLI::success( $amount . ' customers generated in ' . $display_time );
 	}
 
 	/**
@@ -150,6 +164,8 @@ class CLI extends WP_CLI_Command {
 	 */
 	public static function coupons( $args, $assoc_args ) {
 		list( $amount ) = $args;
+
+		$time_start = microtime( true );
 
 		$amount = (int) $amount;
 		if ( empty( $amount ) ) {
@@ -173,7 +189,12 @@ class CLI extends WP_CLI_Command {
 			}
 			$progress->finish();
 		}
-		WP_CLI::success( $amount . ' coupons generated.' );
+
+		$time_end       = microtime( true );
+		$execution_time = round( ( $time_end - $time_start ), 2 );
+		$display_time   = $execution_time < 60 ? $execution_time . ' seconds' : human_time_diff( $time_start, $time_end );
+
+		WP_CLI::success( $amount . ' coupons generated in ' . $display_time );
 	}
 }
 


### PR DESCRIPTION
Besides products.

### Changes proposed in this Pull Request:

The `wc generate products` CLI command outputs the elapsed time when the command finishes. This adds the same functionality to the other `generate` commands as well. It may not be as necessary for the commands that execute more quickly, but it's nice to have parity, and could still be useful if needing to generate a large number of something.

### How to test the changes in this Pull Request:

1. Try the other CLI commands besides products and make sure they output an elapsed time when they complete.

> Measure elapsed time for the orders, customers, and coupons CLI commands.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
