### PR TITLE
Add a "type" argument to the generate products command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ WooCommerce Smooth Generator requires Composer and WP-CLI to function.
 Generate products based on the number of products paramater.
 - `wp wc generate products <nr of products>`
 
+Generate products of the specified type. `simple` or `variable`.
+- `wp wc generate products <nr of products> --type=simple`
+
 ### Orders
 
 Generate orders from existing products based on the number of orders paramater, customers will also be generated to mimic guest checkout.

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -178,19 +178,24 @@ class CLI extends WP_CLI_Command {
 }
 
 WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'products' ), array(
+	'shortdesc' => 'Generate products.',
 	'synopsis' => array(
 		array(
-			'name'     => 'amount',
-			'type'     => 'positional',
-			'optional' => true,
-			'default'  => 100,
+			'name'        => 'amount',
+			'type'        => 'positional',
+			'description' => 'The number of products to generate.',
+			'optional'    => true,
+			'default'     => 100,
 		),
 		array(
-			'name'     => 'type',
-			'type'     => 'assoc',
-			'optional' => true,
+			'name'        => 'type',
+			'type'        => 'assoc',
+			'description' => 'Specify one type of product to generate. Otherwise defaults to a mix.',
+			'optional'    => true,
+			'options'     => array( 'simple', 'variable' ),
 		),
 	),
+	'longdesc' => "## EXAMPLES\n\nwc generate products 100\n\nwc generate products 10 --type=variable",
 ) );
 
 WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'orders' ), array(

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -43,7 +43,7 @@ class CLI extends WP_CLI_Command {
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating products', $amount );
 
 		for ( $i = 1; $i <= $amount; $i++ ) {
-			Generator\Product::generate();
+			Generator\Product::generate( true, $assoc_args );
 			$progress->tick();
 		}
 
@@ -177,7 +177,22 @@ class CLI extends WP_CLI_Command {
 	}
 }
 
-WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'products' ) );
+WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'products' ), array(
+	'synopsis' => array(
+		array(
+			'name'     => 'amount',
+			'type'     => 'positional',
+			'optional' => true,
+			'default'  => 100,
+		),
+		array(
+			'name'     => 'type',
+			'type'     => 'assoc',
+			'optional' => true,
+		),
+	),
+) );
+
 WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'orders' ), array(
 	'synopsis' => array(
 		array(
@@ -208,6 +223,7 @@ WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'ord
 		),
 	),
 ) );
+
 WP_CLI::add_command( 'wc generate customers', array( 'WC\SmoothGenerator\CLI', 'customers' ) );
 
 WP_CLI::add_command( 'wc generate coupons', array( 'WC\SmoothGenerator\CLI', 'coupons' ), array(

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -185,7 +185,7 @@ WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'p
 			'type'        => 'positional',
 			'description' => 'The number of products to generate.',
 			'optional'    => true,
-			'default'     => 100,
+			'default'     => 10,
 		),
 		array(
 			'name'        => 'type',
@@ -195,7 +195,7 @@ WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'p
 			'options'     => array( 'simple', 'variable' ),
 		),
 	),
-	'longdesc' => "## EXAMPLES\n\nwc generate products 100\n\nwc generate products 10 --type=variable",
+	'longdesc' => "## EXAMPLES\n\nwc generate products 10\n\nwc generate products 20 --type=variable",
 ) );
 
 WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'orders' ), array(

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -76,19 +76,22 @@ class Product extends Generator {
 	/**
 	 * Return a new product.
 	 *
-	 * @param bool $save Save the object before returning or not.
+	 * @param bool  $save Save the object before returning or not.
+	 * @param array $assoc_args Arguments passed via the CLI for additional customization.
 	 * @return \WC_Product The product object consisting of random data.
 	 */
-	public static function generate( $save = true ) {
+	public static function generate( $save = true, $assoc_args = array() ) {
 		self::init_faker();
 
-		// 20% chance of a variable product.
-		$is_variable = self::$faker->boolean( 20 );
-
-		if ( $is_variable ) {
-			$product = self::generate_variable_product();
-		} else {
-			$product = self::generate_simple_product();
+		$type = self::get_product_type( $assoc_args );
+		switch ( $type ) {
+			case 'simple':
+			default:
+				$product = self::generate_simple_product();
+				break;
+			case 'variable':
+				$product = self::generate_variable_product();
+				break;
 		}
 
 		if ( $product ) {
@@ -220,6 +223,30 @@ class Product extends Generator {
 		}
 
 		return $attributes;
+	}
+
+	/**
+	 * Returns a product type to generate. If no type is specified, or an invalid type is specified,
+	 * a weighted random type is returned.
+	 *
+	 * @param array $assoc_args CLI arguments.
+	 * @return string A product type.
+	 */
+	protected static function get_product_type( array $assoc_args ) {
+		$type  = $assoc_args['type'] ?? null;
+		$types = array(
+			'simple',
+			'variable',
+		);
+
+		if ( ! is_null( $type ) && in_array( $type, $types, true ) ) {
+			return $type;
+		} else {
+			return self::random_weighted_element( array(
+				'simple'   => 80,
+				'variable' => 20,
+			) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Enables specifying that the product generator should only generate one type of product (currently simple or variable) instead of using a weighted random number to choose the type.

### How to test the changes in this Pull Request:

1. Check out the updated readme
2. Try running the `wc generate products` CLI command with each type option and make sure only that type of product gets generated.

### Changelog entry

> Add a "type" argument to the generate products command.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
