### PR TITLE
Update CLI command documentation for consistency

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -21,6 +21,7 @@ class CLI extends WP_CLI_Command {
 	 */
 	public static function products( $args, $assoc_args ) {
 		list( $amount ) = $args;
+		$amount = absint( $amount );
 
 		$time_start = microtime( true );
 
@@ -53,6 +54,7 @@ class CLI extends WP_CLI_Command {
 	 */
 	public static function orders( $args, $assoc_args ) {
 		list( $amount ) = $args;
+		$amount = absint( $amount );
 
 		$time_start = microtime( true );
 
@@ -89,6 +91,7 @@ class CLI extends WP_CLI_Command {
 	 */
 	public static function customers( $args, $assoc_args ) {
 		list( $amount ) = $args;
+		$amount = absint( $amount );
 
 		$time_start = microtime( true );
 
@@ -115,6 +118,7 @@ class CLI extends WP_CLI_Command {
 	 */
 	public static function coupons( $args, $assoc_args ) {
 		list( $amount ) = $args;
+		$amount = absint( $amount );
 
 		$time_start = microtime( true );
 

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -319,5 +319,5 @@ WP_CLI::add_command( 'wc generate terms', array( 'WC\SmoothGenerator\CLI', 'term
 			'default'     => 0,
 		),
 	),
-	'longdesc' => "## EXAMPLES\n\nwc generate terms product_tag 10\n\nwc generate terms product_cat 50 --max_depth=3",
+	'longdesc' => "## EXAMPLES\n\nwc generate terms product_tag 10\n\nwc generate terms product_cat 50 --max-depth=3",
 ) );

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -16,17 +16,6 @@ class CLI extends WP_CLI_Command {
 	/**
 	 * Generate products.
 	 *
-	 * ## OPTIONS
-	 *
-	 * <amount>
-	 * : The amount of products to generate
-	 * ---
-	 * default: 100
-	 * ---
-	 *
-	 * ## EXAMPLES
-	 * wc generate products 100
-	 *
 	 * @param array $args Arguments specified.
 	 * @param array $assoc_args Associative arguments specified.
 	 */
@@ -59,17 +48,6 @@ class CLI extends WP_CLI_Command {
 	/**
 	 * Generate orders.
 	 *
-	 * ## OPTIONS
-	 *
-	 * <amount>
-	 * : The amount of orders to generate
-	 * ---
-	 * default: 100
-	 * ---
-	 *
-	 * ## EXAMPLES
-	 * wc generate orders 100
-	 *
 	 * @param array $args Arguments specified.
 	 * @param array $assoc_args Associative arguments specified.
 	 */
@@ -77,11 +55,6 @@ class CLI extends WP_CLI_Command {
 		list( $amount ) = $args;
 
 		$time_start = microtime( true );
-
-		$amount = (int) $amount;
-		if ( empty( $amount ) ) {
-			$amount = 100;
-		}
 
 		if ( ! empty( $assoc_args['status'] ) ) {
 			$status = $assoc_args['status'];
@@ -111,17 +84,6 @@ class CLI extends WP_CLI_Command {
 	/**
 	 * Generate customers.
 	 *
-	 * ## OPTIONS
-	 *
-	 * <amount>
-	 * : The amount of customers to generate
-	 * ---
-	 * default: 100
-	 * ---
-	 *
-	 * ## EXAMPLES
-	 * wc generate customers 100
-	 *
 	 * @param array $args Arguments specified.
 	 * @param array $assoc_args Associative arguments specified.
 	 */
@@ -148,17 +110,6 @@ class CLI extends WP_CLI_Command {
 	/**
 	 * Generate coupons.
 	 *
-	 * ## OPTIONS
-	 *
-	 * <amount>
-	 * : The amount of coupons to generate
-	 * ---
-	 * default: 100
-	 * ---
-	 *
-	 * ## EXAMPLES
-	 * wc generate coupons 100
-	 *
 	 * @param array $args Arguments specified.
 	 * @param array $assoc_args Associative arguments specified.
 	 */
@@ -166,11 +117,6 @@ class CLI extends WP_CLI_Command {
 		list( $amount ) = $args;
 
 		$time_start = microtime( true );
-
-		$amount = (int) $amount;
-		if ( empty( $amount ) ) {
-			$amount = 10;
-		}
 
 		$min = 5;
 		$max = 100;
@@ -257,59 +203,84 @@ WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'p
 ) );
 
 WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'orders' ), array(
-	'synopsis' => array(
+	'shortdesc' => 'Generate orders.',
+	'synopsis'  => array(
 		array(
-			'name'     => 'amount',
-			'type'     => 'positional',
-			'optional' => true,
-			'default'  => 100,
+			'name'        => 'amount',
+			'type'        => 'positional',
+			'description' => 'The number of orders to generate.',
+			'optional'    => true,
+			'default'     => 10,
 		),
 		array(
-			'name'     => 'date-start',
-			'type'     => 'assoc',
-			'optional' => true,
+			'name'        => 'date-start',
+			'type'        => 'assoc',
+			'description' => 'Randomize the order date using this as the lower limit. Format as YYYY-MM-DD.',
+			'optional'    => true,
 		),
 		array(
-			'name'     => 'date-end',
-			'type'     => 'assoc',
-			'optional' => true,
+			'name'        => 'date-end',
+			'type'        => 'assoc',
+			'description' => 'Randomize the order date using this as the upper limit. Only works in conjunction with date-start. Format as YYYY-MM-DD.',
+			'optional'    => true,
 		),
 		array(
-			'name'     => 'status',
-			'type'     => 'assoc',
-			'optional' => true,
+			'name'        => 'status',
+			'type'        => 'assoc',
+			'description' => 'Specify one status for all the generated orders. Otherwise defaults to a mix.',
+			'optional'    => true,
+			'options'     => array( 'completed', 'processing', 'on-hold', 'failed' ),
 		),
 		array(
-			'name'     => 'coupons',
-			'type'     => 'assoc',
-			'optional' => true,
+			'name'        => 'coupons',
+			'type'        => 'flag',
+			'description' => 'Create and apply a coupon to each generated order.',
+			'optional'    => true,
 		),
 	),
+	'longdesc'  => "## EXAMPLES\n\nwc generate orders 10\n\nwc generate orders 50 --date-start=2020-01-01 --date-end=2022-12-31 --status=completed --coupons",
 ) );
 
-WP_CLI::add_command( 'wc generate customers', array( 'WC\SmoothGenerator\CLI', 'customers' ) );
-
-WP_CLI::add_command( 'wc generate coupons', array( 'WC\SmoothGenerator\CLI', 'coupons' ), array(
-	'synopsis' => array(
+WP_CLI::add_command( 'wc generate customers', array( 'WC\SmoothGenerator\CLI', 'customers' ), array(
+	'shortdesc' => 'Generate customers.',
+	'synopsis'  => array(
 		array(
-			'name'     => 'amount',
-			'type'     => 'positional',
-			'optional' => true,
-			'default'  => 10,
-		),
-		array(
-			'name'     => 'min',
-			'optional' => true,
-			'type'     => 'assoc',
-			'default'  => 5,
-		),
-		array(
-			'name'     => 'max',
-			'optional' => true,
-			'type'     => 'assoc',
-			'default'  => 100,
+			'name'        => 'amount',
+			'type'        => 'positional',
+			'description' => 'The number of customers to generate.',
+			'optional'    => true,
+			'default'     => 10,
 		),
 	),
+	'longdesc'  => "## EXAMPLES\n\nwc generate customers 10",
+) );
+
+WP_CLI::add_command( 'wc generate coupons', array( 'WC\SmoothGenerator\CLI', 'coupons' ), array(
+	'shortdesc' => 'Generate coupons.',
+	'synopsis'  => array(
+		array(
+			'name'        => 'amount',
+			'type'        => 'positional',
+			'description' => 'The number of coupons to generate.',
+			'optional'    => true,
+			'default'     => 10,
+		),
+		array(
+			'name'        => 'min',
+			'type'        => 'assoc',
+			'description' => 'Specify the minimum discount of each coupon.',
+			'optional'    => true,
+			'default'     => 5,
+		),
+		array(
+			'name'        => 'max',
+			'type'        => 'assoc',
+			'description' => 'Specify the maximum discount of each coupon.',
+			'optional'    => true,
+			'default'     => 100,
+		),
+	),
+	'longdesc'  => "## EXAMPLES\n\nwc generate coupons 10\n\nwc generate coupons 50 --min=1 --max=50",
 ) );
 
 WP_CLI::add_command( 'wc generate terms', array( 'WC\SmoothGenerator\CLI', 'terms' ), array(


### PR DESCRIPTION
In #113 I updated the CLI documentation for the products command, using the `$args` parameter of the `add_command` method. This approach seems easier to maintain compared to putting the documentation in the method doc block, because WP-CLI takes care of the formatting and spacing of everything for us. This PR simply updates the docs for the other CLI commands to take the same approach.

When a command's synopsis declares a default for a parameter, WP-CLI handles passing that value to the command when it's not specified, so this also removes some unnecessary code within some of the command callbacks.

(Note that this changeset does not include the products command because it's addressed in #113)

### How to test the changes in this Pull Request:

1. Run `wp help wc generate {command}` for each of the four commands and make sure the documentation it outputs looks accurate, and that defaults are correctly handled.

### Changelog entry

> Update the documentation for the CLI commands.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
