### PR TITLE
Add term generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,17 @@ Generate coupons with a maximum discount amount.
 
 Generate customers based on the number of customers parameter.
 - `wp wc generate customers <nr of customers>`
+
+### Terms
+
+Generate terms in the Product Categories taxonomy based on the number of terms parameter.
+- `wp wc generate terms product_cat <nr of terms>`
+
+Generate hierarchical product categories with a maximum number of sub-levels.
+- `wp wc generate terms product_cat <nr of terms> --max-depth=5`
+
+Generate product categories that are all child terms of an existing product category term.
+- `wp wc generate terms product_cat <nr of terms> --parent=123`
+
+Generate terms in the Product Tags taxonomy based on the number of terms parameter.
+- `wp wc generate terms product_tag <nr of terms>`

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -205,6 +205,7 @@ class CLI extends WP_CLI_Command {
 	 */
 	public static function terms( $args, $assoc_args ) {
 		list( $taxonomy, $amount ) = $args;
+		$amount = absint( $amount );
 
 		$time_start = microtime( true );
 

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -308,7 +308,7 @@ WP_CLI::add_command( 'wc generate terms', array( 'WC\SmoothGenerator\CLI', 'term
 			'default'     => 10,
 		),
 		array(
-			'name'        => 'max_depth',
+			'name'        => 'max-depth',
 			'type'        => 'assoc',
 			'description' => 'The maximum number of hierarchy levels for the terms. A value of 1 means all categories will be top-level. Max value 5. Only applies to taxonomies that are hierarchical.',
 			'optional'    => true,

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -203,9 +203,8 @@ class CLI extends WP_CLI_Command {
 	 * @param array $args Arguments specified.
 	 * @param array $assoc_args Associative arguments specified.
 	 */
-	public static function product_categories( $args, $assoc_args ) {
-		list( $amount ) = $args;
-		$taxonomy = 'product_cat';
+	public static function terms( $args, $assoc_args ) {
+		list( $taxonomy, $amount ) = $args;
 
 		$time_start = microtime( true );
 
@@ -291,20 +290,26 @@ WP_CLI::add_command( 'wc generate coupons', array( 'WC\SmoothGenerator\CLI', 'co
 	),
 ) );
 
-WP_CLI::add_command( 'wc generate product-categories', array( 'WC\SmoothGenerator\CLI', 'product_categories' ), array(
+WP_CLI::add_command( 'wc generate terms', array( 'WC\SmoothGenerator\CLI', 'terms' ), array(
 	'shortdesc' => 'Generate product categories.',
 	'synopsis'  => array(
 		array(
+			'name'        => 'taxonomy',
+			'type'        => 'positional',
+			'description' => 'The taxonomy to generate the terms for.',
+			'options'     => array( 'product_cat', 'product_tag' ),
+		),
+		array(
 			'name'        => 'amount',
 			'type'        => 'positional',
-			'description' => 'The number of product categories to generate. Max value 100.',
+			'description' => 'The number of terms to generate. Max value 100.',
 			'optional'    => true,
 			'default'     => 10,
 		),
 		array(
 			'name'        => 'max_depth',
 			'type'        => 'assoc',
-			'description' => 'The maximum number of hierarchy levels for the categories. A value of 1 means all categories will be top-level. Max value 5.',
+			'description' => 'The maximum number of hierarchy levels for the terms. A value of 1 means all categories will be top-level. Max value 5. Only applies to taxonomies that are hierarchical.',
 			'optional'    => true,
 			'options'     => array( 1, 2, 3, 4, 5 ),
 			'default'     => 1,
@@ -312,9 +317,10 @@ WP_CLI::add_command( 'wc generate product-categories', array( 'WC\SmoothGenerato
 		array(
 			'name'        => 'parent',
 			'type'        => 'assoc',
-			'description' => 'Specify an existing product category ID as the parent of the new categories.',
+			'description' => 'Specify an existing term ID as the parent for the new terms. Only applies to taxonomies that are hierarchical.',
 			'optional'    => true,
 			'default'     => 0,
 		),
 	),
+	'longdesc' => "## EXAMPLES\n\nwc generate terms product_tag 10\n\nwc generate terms product_cat 50 --max_depth=3",
 ) );

--- a/includes/Generator/Term.php
+++ b/includes/Generator/Term.php
@@ -153,14 +153,14 @@ class Term extends Generator {
 	 */
 	protected static function batch_hierarchical( int $amount, string $taxonomy, array $args = array() ) {
 		$defaults = array(
-			'max_depth' => 1,
+			'max-depth' => 1,
 			'parent'    => 0,
 		);
 
-		list( 'max_depth' => $max_depth, 'parent' => $parent ) = filter_var_array(
+		list( 'max-depth' => $max_depth, 'parent' => $parent ) = filter_var_array(
 			wp_parse_args( $args, $defaults ),
 			array(
-				'max_depth' => array(
+				'max-depth' => array(
 					'filter'  => FILTER_VALIDATE_INT,
 					'options' => array(
 						'min_range' => 1,

--- a/includes/Generator/Term.php
+++ b/includes/Generator/Term.php
@@ -48,7 +48,7 @@ class Term extends Generator {
 
 		$term_name = self::$faker->department( 3 );
 		$term_args = array(
-			'description' => self::$faker->realTextBetween( 20, 300, 5 ),
+			'description' => self::$faker->realTextBetween( 40, 100, 3 ),
 		);
 		if ( 0 !== $parent ) {
 			$term_args['parent'] = $parent;

--- a/includes/Generator/Term.php
+++ b/includes/Generator/Term.php
@@ -46,9 +46,19 @@ class Term extends Generator {
 
 		self::init_faker();
 
-		$term_name = self::$faker->department( 3 );
+		if ( $taxonomy_obj->hierarchical ) {
+			$term_name = ucwords( self::$faker->department( 3 ) );
+		} else {
+			$term_name = self::random_weighted_element( array(
+				self::$faker->lastName()       => 45,
+				self::$faker->colorName()      => 35,
+				self::$faker->words( 3, true ) => 20,
+			) );
+			$term_name = strtolower( $term_name );
+		}
+
 		$term_args = array(
-			'description' => self::$faker->realTextBetween( 40, 100, 3 ),
+			'description' => self::$faker->realTextBetween( 20, rand( 20, 300 ), 4 ),
 		);
 		if ( 0 !== $parent ) {
 			$term_args['parent'] = $parent;

--- a/includes/Generator/Term.php
+++ b/includes/Generator/Term.php
@@ -58,7 +58,7 @@ class Term extends Generator {
 		}
 
 		$term_args = array(
-			'description' => self::$faker->realTextBetween( 20, rand( 20, 300 ), 4 ),
+			'description' => self::$faker->realTextBetween( 20, wp_rand( 20, 300 ), 4 ),
 		);
 		if ( 0 !== $parent ) {
 			$term_args['parent'] = $parent;
@@ -230,7 +230,7 @@ class Term extends Generator {
 				} else {
 					// Subsequent hierarchy levels.
 					foreach ( $levels[ $i - 1 ] as $term_id ) {
-						$tcount = rand( 0, $term_max );
+						$tcount = wp_rand( 0, $term_max );
 
 						for ( $j = 1; $j <= $tcount && $remaining > 0; $j ++ ) {
 							$term = self::generate( true, $taxonomy, $term_id );

--- a/includes/Generator/Term.php
+++ b/includes/Generator/Term.php
@@ -60,6 +60,191 @@ class Term extends Generator {
 			return $result;
 		}
 
-		return get_term( $result['term_id'] );
+		$term = get_term( $result['term_id'] );
+
+		/**
+		 * Action: Term generator returned a new term.
+		 *
+		 * @since TBD
+		 *
+		 * @param \WP_Term $term
+		 */
+		do_action( 'smoothgenerator_term_generated', $term );
+
+		return $term;
+	}
+
+	/**
+	 * Create multiple terms for a taxonomy.
+	 *
+	 * @param int    $amount   The number of terms to create.
+	 * @param string $taxonomy The taxonomy to assign the terms to.
+	 * @param array  $args     Additional args for term creation.
+	 *
+	 * @return int[]|\WP_Error
+	 */
+	public static function batch( $amount, $taxonomy, array $args = array() ) {
+		$amount = filter_var(
+			$amount,
+			FILTER_VALIDATE_INT,
+			array(
+				'min_range' => 1,
+				'max_range' => 100,
+			)
+		);
+
+		if ( false === $amount ) {
+			return new \WP_Error(
+				'smoothgenerator_term_batch_invalid_amount',
+				'Amount must be a number between 1 and 100.'
+			);
+		}
+
+		$taxonomy_obj = get_taxonomy( $taxonomy );
+		if ( ! $taxonomy_obj ) {
+			return new \WP_Error(
+				'smoothgenerator_term_batch_invalid_taxonomy',
+				'The specified taxonomy is invalid.'
+			);
+		}
+
+		if ( true === $taxonomy_obj->hierarchical ) {
+			return self::batch_hierarchical( $amount, $taxonomy, $args );
+		}
+
+		$term_ids = array();
+
+		for ( $i = 1; $i <= $amount; $i ++ ) {
+			$term = self::generate( true, $taxonomy );
+			if ( is_wp_error( $term ) ) {
+				if ( 'term_exists' === $term->get_error_code() ) {
+					$i --; // Try again.
+					continue;
+				}
+
+				return $term;
+			}
+			$term_ids[] = $term->term_id;
+		}
+
+		return $term_ids;
+	}
+
+	/**
+	 * Create multiple terms for a hierarchical taxonomy.
+	 *
+	 * @param int    $amount   The number of terms to create.
+	 * @param string $taxonomy The taxonomy to assign the terms to.
+	 * @param array  $args     Additional args for term creation.
+	 *   @type int $max_depth The maximum level of hierarchy.
+	 *   @type int $parent    ID of a term to be the parent of the generated terms.
+	 *
+	 * @return int[]|\WP_Error
+	 */
+	protected static function batch_hierarchical( int $amount, string $taxonomy, array $args = array() ) {
+		$defaults = array(
+			'max_depth' => 1,
+			'parent'    => 0,
+		);
+
+		list( 'max_depth' => $max_depth, 'parent' => $parent ) = filter_var_array(
+			wp_parse_args( $args, $defaults ),
+			array(
+				'max_depth' => array(
+					'filter'  => FILTER_VALIDATE_INT,
+					'options' => array(
+						'min_range' => 1,
+						'max_range' => 5,
+					),
+				),
+				'parent'    => FILTER_VALIDATE_INT,
+			)
+		);
+
+		if ( false === $max_depth ) {
+			return new \WP_Error(
+				'smoothgenerator_term_batch_invalid_max_depth',
+				'Max depth must be a number between 1 and 5.'
+			);
+		}
+		if ( false === $parent ) {
+			return new \WP_Error(
+				'smoothgenerator_term_batch_invalid_parent',
+				'Parent must be the ID number of an existing term.'
+			);
+		}
+
+		$term_ids = array();
+
+		self::init_faker();
+
+		if ( $parent || 1 === $max_depth ) {
+			// All terms will be in the same hierarchy level.
+			for ( $i = 1; $i <= $amount; $i ++ ) {
+				$term = self::generate( true, $taxonomy, $parent );
+				if ( is_wp_error( $term ) ) {
+					if ( 'term_exists' === $term->get_error_code() ) {
+						$i --; // Try again.
+						continue;
+					}
+
+					return $term;
+				}
+				$term_ids[] = $term->term_id;
+			}
+		} else {
+			$remaining = $amount;
+			$term_max  = 1;
+			if ( $amount > 2 ) {
+				$term_max = floor( log( $amount ) );
+			}
+			$levels = array_fill( 1, $max_depth, array() );
+
+			for ( $i = 1; $i <= $max_depth; $i ++ ) {
+				if ( 1 === $i ) {
+					// Always use the full term max for the top level of the hierarchy.
+					for ( $j = 1; $j <= $term_max && $remaining > 0; $j ++ ) {
+						$term = self::generate( true, $taxonomy );
+						if ( is_wp_error( $term ) ) {
+							if ( 'term_exists' === $term->get_error_code() ) {
+								$j --; // Try again.
+								continue;
+							}
+
+							return $term;
+						}
+						$term_ids[] = $term->term_id;
+						$levels[ $i ][] = $term->term_id;
+						$remaining --;
+					}
+				} else {
+					// Subsequent hierarchy levels.
+					foreach ( $levels[ $i - 1 ] as $term_id ) {
+						$tcount = rand( 0, $term_max );
+
+						for ( $j = 1; $j <= $tcount && $remaining > 0; $j ++ ) {
+							$term = self::generate( true, $taxonomy, $term_id );
+							if ( is_wp_error( $term ) ) {
+								if ( 'term_exists' === $term->get_error_code() ) {
+									$j --; // Try again.
+									continue;
+								}
+
+								return $term;
+							}
+							$term_ids[] = $term->term_id;
+							$levels[ $i ][] = $term->term_id;
+							$remaining --;
+						}
+					}
+				}
+				if ( $i === $max_depth && $remaining > 0 ) {
+					// If we haven't generated enough yet, start back at the top level of the hierarchy.
+					$i = 0;
+				}
+			}
+		}
+
+		return $term_ids;
 	}
 }

--- a/includes/Generator/Term.php
+++ b/includes/Generator/Term.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Generate taxonomy terms.
+ *
+ * @package SmoothGenerator\Classes
+ */
+
+namespace WC\SmoothGenerator\Generator;
+
+/**
+ * Customer data generator.
+ */
+class Term extends Generator {
+	/**
+	 * Init faker library.
+	 */
+	protected static function init_faker() {
+		parent::init_faker();
+		self::$faker->addProvider( new \Bezhanov\Faker\Provider\Commerce( self::$faker ) );
+	}
+
+	/**
+	 * Create a new taxonomy term.
+	 *
+	 * @param bool   $save     Whether to save the new term to the database.
+	 * @param string $taxonomy The taxonomy slug.
+	 * @param int    $parent   ID of parent term.
+	 *
+	 * @return \WP_Error|\WP_Term
+	 */
+	public static function generate( $save = true, string $taxonomy = 'product_cat', int $parent = 0 ) {
+		$taxonomy_obj = get_taxonomy( $taxonomy );
+		if ( ! $taxonomy_obj ) {
+			return new \WP_Error(
+				'smoothgenerator_invalid_taxonomy',
+				'The specified taxonomy is invalid.'
+			);
+		}
+
+		if ( 0 !== $parent && true !== $taxonomy_obj->hierarchical ) {
+			return new \WP_Error(
+				'smoothgenerator_invalid_term_hierarchy',
+				'The specified taxonomy does not support parent terms.'
+			);
+		}
+
+		self::init_faker();
+
+		$term_name = self::$faker->department( 3 );
+		$term_args = array(
+			'description' => self::$faker->realTextBetween( 20, 300, 5 ),
+		);
+		if ( 0 !== $parent ) {
+			$term_args['parent'] = $parent;
+		}
+
+		$result = wp_insert_term( $term_name, $taxonomy, $term_args );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return get_term( $result['term_id'] );
+	}
+}


### PR DESCRIPTION
Adds a generator class and CLI command for generating terms in the product categories and product tags taxonomies.

Could be used to generate terms within the Product generator, but that's probably best left to a separate PR.

### How to test the changes in this Pull Request:

1. Check out the CLI doc, make sure it looks right: `wp help wc generate terms`
2. Try generating some product tags, and check the work in the WC Admin UI:
  `wp wc generate terms product_tag`
3. Try generating some product categories, and check the work in the WC Admin UI:
  `wp wc generate terms product_cat`
  `wp wc generate terms product_cat 100 --max-depth=5`
4. Using an existing product_cat term, create some more terms that are all children of the existing term:
  `wp wc generate terms product_cat --parent={existing term ID}`

### Changelog entry

> Add a new generator and CLI command for taxonomy terms.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
