### PR TITLE
Add batch generation methods to Product and Order

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -99,7 +99,7 @@ class CLI extends WP_CLI_Command {
 		$generated        = 0;
 
 		while ( $remaining_amount > 0 ) {
-			$batch = $remaining_amount > Generator\Product::MAX_BATCH_SIZE ? Generator\Product::MAX_BATCH_SIZE : $remaining_amount;
+			$batch = $remaining_amount > Generator\Order::MAX_BATCH_SIZE ? Generator\Order::MAX_BATCH_SIZE : $remaining_amount;
 
 			$result = Generator\Order::batch( $batch, $assoc_args );
 

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -32,18 +32,36 @@ class CLI extends WP_CLI_Command {
 
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating products', $amount );
 
-		for ( $i = 1; $i <= $amount; $i++ ) {
-			Generator\Product::generate( true, $assoc_args );
-			$progress->tick();
+		add_action(
+			'smoothgenerator_product_generated',
+			function () use ( $progress ) {
+				$progress->tick();
+			}
+		);
+
+		$remaining_amount = $amount;
+		$generated        = 0;
+
+		while ( $remaining_amount > 0 ) {
+			$batch = $remaining_amount > Generator\Product::MAX_BATCH_SIZE ? Generator\Product::MAX_BATCH_SIZE : $remaining_amount;
+
+			$result = Generator\Product::batch( $batch, $assoc_args );
+
+			if ( is_wp_error( $result ) ) {
+				WP_CLI::error( $result );
+			}
+
+			$generated        += count( $result );
+			$remaining_amount -= $batch;
 		}
+
+		$progress->finish();
 
 		$time_end       = microtime( true );
 		$execution_time = round( ( $time_end - $time_start ), 2 );
 		$display_time   = $execution_time < 60 ? $execution_time . ' seconds' : human_time_diff( $time_start, $time_end );
 
-		$progress->finish();
-
-		WP_CLI::success( $amount . ' products generated in ' . $display_time );
+		WP_CLI::success( $generated . ' products generated in ' . $display_time );
 	}
 
 	/**
@@ -61,26 +79,45 @@ class CLI extends WP_CLI_Command {
 		if ( ! empty( $assoc_args['status'] ) ) {
 			$status = $assoc_args['status'];
 			if ( ! wc_is_order_status( 'wc-' . $status ) ) {
-				WP_CLI::log( "The argument \"$status\" is not a valid order status." );
+				WP_CLI::error( "The argument \"$status\" is not a valid order status." );
 				return;
 			}
 		}
 
-		if ( $amount > 0 ) {
-			Generator\Order::disable_emails();
-			$progress = \WP_CLI\Utils\make_progress_bar( 'Generating orders', $amount );
-			for ( $i = 1; $i <= $amount; $i++ ) {
-				Generator\Order::generate( true, $assoc_args );
+		Generator\Order::disable_emails();
+
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating orders', $amount );
+
+		add_action(
+			'smoothgenerator_order_generated',
+			function () use ( $progress ) {
 				$progress->tick();
 			}
-			$progress->finish();
+		);
+
+		$remaining_amount = $amount;
+		$generated        = 0;
+
+		while ( $remaining_amount > 0 ) {
+			$batch = $remaining_amount > Generator\Product::MAX_BATCH_SIZE ? Generator\Product::MAX_BATCH_SIZE : $remaining_amount;
+
+			$result = Generator\Order::batch( $batch, $assoc_args );
+
+			if ( is_wp_error( $result ) ) {
+				WP_CLI::error( $result );
+			}
+
+			$generated        += count( $result );
+			$remaining_amount -= $batch;
 		}
+
+		$progress->finish();
 
 		$time_end       = microtime( true );
 		$execution_time = round( ( $time_end - $time_start ), 2 );
 		$display_time   = $execution_time < 60 ? $execution_time . ' seconds' : human_time_diff( $time_start, $time_end );
 
-		WP_CLI::success( $amount . ' orders generated in ' . $display_time );
+		WP_CLI::success( $generated . ' orders generated in ' . $display_time );
 	}
 
 	/**

--- a/includes/Generator/Generator.php
+++ b/includes/Generator/Generator.php
@@ -12,6 +12,8 @@ namespace WC\SmoothGenerator\Generator;
  */
 abstract class Generator {
 
+	const MAX_BATCH_SIZE = 100;
+
 	const IMAGE_SIZE = 700;
 
 	/**

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -106,7 +106,56 @@ class Product extends Generator {
 
 		self::$product_ids[] = $product->get_id();
 
+		/**
+		 * Action: Product generator returned a new product.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @param \WC_Product $product
+		 */
+		do_action( 'smoothgenerator_product_generated', $product );
+
 		return $product;
+	}
+
+	/**
+	 * Create multiple products.
+	 *
+	 * @param int    $amount   The number of products to create.
+	 * @param array  $args     Additional args for product creation.
+	 *
+	 * @return int[]|\WP_Error
+	 */
+	public static function batch( $amount, array $args = array() ) {
+		$amount = filter_var(
+			$amount,
+			FILTER_VALIDATE_INT,
+			array(
+				'options' => array(
+					'min_range' => 1,
+					'max_range' => self::MAX_BATCH_SIZE,
+				),
+			)
+		);
+
+		if ( false === $amount ) {
+			return new \WP_Error(
+				'smoothgenerator_product_batch_invalid_amount',
+				sprintf(
+					'Amount must be a number between 1 and %d.',
+					self::MAX_BATCH_SIZE
+				)
+			);
+		}
+
+		$product_ids = array();
+
+		for ( $i = 1; $i <= $amount; $i ++ ) {
+			$product       = self::generate( true, $args );
+			$product_ids[] = $product->get_id();
+		}
+
+		return $product_ids;
 	}
 
 	/**

--- a/includes/Generator/Term.php
+++ b/includes/Generator/Term.php
@@ -75,7 +75,7 @@ class Term extends Generator {
 		/**
 		 * Action: Term generator returned a new term.
 		 *
-		 * @since TBD
+		 * @since 1.1.0
 		 *
 		 * @param \WP_Term $term
 		 */
@@ -98,15 +98,20 @@ class Term extends Generator {
 			$amount,
 			FILTER_VALIDATE_INT,
 			array(
-				'min_range' => 1,
-				'max_range' => 100,
+				'options' => array(
+					'min_range' => 1,
+					'max_range' => self::MAX_BATCH_SIZE,
+				),
 			)
 		);
 
 		if ( false === $amount ) {
 			return new \WP_Error(
 				'smoothgenerator_term_batch_invalid_amount',
-				'Amount must be a number between 1 and 100.'
+				sprintf(
+					'Amount must be a number between 1 and %d.',
+					self::MAX_BATCH_SIZE
+				)
 			);
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This takes the `batch()` method pattern introduced in #117 and applies it to the Product and Order generators. It's a first step towards addressing #121 and allowing generator scheduled actions to run batches instead of having a separate action for each item to generate.

This also makes improvements to the `batch()` pattern, so those improvements are backported to the Term generator in this PR as well.

### How to test the changes in this Pull Request:

There should not be any noticeable differences in functionality with this PR. Try running the CLI commands to generate products, orders, and terms, each with amounts over 100, and make sure there aren't any errors or unexpected results.
