### PR TITLE
Improvements to Coupon generator

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -43,7 +43,7 @@ class CLI extends WP_CLI_Command {
 		$generated        = 0;
 
 		while ( $remaining_amount > 0 ) {
-			$batch = $remaining_amount > Generator\Product::MAX_BATCH_SIZE ? Generator\Product::MAX_BATCH_SIZE : $remaining_amount;
+			$batch = min( $remaining_amount, Generator\Product::MAX_BATCH_SIZE );
 
 			$result = Generator\Product::batch( $batch, $assoc_args );
 
@@ -99,7 +99,7 @@ class CLI extends WP_CLI_Command {
 		$generated        = 0;
 
 		while ( $remaining_amount > 0 ) {
-			$batch = $remaining_amount > Generator\Order::MAX_BATCH_SIZE ? Generator\Order::MAX_BATCH_SIZE : $remaining_amount;
+			$batch = min( $remaining_amount, Generator\Order::MAX_BATCH_SIZE );
 
 			$result = Generator\Order::batch( $batch, $assoc_args );
 
@@ -172,7 +172,7 @@ class CLI extends WP_CLI_Command {
 		$generated        = 0;
 
 		while ( $remaining_amount > 0 ) {
-			$batch = $remaining_amount > Generator\Coupon::MAX_BATCH_SIZE ? Generator\Coupon::MAX_BATCH_SIZE : $remaining_amount;
+			$batch = min( $remaining_amount, Generator\Coupon::MAX_BATCH_SIZE );
 
 			$result = Generator\Coupon::batch( $batch, $assoc_args );
 
@@ -218,7 +218,7 @@ class CLI extends WP_CLI_Command {
 		$generated        = 0;
 
 		while ( $remaining_amount > 0 ) {
-			$batch = $remaining_amount > Generator\Term::MAX_BATCH_SIZE ? Generator\Term::MAX_BATCH_SIZE : $remaining_amount;
+			$batch = min( $remaining_amount, Generator\Term::MAX_BATCH_SIZE );
 
 			$result = Generator\Term::batch( $amount, $taxonomy, $assoc_args );
 

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -41,15 +41,39 @@ class Coupon extends Generator {
 		list( 'min' => $min, 'max' => $max ) = filter_var_array(
 			wp_parse_args( $assoc_args, $defaults ),
 			array(
-				'min' => FILTER_VALIDATE_INT,
-				'max' => FILTER_VALIDATE_INT,
+				'min' => array(
+					'filter'  => FILTER_VALIDATE_INT,
+					'options' => array(
+						'min_range' => 1,
+					),
+				),
+				'max' => array(
+					'filter'  => FILTER_VALIDATE_INT,
+					'options' => array(
+						'min_range' => 1,
+					),
+				),
 			)
 		);
 
-		if ( $min >= $max ) {
+		if ( false === $min ) {
 			return new \WP_Error(
 				'smoothgenerator_coupon_invalid_min_max',
-				'The maximum coupon amount must be an integer that is greater than the minimum amount.'
+				'The minimum coupon amount must be a valid positive integer.'
+			);
+		}
+
+		if ( false === $max ) {
+			return new \WP_Error(
+				'smoothgenerator_coupon_invalid_min_max',
+				'The maximum coupon amount must be a valid positive integer.'
+			);
+		}
+
+		if ( $min > $max ) {
+			return new \WP_Error(
+				'smoothgenerator_coupon_invalid_min_max',
+				'The maximum coupon amount must be an integer that is greater than or equal to the minimum amount.'
 			);
 		}
 

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -7,34 +7,108 @@
 
 namespace WC\SmoothGenerator\Generator;
 
+use WC_Data_Store;
+
 /**
  * Customer data generator.
  */
 class Coupon extends Generator {
 
+	/**
+	 * Init faker library.
+	 */
+	protected static function init_faker() {
+		parent::init_faker();
+		self::$faker->addProvider( new \Bezhanov\Faker\Provider\Commerce( self::$faker ) );
+	}
 
 	/**
-	 * Return a new customer.
+	 * Create a new coupon.
 	 *
-	 * @param bool $save Save the object before returning or not.
-	 * @param int  $min minimum coupon amount.
-	 * @param int  $max maximum coupon amount.
-	 * @return \WC_Customer Customer object with data populated.
+	 * @param bool  $save       Whether to save the new coupon to the database.
+	 * @param array $assoc_args Arguments passed via the CLI for additional customization.
+	 *
+	 * @return \WC_Coupon|\WP_Error Coupon object with data populated.
 	 */
-	public static function generate( $save = true, $min = 5, $max = 100 ) {
-		$amount    = random_int( $min, $max );
-		$coupon_id = "discount$amount";
-		$coupon    = new \WC_Coupon( $coupon_id );
-		if ( $coupon->get_id() === 0 ) {
-			$coupon->set_props( array(
-				'code'   => "discount$amount",
-				'amount' => $amount,
-			) );
-			$coupon->save();
-			return new \WC_Coupon( $coupon->get_id() );
+	public static function generate( $save = true, $assoc_args = array() ) {
+		self::init_faker();
+
+		$defaults = array(
+			'min' => 5,
+			'max' => 100,
+		);
+
+		list( 'min' => $min, 'max' => $max ) = filter_var_array(
+			wp_parse_args( $assoc_args, $defaults ),
+			array(
+				'min' => FILTER_VALIDATE_INT,
+				'max' => FILTER_VALIDATE_INT,
+			)
+		);
+
+		if ( $min >= $max ) {
+			return new \WP_Error(
+				'smoothgenerator_coupon_invalid_min_max',
+				'The maximum coupon amount must be an integer that is greater than the minimum amount.'
+			);
 		}
+
+		$code        = substr( self::$faker->promotionCode( 1 ), 0, -1 ); // Omit the random digit.
+		$amount      = self::$faker->numberBetween( $min, $max );
+		$coupon_code = sprintf(
+			'%s%d',
+			$code,
+			$amount
+		);
+
+		$coupon = new \WC_Coupon( $coupon_code );
+		$coupon->set_props( array(
+			'code'   => $coupon_code,
+			'amount' => $amount,
+		) );
+
+		if ( $save ) {
+			$data_store = WC_Data_Store::load( 'coupon' );
+			$data_store->create( $coupon );
+		}
+
+		/**
+		 * Action: Coupon generator returned a new coupon.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @param \WC_Coupon $coupon
+		 */
+		do_action( 'smoothgenerator_coupon_generated', $coupon );
+
 		return $coupon;
 	}
 
+	/**
+	 * Create multiple coupons.
+	 *
+	 * @param int   $amount The number of coupons to create.
+	 * @param array $args   Additional args for coupon creation.
+	 *
+	 * @return array|\WP_Error
+	 */
+	public static function batch( $amount, array $args = array() ) {
+		$amount = self::validate_batch_amount( $amount );
+		if ( is_wp_error( $amount ) ) {
+			return $amount;
+		}
+
+		$coupon_ids = array();
+
+		for ( $i = 1; $i <= $amount; $i ++ ) {
+			$coupon = self::generate( true, $args );
+			if ( is_wp_error( $coupon ) ) {
+				return $coupon;
+			}
+			$coupon_ids[] = $coupon->get_id();
+		}
+
+		return $coupon_ids;
+	}
 }
 

--- a/includes/Generator/Generator.php
+++ b/includes/Generator/Generator.php
@@ -55,6 +55,38 @@ abstract class Generator {
 	}
 
 	/**
+	 * Validate the value of the amount input for a batch command.
+	 *
+	 * @param int $amount The number of items to create in a batch.
+	 *
+	 * @return mixed|\WP_Error
+	 */
+	protected static function validate_batch_amount( $amount ) {
+		$amount = filter_var(
+			$amount,
+			FILTER_VALIDATE_INT,
+			array(
+				'options' => array(
+					'min_range' => 1,
+					'max_range' => static::MAX_BATCH_SIZE,
+				),
+			)
+		);
+
+		if ( false === $amount ) {
+			return new \WP_Error(
+				'smoothgenerator_batch_invalid_amount',
+				sprintf(
+					'Amount must be a number between 1 and %d.',
+					static::MAX_BATCH_SIZE
+				)
+			);
+		}
+
+		return $amount;
+	}
+
+	/**
 	 * Get random term ids.
 	 *
 	 * @param int    $limit Number of term IDs to get.

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -128,25 +128,9 @@ class Order extends Generator {
 	 * @return int[]|\WP_Error
 	 */
 	public static function batch( $amount, array $args = array() ) {
-		$amount = filter_var(
-			$amount,
-			FILTER_VALIDATE_INT,
-			array(
-				'options' => array(
-					'min_range' => 1,
-					'max_range' => self::MAX_BATCH_SIZE,
-				),
-			)
-		);
-
-		if ( false === $amount ) {
-			return new \WP_Error(
-				'smoothgenerator_order_batch_invalid_amount',
-				sprintf(
-					'Amount must be a number between 1 and %d.',
-					self::MAX_BATCH_SIZE
-				)
-			);
+		$amount = self::validate_batch_amount( $amount );
+		if ( is_wp_error( $amount ) ) {
+			return $amount;
 		}
 
 		$order_ids = array();

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -127,25 +127,9 @@ class Product extends Generator {
 	 * @return int[]|\WP_Error
 	 */
 	public static function batch( $amount, array $args = array() ) {
-		$amount = filter_var(
-			$amount,
-			FILTER_VALIDATE_INT,
-			array(
-				'options' => array(
-					'min_range' => 1,
-					'max_range' => self::MAX_BATCH_SIZE,
-				),
-			)
-		);
-
-		if ( false === $amount ) {
-			return new \WP_Error(
-				'smoothgenerator_product_batch_invalid_amount',
-				sprintf(
-					'Amount must be a number between 1 and %d.',
-					self::MAX_BATCH_SIZE
-				)
-			);
+		$amount = self::validate_batch_amount( $amount );
+		if ( is_wp_error( $amount ) ) {
+			return $amount;
 		}
 
 		$product_ids = array();

--- a/includes/Generator/Term.php
+++ b/includes/Generator/Term.php
@@ -94,25 +94,9 @@ class Term extends Generator {
 	 * @return int[]|\WP_Error
 	 */
 	public static function batch( $amount, $taxonomy, array $args = array() ) {
-		$amount = filter_var(
-			$amount,
-			FILTER_VALIDATE_INT,
-			array(
-				'options' => array(
-					'min_range' => 1,
-					'max_range' => self::MAX_BATCH_SIZE,
-				),
-			)
-		);
-
-		if ( false === $amount ) {
-			return new \WP_Error(
-				'smoothgenerator_term_batch_invalid_amount',
-				sprintf(
-					'Amount must be a number between 1 and %d.',
-					self::MAX_BATCH_SIZE
-				)
-			);
+		$amount = self::validate_batch_amount( $amount );
+		if ( is_wp_error( $amount ) ) {
+			return $amount;
 		}
 
 		$taxonomy_obj = get_taxonomy( $taxonomy );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates the Coupons generator:

* Makes coupon codes more unique to address #118 
* Adds a batch method, using the same pattern as the methods added in Products, Orders, and Terms, and updates the CLI command to use that method.
* Backports some batch improvements to other generators.

Fixes #118 
Towards #121 

### How to test the changes in this Pull Request:

1. Run the basic command and ensure it generates 10 coupon codes: `wp wc generate coupons`
2. Run the command with a large number and when it completes, make sure the number it says were generated matches what you entered, e.g. `wp wc generate coupons 100`
3. Try generating more than 100 (the limit for a single batch). It should seamlessly generate the full number over multiple batches.
4. Test the min and max parameters. E.g. `wp wc generate coupons --min=14 --max=18`. Try using invalid values for the parameters.

### Changelog entry

> Improved the uniqueness of coupon codes.
