### PR TITLE
Add batch method to Customers generator

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -132,19 +132,40 @@ class CLI extends WP_CLI_Command {
 
 		$time_start = microtime( true );
 
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating coupons', $amount );
+
 		Generator\Customer::disable_emails();
-		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating customers', $amount );
-		for ( $i = 1; $i <= $amount; $i++ ) {
-			Generator\Customer::generate();
-			$progress->tick();
+
+		add_action(
+			'smoothgenerator_customer_generated',
+			function () use ( $progress ) {
+				$progress->tick();
+			}
+		);
+
+		$remaining_amount = $amount;
+		$generated        = 0;
+
+		while ( $remaining_amount > 0 ) {
+			$batch = $remaining_amount > Generator\Customer::MAX_BATCH_SIZE ? Generator\Customer::MAX_BATCH_SIZE : $remaining_amount;
+
+			$result = Generator\Customer::batch( $batch );
+
+			if ( is_wp_error( $result ) ) {
+				WP_CLI::error( $result );
+			}
+
+			$generated        += count( $result );
+			$remaining_amount -= $batch;
 		}
+
 		$progress->finish();
 
 		$time_end       = microtime( true );
 		$execution_time = round( ( $time_end - $time_start ), 2 );
 		$display_time   = $execution_time < 60 ? $execution_time . ' seconds' : human_time_diff( $time_start, $time_end );
 
-		WP_CLI::success( $amount . ' customers generated in ' . $display_time );
+		WP_CLI::success( $generated . ' customers generated in ' . $display_time );
 	}
 
 	/**

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -147,7 +147,7 @@ class CLI extends WP_CLI_Command {
 		$generated        = 0;
 
 		while ( $remaining_amount > 0 ) {
-			$batch = $remaining_amount > Generator\Customer::MAX_BATCH_SIZE ? Generator\Customer::MAX_BATCH_SIZE : $remaining_amount;
+			$batch = min( $remaining_amount, Generator\Customer::MAX_BATCH_SIZE );
 
 			$result = Generator\Customer::batch( $batch );
 

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -114,7 +114,7 @@ class Coupon extends Generator {
 	 * @param int   $amount The number of coupons to create.
 	 * @param array $args   Additional args for coupon creation.
 	 *
-	 * @return array|\WP_Error
+	 * @return int[]|\WP_Error
 	 */
 	public static function batch( $amount, array $args = array() ) {
 		$amount = self::validate_batch_amount( $amount );

--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -12,7 +12,6 @@ namespace WC\SmoothGenerator\Generator;
  */
 class Customer extends Generator {
 
-
 	/**
 	 * Return a new customer.
 	 *
@@ -141,9 +140,40 @@ class Customer extends Generator {
 			$customer->save();
 		}
 
+		/**
+		 * Action: Customer generator returned a new customer.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @param \WC_Customer $customer
+		 */
+		do_action( 'smoothgenerator_customer_generated', $customer );
+
 		return $customer;
 	}
 
+	/**
+	 * Create multiple customers.
+	 *
+	 * @param int $amount The number of customers to create.
+	 *
+	 * @return int[]|\WP_Error
+	 */
+	public static function batch( $amount ) {
+		$amount = self::validate_batch_amount( $amount );
+		if ( is_wp_error( $amount ) ) {
+			return $amount;
+		}
+
+		$customer_ids = array();
+
+		for ( $i = 1; $i <= $amount; $i ++ ) {
+			$customer       = self::generate( true );
+			$customer_ids[] = $customer->get_id();
+		}
+
+		return $customer_ids;
+	}
 
 	/**
 	 * Disable sending WooCommerce emails when generating objects.

--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -167,7 +167,7 @@ class Customer extends Generator {
 
 		$customer_ids = array();
 
-		for ( $i = 1; $i <= $amount; $i ++ ) {
+		for ( $i = 1; $i <= $amount; $i++ ) {
 			$customer       = self::generate( true );
 			$customer_ids[] = $customer->get_id();
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a batch method to the Customers generator using the same pattern as the other generators. Updates the CLI command to use the batch method.

Depends on #134. This should be rebased to trunk once that PR is merged.

Towards #121

### How to test the changes in this Pull Request:

1. Run the basic command and make sure it successfully generates customers: `wp wc generate customers`
2. Try generating more than 100 customers (the limit for a single batch). It should seamlessly generate the requested amount over multiple batches. E.g. `wp wc generate customers 150`

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
