### PR TITLE
Improvements to Customer generator

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -149,7 +149,7 @@ class CLI extends WP_CLI_Command {
 		while ( $remaining_amount > 0 ) {
 			$batch = min( $remaining_amount, Generator\Customer::MAX_BATCH_SIZE );
 
-			$result = Generator\Customer::batch( $batch );
+			$result = Generator\Customer::batch( $batch, $assoc_args );
 
 			if ( is_wp_error( $result ) ) {
 				WP_CLI::error( $result );
@@ -337,8 +337,22 @@ WP_CLI::add_command( 'wc generate customers', array( 'WC\SmoothGenerator\CLI', '
 			'optional'    => true,
 			'default'     => 10,
 		),
+		array(
+			'name'        => 'country',
+			'type'        => 'assoc',
+			'description' => 'The ISO 3166-1 alpha-2 country code to use for localizing the customer data. If none is specified, any country in the "Selling location(s)" setting may be used.',
+			'optional'    => true,
+			'default'     => '',
+		),
+		array(
+			'name'        => 'type',
+			'type'        => 'assoc',
+			'description' => 'The type of customer to generate data for. If none is specified, it will be a 70% person, 30% company mix.',
+			'optional'    => true,
+			'options'     => array( 'company', 'person' ),
+		),
 	),
-	'longdesc'  => "## EXAMPLES\n\nwc generate customers 10",
+	'longdesc'  => "## EXAMPLES\n\nwc generate customers 10\n\nwc generate customers --country=ES --type=company",
 ) );
 
 WP_CLI::add_command( 'wc generate coupons', array( 'WC\SmoothGenerator\CLI', 'coupons' ), array(

--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -28,7 +28,8 @@ class Customer extends Generator {
 				'country' => array(
 					'filter'  => FILTER_VALIDATE_REGEXP,
 					'options' => array(
-						'regexp' => '/^[A-Z]{2}$/',
+						'regexp'  => '/^[A-Za-z]{2}$/',
+						'default' => '',
 					),
 				),
 				'type'    => array(
@@ -42,12 +43,8 @@ class Customer extends Generator {
 
 		list( 'country' => $country, 'type' => $type ) = $args;
 
-		if ( ! $country ) {
-			$country = self::$faker->randomElement( array_keys( WC()->countries->get_allowed_countries() ) );
-		}
-
 		if ( ! $type ) {
-			$type = self::$faker->randomDigit() < 7 ? 'person' : 'company';
+			$type = self::$faker->randomDigit() < 7 ? 'person' : 'company'; // 70% person, 30% company.
 		}
 
 		$keys_for_address = array( 'email' );
@@ -128,11 +125,12 @@ class Customer extends Generator {
 	/**
 	 * Create multiple customers.
 	 *
-	 * @param int $amount The number of customers to create.
+	 * @param int   $amount The number of customers to create.
+	 * @param array $args   Additional args for customer creation.
 	 *
 	 * @return int[]|\WP_Error
 	 */
-	public static function batch( $amount ) {
+	public static function batch( $amount, array $args = array() ) {
 		$amount = self::validate_batch_amount( $amount );
 		if ( is_wp_error( $amount ) ) {
 			return $amount;
@@ -141,7 +139,7 @@ class Customer extends Generator {
 		$customer_ids = array();
 
 		for ( $i = 1; $i <= $amount; $i++ ) {
-			$customer       = self::generate( true );
+			$customer       = self::generate( true, $args );
 			$customer_ids[] = $customer->get_id();
 		}
 

--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -11,130 +11,103 @@ namespace WC\SmoothGenerator\Generator;
  * Customer data generator.
  */
 class Customer extends Generator {
-
 	/**
 	 * Return a new customer.
 	 *
-	 * @param  bool $save Save the object before returning or not.
+	 * @param bool  $save       Save the object before returning or not.
+	 * @param array $assoc_args Arguments passed via the CLI for additional customization.
+	 *
 	 * @return \WC_Customer Customer object with data populated.
 	 */
-	public static function generate( $save = true ) {
+	public static function generate( $save = true, array $assoc_args = array() ) {
 		self::init_faker();
 
-		// Make sure a unique username and e-mail are used.
-		do {
-			$username = self::$faker->userName();
-		} while ( username_exists( $username ) );
+		$args = filter_var_array(
+			$assoc_args,
+			array(
+				'country' => array(
+					'filter'  => FILTER_VALIDATE_REGEXP,
+					'options' => array(
+						'regexp' => '/^[A-Z]{2}$/',
+					),
+				),
+				'type'    => array(
+					'filter'  => FILTER_VALIDATE_REGEXP,
+					'options' => array(
+						'regexp' => '/^(company|person)$/',
+					),
+				),
+			)
+		);
 
-		do {
-			$email = self::$faker->safeEmail();
-		} while ( email_exists( $email ) );
+		list( 'country' => $country, 'type' => $type ) = $args;
 
-		/*PERSON*/
-		$person['billing']['firstname'] = self::$faker->firstName( self::$faker->randomElement( array( 'male', 'female' ) ) );
-		$person['billing']['lastname']  = self::$faker->lastName();
-
-		// 50% chance
-		if ( (bool) wp_rand( 0, 1 ) ) {
-			$person['shipping']['firstname'] = self::$faker->firstName( self::$faker->randomElement( array( 'male', 'female' ) ) );
-			$person['shipping']['lastname']  = self::$faker->lastName();
-		} else {
-			$person['shipping']['firstname'] = $person['billing']['firstname'];
-			$person['shipping']['lastname']  = $person['billing']['lastname'];
+		if ( ! $country ) {
+			$country = self::$faker->randomElement( array_keys( WC()->countries->get_allowed_countries() ) );
 		}
 
-		/*COMPANY*/
-		$company_variations = array( 'B2B', 'C2C', 'C2B', 'B2C' );
-		$relationType = self::$faker->randomElements( $company_variations, $count = 1 );
+		if ( ! $type ) {
+			$type = self::$faker->randomDigit() < 7 ? 'person' : 'company';
+		}
 
-		switch ( $relationType[0] ) {
-			case 'B2B':
-				$company['billing']['company_name'] = self::$faker->company();
-				if ( self::$faker->randomFloat( 0, 0, 1 ) == 1 ) {
-					$company['shipping']['company_name'] = self::$faker->company();
-				} else {
-					$company['shipping']['company_name'] = $company['billing']['company_name'];
-				}
+		$keys_for_address = array( 'email' );
 
-				break;
-			case 'C2C':
-				$company['billing']['company_name']  = '';
-				$company['shipping']['company_name'] = '';
-				break;
-			case 'B2C':
-				$company['billing']['company_name']  = self::$faker->company();
-				$company['shipping']['company_name'] = '';
-				break;
-			case 'C2B':
-				$company['billing']['company_name']  = '';
-				$company['shipping']['company_name'] = self::$faker->company();
-				break;
+		$customer_data = array(
+			'role' => 'customer',
+		);
+		switch ( $type ) {
+			case 'person':
 			default:
+				$customer_data       = array_merge( $customer_data, CustomerInfo::generate_person( $country ) );
+				$other_customer_data = CustomerInfo::generate_person( $country );
+				$keys_for_address[]  = 'first_name';
+				$keys_for_address[]  = 'last_name';
+				break;
+
+			case 'company':
+				$customer_data       = array_merge( $customer_data, CustomerInfo::generate_company( $country ) );
+				$other_customer_data = CustomerInfo::generate_company( $country );
+				$keys_for_address[]  = 'company';
 				break;
 		}
-		/*ADDRESS*/
-		$address['billing']['address0'] = self::$faker->buildingNumber() . ' ' . self::$faker->streetName();
-		$address['billing']['address1'] = self::$faker->streetAddress();
-		$address['billing']['city']     = self::$faker->city();
-		$address['billing']['state']    = self::$faker->stateAbbr();
-		$address['billing']['postcode'] = self::$faker->postcode();
-		$address['billing']['country']  = self::$faker->countryCode();
-		$address['billing']['phone']    = self::$faker->e164PhoneNumber();
-		$address['billing']['email']    = $email;
 
-		// 50% chance
-		if ( (bool) wp_rand( 0, 1 ) ) {
-			$address['shipping']['address0'] = self::$faker->buildingNumber() . ' ' . self::$faker->streetName();
-			$address['shipping']['address1'] = self::$faker->streetAddress();
-			$address['shipping']['city']     = self::$faker->city();
-			$address['shipping']['state']    = self::$faker->stateAbbr();
-			$address['shipping']['postcode'] = self::$faker->postcode();
-			$address['shipping']['country']  = self::$faker->countryCode();
-		} else {
-			$address['shipping']['address0'] = $address['billing']['address0'];
-			$address['shipping']['address1'] = $address['billing']['address1'];
-			$address['shipping']['city']     = $address['billing']['city'];
-			$address['shipping']['state']    = $address['billing']['state'];
-			$address['shipping']['postcode'] = $address['billing']['postcode'];
-			$address['shipping']['country']  = $address['billing']['country'];
+		$customer_data['billing'] = array_merge(
+			CustomerInfo::generate_address( $country ),
+			array_intersect_key( $customer_data, array_fill_keys( $keys_for_address, '' ) )
+		);
+
+		$has_shipping = self::$faker->randomDigit() < 5;
+		if ( $has_shipping ) {
+			$same_shipping = self::$faker->randomDigit() < 5;
+			if ( $same_shipping ) {
+				$customer_data['shipping'] = $customer_data['billing'];
+			} else {
+				$customer_data['shipping'] = array_merge(
+					CustomerInfo::generate_address( $country ),
+					array_intersect_key( $other_customer_data, array_fill_keys( $keys_for_address, '' ) )
+				);
+			}
+		}
+
+		unset( $customer_data['company'], $customer_data['shipping']['email'] );
+
+		foreach ( array( 'billing', 'shipping' ) as $address_type ) {
+			if ( isset( $customer_data[ $address_type ] ) ) {
+				$address_data = array_combine(
+					array_map(
+						fn( $line ) => $address_type . '_' . $line,
+						array_keys( $customer_data[ $address_type ] )
+					),
+					array_values( $customer_data[ $address_type ] )
+				);
+
+				$customer_data = array_merge( $customer_data, $address_data );
+				unset( $customer_data[ $address_type ] );
+			}
 		}
 
 		$customer = new \WC_Customer();
-
-		$customer->set_props(
-			array(
-				'date_created'        => null,
-				'date_modified'       => null,
-				'email'               => $email,
-				'first_name'          => $person['billing']['firstname'],
-				'last_name'           => $person['billing']['lastname'],
-				'display_name'        => $person['billing']['firstname'],
-				'role'                => 'customer',
-				'username'            => $username,
-				'password'            => self::$faker->password(),
-				'billing_first_name'  => $person['billing']['firstname'],
-				'billing_last_name'   => $person['billing']['lastname'],
-				'billing_company'     => $company['billing']['company_name'],
-				'billing_address_0'   => $address['billing']['address0'],
-				'billing_address_1'   => $address['billing']['address1'],
-				'billing_city'        => $address['billing']['city'],
-				'billing_state'       => $address['billing']['state'],
-				'billing_postcode'    => $address['billing']['postcode'],
-				'billing_country'     => $address['billing']['country'],
-				'billing_email'       => $address['billing']['email'],
-				'billing_phone'       => $address['billing']['phone'],
-				'shipping_first_name' => $person['shipping']['firstname'],
-				'shipping_last_name'  => $person['shipping']['lastname'],
-				'shipping_company'    => $company['shipping']['company_name'],
-				'shipping_address_0'  => $address['shipping']['address0'],
-				'shipping_address_1'  => $address['shipping']['address1'],
-				'shipping_city'       => $address['shipping']['city'],
-				'shipping_state'      => $address['shipping']['state'],
-				'shipping_postcode'   => $address['shipping']['postcode'],
-				'shipping_country'    => $address['shipping']['country'],
-				'is_paying_customer'  => false,
-			)
-		);
+		$customer->set_props( $customer_data );
 
 		if ( $save ) {
 			$customer->save();

--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -17,7 +17,7 @@ class Customer extends Generator {
 	 * @param bool  $save       Save the object before returning or not.
 	 * @param array $assoc_args Arguments passed via the CLI for additional customization.
 	 *
-	 * @return \WC_Customer Customer object with data populated.
+	 * @return \WC_Customer|\WP_Error Customer object with data populated.
 	 */
 	public static function generate( $save = true, array $assoc_args = array() ) {
 		self::init_faker();
@@ -42,6 +42,11 @@ class Customer extends Generator {
 		);
 
 		list( 'country' => $country, 'type' => $type ) = $args;
+
+		$country = CustomerInfo::get_valid_country_code( $country );
+		if ( is_wp_error( $country ) ) {
+			return $country;
+		}
 
 		if ( ! $type ) {
 			$type = self::$faker->randomDigit() < 7 ? 'person' : 'company'; // 70% person, 30% company.
@@ -140,6 +145,9 @@ class Customer extends Generator {
 
 		for ( $i = 1; $i <= $amount; $i++ ) {
 			$customer       = self::generate( true, $args );
+			if ( is_wp_error( $customer ) ) {
+				return $customer;
+			}
 			$customer_ids[] = $customer->get_id();
 		}
 

--- a/includes/Generator/CustomerInfo.php
+++ b/includes/Generator/CustomerInfo.php
@@ -15,7 +15,7 @@ class CustomerInfo {
 	 *
 	 * @return string|\WP_Error
 	 */
-	protected static function get_valid_country_code( string $country_code = '' ) {
+	public static function get_valid_country_code( string $country_code = '' ) {
 		$country_code = strtoupper( $country_code );
 
 		if ( $country_code && ! WC()->countries->country_exists( $country_code ) ) {

--- a/includes/Generator/CustomerInfo.php
+++ b/includes/Generator/CustomerInfo.php
@@ -16,6 +16,8 @@ class CustomerInfo {
 	 * @return string|\WP_Error
 	 */
 	protected static function get_valid_country_code( string $country_code = '' ) {
+		$country_code = strtoupper( $country_code );
+
 		if ( $country_code && ! WC()->countries->country_exists( $country_code ) ) {
 			$country_code = new \WP_Error(
 				'smoothgenerator_customer_invalid_country',
@@ -58,11 +60,8 @@ class CustomerInfo {
 	 * @return \Faker\Generator
 	 */
 	protected static function get_faker( $country_code = 'en_US' ) {
-		$locale_info = self::get_country_locale_info( $country_code );
-		list( 'default_locale' => $default_locale ) = $locale_info;
-		if ( ! $default_locale ) {
-			$default_locale = 'en_US';
-		}
+		$locale_info    = self::get_country_locale_info( $country_code );
+		$default_locale = $locale_info['default_locale'] ?? 'en_US';
 
 		$faker = \Faker\Factory::create( $default_locale );
 
@@ -249,8 +248,8 @@ class CustomerInfo {
 			}
 
 			if ( isset( $exceptions[ $country_code ][ $line ]['required'] ) && false === $exceptions[ $country_code ][ $line ]['required'] ) {
-				// 30% chance to skip if it's not required.
-				if ( $faker->randomDigit() <= 2 ) {
+				// 50% chance to skip if it's not required.
+				if ( $faker->randomDigit() < 5 ) {
 					continue;
 				}
 			}

--- a/includes/Generator/CustomerInfo.php
+++ b/includes/Generator/CustomerInfo.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace WC\SmoothGenerator\Generator;
+
+/**
+ * Class CustomerInfo.
+ *
+ * Helper class for generating locale-specific coherent customer test data.
+ */
+class CustomerInfo {
+	/**
+	 * Get a country code for a country that the store is set to sell to, or validate a given country code.
+	 *
+	 * @param string $country_code ISO 3166-1 alpha-2 country code. E.g. US, ES, CN, RU etc.
+	 *
+	 * @return string|\WP_Error
+	 */
+	protected static function get_valid_country_code( string $country_code = '' ) {
+		if ( $country_code && ! WC()->countries->country_exists( $country_code ) ) {
+			$country_code = new \WP_Error(
+				'smoothgenerator_customer_invalid_country',
+				sprintf(
+					'No data for a country with country code "%s"',
+					esc_html( $country_code )
+				)
+			);
+		} elseif ( ! $country_code ) {
+			$valid_countries = WC()->countries->get_allowed_countries();
+			$country_code    = array_rand( $valid_countries );
+		}
+
+		return $country_code;
+	}
+
+	/**
+	 * Retrieve locale data for a given country.
+	 *
+	 * @param string string $country_code ISO 3166-1 alpha-2 country code. E.g. US, ES, CN, RU etc.
+	 *
+	 * @return array
+	 */
+	protected static function get_country_locale_info( string $country_code = 'en_US' ) {
+		$all_locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
+
+		if ( ! isset( $all_locale_info[ $country_code ] ) ) {
+			return array();
+		}
+
+		return $all_locale_info[ $country_code ];
+	}
+
+
+	/**
+	 * Get a localized Faker library instance.
+	 *
+	 * @param string $country_code ISO 3166-1 alpha-2 country code. E.g. US, ES, CN, RU etc.
+	 *
+	 * @return \Faker\Generator
+	 */
+	protected static function get_faker( $country_code = 'en_US' ) {
+		$locale_info = self::get_country_locale_info( $country_code );
+		list( 'default_locale' => $default_locale ) = $locale_info;
+		if ( ! $default_locale ) {
+			$default_locale = 'en_US';
+		}
+
+		$faker = \Faker\Factory::create( $default_locale );
+
+		return $faker;
+	}
+
+	/**
+	 * Retrieve the localized instance of a particular provider from within the Faker.
+	 *
+	 * @param \Faker\Generator $faker         The current instance of the Faker.
+	 * @param string           $provider_name The name of the provider to retrieve. E.g. 'Person'.
+	 *
+	 * @return \Faker\Provider\Base|null
+	 */
+	protected static function get_provider_instance( \Faker\Generator $faker, string $provider_name ) {
+		$instance = null;
+		foreach ( $faker->getProviders() as $provider ) {
+			if ( str_ends_with( get_class( $provider ), $provider_name ) ) {
+				$instance = $provider;
+				break;
+			}
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Generate data for a person, localized for a particular country.
+	 *
+	 * Includes first name, last name, username, email address, and password.
+	 *
+	 * @param string $country_code ISO 3166-1 alpha-2 country code. E.g. US, ES, CN, RU etc.
+	 *
+	 * @return string[]|\WP_Error
+	 * @throws \ReflectionException
+	 */
+	public static function generate_person( string $country_code = '' ) {
+		$country_code = self::get_valid_country_code( $country_code );
+		if ( is_wp_error( $country_code ) ) {
+			return $country_code;
+		}
+
+		$faker = self::get_faker( $country_code );
+
+		$first_name = $faker->firstName( $faker->randomElement( array( 'male', 'female' ) ) );
+		$last_name  = $faker->lastName();
+
+		$person = array(
+			'first_name' => $first_name,
+			'last_name'  => $last_name,
+			'password'   => 'password',
+		);
+
+		// Make sure email and username use the same first and last name that were previously generated.
+		$person_provider    = self::get_provider_instance( $faker, 'Person' );
+		$reflected_provider = new \ReflectionClass( $person_provider );
+		$orig_fn_male       = $reflected_provider->getStaticPropertyValue( 'firstNameMale', array() );
+		$orig_fn_female     = $reflected_provider->getStaticPropertyValue( 'firstNameFemale', array() );
+		$orig_ln            = $reflected_provider->getStaticPropertyValue( 'lastName', array() );
+
+		$reflected_provider->setStaticPropertyValue( 'firstNameMale', array( $first_name ) );
+		$reflected_provider->setStaticPropertyValue( 'firstNameFemale', array( $first_name ) );
+		$reflected_provider->setStaticPropertyValue( 'lastName', array( $last_name ) );
+
+		$person['display_name'] = $faker->name();
+
+		// Switch Faker to default locale if transliteration fails or there's another issue.
+		try {
+			$faker->safeEmail();
+			$faker->userName();
+		} catch ( \Exception $e ) {
+			$faker = self::get_faker();
+		}
+
+		do {
+			$person['email'] = $faker->safeEmail();
+		} while ( email_exists( $person['email'] ) );
+
+		do {
+			$person['username'] = $faker->userName();
+		} while ( username_exists( $person['username'] ) );
+
+		$reflected_provider->setStaticPropertyValue( 'firstNameMale', $orig_fn_male );
+		$reflected_provider->setStaticPropertyValue( 'firstNameFemale', $orig_fn_female );
+		$reflected_provider->setStaticPropertyValue( 'lastName', $orig_ln );
+
+		return $person;
+	}
+
+	/**
+	 * Generate data for a company, localized for a particular country.
+	 *
+	 * Includes company name, username, email address, and password.
+	 *
+	 * @param string $country_code ISO 3166-1 alpha-2 country code. E.g. US, ES, CN, RU etc.
+	 *
+	 * @return string[]|\WP_Error
+	 */
+	public static function generate_company( string $country_code = '' ) {
+		$country_code = self::get_valid_country_code( $country_code );
+		if ( is_wp_error( $country_code ) ) {
+			return $country_code;
+		}
+
+		$faker = self::get_faker( $country_code );
+
+		$last_names = array();
+		for ( $i = 0; $i < 3; $i++ ) {
+			try {
+				$last_names[] = $faker->unique()->lastName();
+			} catch ( \OverflowException $e ) {
+				$last_names[] = $faker->unique( true )->lastName();
+			}
+		}
+
+		// Make sure all the company-related strings draw from the same set of last names that were previously generated.
+		$person_provider    = self::get_provider_instance( $faker, 'Person' );
+		$reflected_provider = new \ReflectionClass( $person_provider );
+		$orig_ln            = $reflected_provider->getStaticPropertyValue( 'lastName', array() );
+
+		$reflected_provider->setStaticPropertyValue( 'lastName', $last_names );
+
+		$company = array(
+			'company'  => $faker->company(),
+			'password' => 'password',
+		);
+
+		$company['display_name'] = $company['company'];
+
+		$reflected_provider->setStaticPropertyValue( 'lastName', array( $faker->randomElement( $last_names ) ) );
+
+		// Make sure a unique email and username are used.
+		do {
+			try {
+				$company['email'] = $faker->companyEmail();
+			} catch ( \Exception $e ) {
+				$default_faker    = self::get_faker();
+				$company['email'] = $default_faker->email();
+			}
+		} while ( email_exists( $company['email'] ) );
+
+		do {
+			try {
+				$company['username'] = $faker->domainWord() . $faker->optional()->randomNumber( 2 );
+			} catch ( \Exception $e ) {
+				$default_faker       = self::get_faker();
+				$company['username'] = $default_faker->userName();
+			}
+		} while ( username_exists( $company['username'] ) || strlen( $company['username'] ) < 3 );
+
+		$reflected_provider->setStaticPropertyValue( 'lastName', $orig_ln );
+
+		return $company;
+	}
+
+	/**
+	 * Generate address data, localized for a particular country.
+	 *
+	 * @param string $country_code ISO 3166-1 alpha-2 country code. E.g. US, ES, CN, RU etc.
+	 *
+	 * @return string[]|\WP_Error
+	 */
+	public static function generate_address( string $country_code = '' ) {
+		$country_code = self::get_valid_country_code( $country_code );
+		if ( is_wp_error( $country_code ) ) {
+			return $country_code;
+		}
+
+		$faker = self::get_faker( $country_code );
+
+		$address = array(
+			'address1' => '',
+			'city'     => '',
+			'state'    => '',
+			'postcode' => '',
+			'country'  => '',
+			'phone'    => '',
+		);
+
+		$exceptions = WC()->countries->get_country_locale();
+		foreach ( array_keys( $address ) as $line ) {
+			if ( isset( $exceptions[ $country_code ][ $line ]['hidden'] ) && true === $exceptions[ $country_code ][ $line ]['hidden'] ) {
+				continue;
+			}
+
+			if ( isset( $exceptions[ $country_code ][ $line ]['required'] ) && false === $exceptions[ $country_code ][ $line ]['required'] ) {
+				// 30% chance to skip if it's not required.
+				if ( $faker->randomDigit() <= 2 ) {
+					continue;
+				}
+			}
+
+			switch ( $line ) {
+				case 'address1':
+					$address[ $line ] = $faker->streetAddress();
+					break;
+				case 'city':
+					$address[ $line ] = $faker->city();
+					break;
+				case 'state':
+					$states           = WC()->countries->get_states( $country_code );
+					if ( is_array( $states ) ) {
+						$address[ $line ] = $faker->randomElement( array_keys( $states ) );
+					}
+					break;
+				case 'postcode':
+					$address[ $line ] = $faker->postcode();
+					break;
+				case 'country':
+					$address[ $line ] = $country_code;
+					break;
+				case 'phone':
+					$address[ $line ] = $faker->phoneNumber();
+					break;
+			}
+		}
+
+		return $address;
+	}
+}

--- a/includes/Generator/CustomerInfo.php
+++ b/includes/Generator/CustomerInfo.php
@@ -109,6 +109,12 @@ class CustomerInfo {
 		$first_name = $faker->firstName( $faker->randomElement( array( 'male', 'female' ) ) );
 		$last_name  = $faker->lastName();
 
+		if ( $faker->randomDigit() < 3 ) {
+			// 30% chance for no capitalization.
+			$first_name = strtolower( $first_name );
+			$last_name  = strtolower( $last_name );
+		}
+
 		$person = array(
 			'first_name' => $first_name,
 			'last_name'  => $last_name,
@@ -175,6 +181,11 @@ class CustomerInfo {
 			} catch ( \OverflowException $e ) {
 				$last_names[] = $faker->unique( true )->lastName();
 			}
+		}
+
+		if ( $faker->randomDigit() < 3 ) {
+			// 30% chance for no capitalization.
+			$last_names = array_map( 'strtolower', $last_names );
 		}
 
 		// Make sure all the company-related strings draw from the same set of last names that were previously generated.

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -46,6 +46,7 @@ class Order extends Generator {
 		$order->set_billing_last_name( $customer->get_billing_last_name() );
 		$order->set_billing_address_1( $customer->get_billing_address_1() );
 		$order->set_billing_address_2( $customer->get_billing_address_2() );
+		$order->set_billing_email( $customer->get_billing_email() );
 		$order->set_billing_phone( $customer->get_billing_phone() );
 		$order->set_billing_city( $customer->get_billing_city() );
 		$order->set_billing_postcode( $customer->get_billing_postcode() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Makes the data generated by the Customers generator more "coherent" and contextual to a locale, plus a few other enhancements to make it more useful for testing.

* Adds an optional `country` parameter to the generator, which is used to localize the Faker library that produces the random data. If a country isn't specified, falls back on randomly selecting any country that the store is configured to sell to.
* Ensures that first, last, and/or company name that is generated is then used when generating username and email address.
* Adds an optional `type` parameter to the generator, to specify if the customer should be a person or a company. Company customers do not have the first and last name fields filled in.
* Sets the password of every created customer account to `password` so that it's easy to log in as that customer and see the store from that perspective.
* Misc tweaks.

Fixes #131 
Fixes #108
Fixes #66

### How to test the changes in this Pull Request:

1. Open a tab to your test site's admin and go to WooCommerce > Customers. Sort the table by Date Registered so you can quickly see new customers when they are generated.
1. In your terminal, view the docs for the customers cli command: `wp help wc generate customers`. Note the optional parameters for the command.
1. In your browser, go to WooCommerce > Settings. Make sure "Selling location(s)" is set to "Sell to all countries".
1. Try the default command: `wp wc generate customers`. You should get 10 new customers, from a wide variety of countries.
1. Now change the "Selling location(s)" setting to one or two specific countries, and run the command again. All 10 of the generated customers should be from those countries.
1. Try specifying some different countries on the command line, e.g. `wp wc generate customers 1 --country=DE` and see if the generated data matches. Try some countries that don't use a Latin alphabet, e.g. `CN` or `RU`.
1. Try specifying a country code that is invalid.
1. Try choosing just one type of customer, e.g. `wp wc generate customers --type=company --country=FR`

### Changelog entry

> Improved test data for the Customers generator.
