### PR TITLE
Fix progress bar feedback when generating customers via WP-CLI

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -132,7 +132,7 @@ class CLI extends WP_CLI_Command {
 
 		$time_start = microtime( true );
 
-		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating coupons', $amount );
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating customers', $amount );
 
 		Generator\Customer::disable_emails();
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When generating customers via WP-CLI the plugin incorrectly states that coupons are being generated before the progress bar.

![Screenshot-2024-07-27 --22 11 25](https://github.com/user-attachments/assets/b3db0075-7a8e-4b56-bf52-bb1cedc4c005)

![Screenshot-2024-07-27 --22 11 25](https://github.com/user-attachments/assets/4fcee0dd-dd83-4d55-b6e9-3b8445c4bbc8)

This PR fixes the text feedback for the progress bar.

### How to test the changes in this Pull Request:

1. Run wp-cli command `wp wc generate customers 1`
2. Check the feedback given on screen

### Changelog entry

Fixes progress bar feedback when generating customers via WP-CLI

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
