### PR TITLE
Fix fatal when default_locale is empty

### DIFF
--- a/includes/Generator/CustomerInfo.php
+++ b/includes/Generator/CustomerInfo.php
@@ -61,7 +61,7 @@ class CustomerInfo {
 	 */
 	protected static function get_faker( $country_code = 'en_US' ) {
 		$locale_info    = self::get_country_locale_info( $country_code );
-		$default_locale = $locale_info['default_locale'] ?? 'en_US';
+		$default_locale = ! empty( $locale_info['default_locale'] ) ? $locale_info['default_locale'] : 'en_US';
 
 		$faker = \Faker\Factory::create( $default_locale );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes a fatal error when trying to generate orders. Some countries may have an empty "default_locale" property. In which case, this would throw a fatal (at least in PHP 8).

There's actually, only one case of this [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/i18n/locale-info.php#L2471), so I guess I was "lucky" to hit this. This issue should be fixed separately in Woo itself, but checking here to avoid a fatal wouldn't be bad either IMO.

### How to test the changes in this Pull Request:

1. Check out trunk
2. Run `wp eval "var_dump( WC\SmoothGenerator\Generator\CustomerInfo::generate_person('MV') );"`
3. See fatal
4. Check out this branch
5. Run `wp eval "var_dump( WC\SmoothGenerator\Generator\CustomerInfo::generate_person('MV') );"`
6. See success

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix fatal when generating a large amount of orders, which increases the chances of hitting the empty locale issue.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
