### PR TITLE
Set paid and completed dates

### DIFF
--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -111,7 +111,9 @@ class Order extends Generator {
 			$date_paid = date( 'Y-m-d H:i:s', strtotime( $date ) + ( wp_rand( 0, 36 ) * HOUR_IN_SECONDS ) );
 			$order->set_date_paid( $date_paid );
 			if ( 'completed' === $status ) {
-				$order->set_date_completed( $date_paid );
+				// Add random 0 to 36 hours to paid date.
+				$date_completed = date( 'Y-m-d H:i:s', strtotime( $date_paid ) + ( wp_rand( 0, 36 ) * HOUR_IN_SECONDS ) );
+				$order->set_date_completed( $date_completed );
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

### Changes proposed in this Pull Request:
When we generate orders we are able to generate them over a range of dates. This works correctly when setting the order creation date. However other dates will default to the current date.

So if we generate a set of orders for the Analytics reports the `date_paid` will all be at the time of when the order was generated. Which isn't very useful for populating some test data for these reports.

This PR changes that behaviour and allows setting both the paid date as well as the order completed date. This is set based on the chosen status of the order. Paid date is set for both processing and completed. Completed date is set for only completed orders. The date is set by adding a random amount of 0 to 36 hours to the creation date.

### How to test the changes in this Pull Request:

1. Generate a set of orders in WP-CLI, for January `wp wc generate orders 10 --date-start=2024-01-01 --date-end=2024-01-31`
2. Go to Analytics > Orders
3. Set a custom date range to view all orders from January
4. Confirm that we are seeing orders within the report (with a date of January and not the date we generate the orders)
![image](https://github.com/user-attachments/assets/3e5b7a9d-b2e6-4274-b9ba-2635ea1ac34d)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Set paid and completed dates based on order status.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
