### PR TITLE
Add support for campaign order attribution data.

### DIFF
--- a/includes/Generator/OrderAttribution.php
+++ b/includes/Generator/OrderAttribution.php
@@ -378,11 +378,11 @@ class OrderAttribution {
 	 */
 	private static function get_seasonal_campaign_data() {
 		$campaigns = array(
-			'summer_sale_2024'  => array(
+			'summer_sale'  => array(
 				'content' => 'summer_deals',
 				'term'    => 'seasonal_discount',
 			),
-			'black_friday_2024' => array(
+			'black_friday' => array(
 				'content' => 'bf_deals',
 				'term'    => 'black_friday_sale',
 			),
@@ -441,7 +441,7 @@ class OrderAttribution {
 				'term'    => 'new_arrival',
 			),
 			'spring_collection'  => array(
-				'content' => 'spring_2024',
+				'content' => 'spring',
 				'term'    => 'new_collection',
 			),
 		);

--- a/includes/Generator/OrderAttribution.php
+++ b/includes/Generator/OrderAttribution.php
@@ -59,6 +59,9 @@ class OrderAttribution {
 				'_wc_order_attribution_session_pages'      => wp_rand( 1, 10 ),
 				'_wc_order_attribution_session_start_time' => self::get_random_session_start_time( $order ),
 				'_wc_order_attribution_session_entry'      => $product_url,
+				'_wc_order_attribution_utm_content'        => $utm_content,
+				'_wc_order_attribution_utm_source'         => self::get_source( $source_type ),
+				'_wc_order_attribution_referrer'           => self::get_referrer( $source_type ),
 				'_wc_order_attribution_source_type'        => $source_type,
 			);
 
@@ -67,7 +70,6 @@ class OrderAttribution {
 				$campaign_data = self::get_campaign_data();
 				$meta          = array_merge( $meta, $campaign_data );
 			} else {
-				$meta['_wc_order_attribution_utm_content'] = $utm_content;
 			}
 		}
 
@@ -398,8 +400,6 @@ class OrderAttribution {
 			'_wc_order_attribution_utm_campaign' => $campaign_name,
 			'_wc_order_attribution_utm_content'  => $campaign['content'],
 			'_wc_order_attribution_utm_term'     => $campaign['term'],
-			'_wc_order_attribution_utm_source'   => 'email',
-			'_wc_order_attribution_utm_medium'   => 'email',
 		);
 	}
 
@@ -427,8 +427,6 @@ class OrderAttribution {
 			'_wc_order_attribution_utm_campaign' => $campaign_name,
 			'_wc_order_attribution_utm_content'  => $campaign['content'],
 			'_wc_order_attribution_utm_term'     => $campaign['term'],
-			'_wc_order_attribution_utm_source'   => 'social',
-			'_wc_order_attribution_utm_medium'   => 'cpc',
 		);
 	}
 
@@ -456,8 +454,6 @@ class OrderAttribution {
 			'_wc_order_attribution_utm_campaign' => $campaign_name,
 			'_wc_order_attribution_utm_content'  => $campaign['content'],
 			'_wc_order_attribution_utm_term'     => $campaign['term'],
-			'_wc_order_attribution_utm_source'   => 'google',
-			'_wc_order_attribution_utm_medium'   => 'cpc',
 		);
 	}
 
@@ -489,8 +485,6 @@ class OrderAttribution {
 			'_wc_order_attribution_utm_campaign' => $campaign_name,
 			'_wc_order_attribution_utm_content'  => $campaign['content'],
 			'_wc_order_attribution_utm_term'     => $campaign['term'],
-			'_wc_order_attribution_utm_source'   => 'email',
-			'_wc_order_attribution_utm_medium'   => 'email',
 		);
 	}
 

--- a/includes/Generator/OrderAttribution.php
+++ b/includes/Generator/OrderAttribution.php
@@ -69,7 +69,6 @@ class OrderAttribution {
 			if ( wp_rand( 1, 100 ) <= self::CAMPAIGN_PROBABILITY ) {
 				$campaign_data = self::get_campaign_data();
 				$meta          = array_merge( $meta, $campaign_data );
-			} else {
 			}
 		}
 

--- a/includes/Generator/OrderAttribution.php
+++ b/includes/Generator/OrderAttribution.php
@@ -58,6 +58,8 @@ class OrderAttribution {
 				'_wc_order_attribution_utm_source'         => self::get_source( $source_type ),
 				'_wc_order_attribution_referrer'           => self::get_referrer( $source_type ),
 				'_wc_order_attribution_source_type'        => $source_type,
+				'_wc_order_attribution_utm_campaign'       => self::get_random_utm_campaign(),
+				'_wc_order_attribution_utm_term'          => self::get_random_utm_term(),
 			);
 		}
 
@@ -319,6 +321,50 @@ class OrderAttribution {
 		$order_created_date->sub( $random_interval );
 
 		return $order_created_date->format( 'Y-m-d H:i:s' );
+	}
+
+	/**
+	 * Get a random UTM campaign name.
+	 *
+	 * @return string The UTM campaign name.
+	 */
+	public static function get_random_utm_campaign() {
+		$campaigns = array(
+			'summer_sale_2024',
+			'black_friday_2024',
+			'new_product_launch',
+			'holiday_special',
+			'spring_collection',
+			'flash_sale',
+			'membership_promo',
+			'newsletter_special',
+			'social_campaign',
+			'influencer_collab',
+		);
+
+		return $campaigns[ array_rand( $campaigns ) ];
+	}
+
+	/**
+	 * Get a random UTM term (usually for paid search keywords).
+	 *
+	 * @return string The UTM term.
+	 */
+	public static function get_random_utm_term() {
+		$terms = array(
+			'buy_online',
+			'best_deals',
+			'discount_code',
+			'free_shipping',
+			'premium_products',
+			'sale_items',
+			'new_arrival',
+			'trending_products',
+			'limited_offer',
+			'',  // Sometimes term might be empty
+		);
+
+		return $terms[ array_rand( $terms ) ];
 	}
 
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?


### Changes proposed in this Pull Request:

This PR adds campaign-specific attributes to the order attribution data.


### How to test the changes in this Pull Request:

1. Using this branch, generate at least 500 orders
2. Follow the steps to test Woo Analytics Order Attribution reports ( [woocommercep2.wordpress.com/2024/12/03/order-attribution-reports-hpos-and-non-hpos-support-internal-call-for-testing#how-do-i-test](https://woocommercep2.wordpress.com/2024/12/03/order-attribution-reports-hpos-and-non-hpos-support-internal-call-for-testing/#how-do-i-test))
3. Once connected, review the report, filter by Campaigns, and confirm there are campaign data,


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?


### Changelog entry

> Add - Support for campaign order attribution data

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
