### PR TITLE
Terms: Update description generator for new Faker behavior

### DIFF
--- a/includes/Generator/Term.php
+++ b/includes/Generator/Term.php
@@ -57,8 +57,10 @@ class Term extends Generator {
 			$term_name = strtolower( $term_name );
 		}
 
+		$description_size = wp_rand( 20, 260 );
+
 		$term_args = array(
-			'description' => self::$faker->realTextBetween( 20, wp_rand( 20, 300 ), 4 ),
+			'description' => self::$faker->realTextBetween( $description_size, $description_size + 40, 4 ),
 		);
 		if ( 0 !== $parent ) {
 			$term_args['parent'] = $parent;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

With the new version of the Faker library introduced in #147, the behavior of the `realTextBetween` seems to have changed, making it more strict in its interpretation of the input parameters. This change avoids fatal errors by ensuring that there is always a range of 40 between the specified minimum number of characters and the maximum, so that the generator can always build a string with a length that falls somewhere within the range.

Fixes #153

### How to test the changes in this Pull Request:

1. Before getting started, make sure you're running Smooth Generator with the latest dependencies:
    `nvm use && npm run setup`
2. Replicate the issue on trunk. Run `wp wc generate terms product_cat 100` and observe the fatal error (there are two different ones you might see, as described in the linked issue). You may have to run it a few times before you get an error.
3. Check out this branch, and then run the command a few more times. You shouldn't be able to get either of the reported fatal errors anymore.

### Changelog entry

> Avoid fatal errors that sporadically occurred while generating taxonomy terms
