### PR TITLE
Products: Decouple taxonomy term generation

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -263,7 +263,7 @@ class CLI extends WP_CLI_Command {
 
 WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'products' ), array(
 	'shortdesc' => 'Generate products.',
-	'synopsis' => array(
+	'synopsis'  => array(
 		array(
 			'name'        => 'amount',
 			'type'        => 'positional',
@@ -278,8 +278,14 @@ WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'p
 			'optional'    => true,
 			'options'     => array( 'simple', 'variable' ),
 		),
+		array(
+			'name'        => 'use-existing-terms',
+			'type'        => 'flag',
+			'description' => 'Only apply existing categories and tags to products, rather than generating new ones.',
+			'optional'    => true,
+		),
 	),
-	'longdesc' => "## EXAMPLES\n\nwc generate products 10\n\nwc generate products 20 --type=variable",
+	'longdesc'  => "## EXAMPLES\n\nwc generate products 10\n\nwc generate products 20 --type=variable --use-existing-terms",
 ) );
 
 WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'orders' ), array(

--- a/includes/Generator/Generator.php
+++ b/includes/Generator/Generator.php
@@ -26,6 +26,8 @@ abstract class Generator {
 	/**
 	 * Caches term IDs.
 	 *
+	 * @deprecated
+	 *
 	 * @var array Array of IDs.
 	 */
 	protected static $term_ids;
@@ -100,9 +102,12 @@ abstract class Generator {
 	/**
 	 * Get random term ids.
 	 *
+	 * @deprecated Use Product::get_term_ids instead.
+	 *
 	 * @param int    $limit Number of term IDs to get.
 	 * @param string $taxonomy Taxonomy name.
 	 * @param string $name Product name to extract terms from.
+	 *
 	 * @return array
 	 */
 	protected static function generate_term_ids( $limit, $taxonomy, $name = '' ) {

--- a/includes/Generator/Generator.php
+++ b/includes/Generator/Generator.php
@@ -106,6 +106,8 @@ abstract class Generator {
 	 * @return array
 	 */
 	protected static function generate_term_ids( $limit, $taxonomy, $name = '' ) {
+		_deprecated_function( __METHOD__, '1.2.2', 'Product::get_term_ids' );
+
 		self::init_faker();
 
 		$term_ids = array();

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -146,7 +146,8 @@ class Product extends Generator {
 		}
 
 		// In case multiple batches are being run in one request, refresh the cache data.
-		RandomRuntimeCache::reset();
+		RandomRuntimeCache::clear( 'product_cat' );
+		RandomRuntimeCache::clear( 'product_tag' );
 
 		return $product_ids;
 	}

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -423,7 +423,7 @@ class Product extends Generator {
 	 * Get a number of random term IDs for a specific taxonomy.
 	 *
 	 * @param string $taxonomy The taxonomy to get terms for.
-	 * @param int    $limit    The number of term IDs to get.
+	 * @param int    $limit    The number of term IDs to get. Maximum value of 50.
 	 *
 	 * @return array
 	 */
@@ -435,7 +435,7 @@ class Product extends Generator {
 		if ( ! RandomRuntimeCache::exists( $taxonomy ) ) {
 			$args = array(
 				'taxonomy'   => $taxonomy,
-				'number'     => 20,
+				'number'     => 50,
 				'orderby'    => 'count',
 				'order'      => 'ASC',
 				'hide_empty' => false,

--- a/includes/Util/RandomRuntimeCache.php
+++ b/includes/Util/RandomRuntimeCache.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * A runtime object cache for storing and randomly retrieving reusable data.
+ *
+ * @package SmoothGenerator\Util
+ */
+
+namespace WC\SmoothGenerator\Util;
+
+/**
+ * Class RandomRuntimeCache.
+ */
+class RandomRuntimeCache {
+	/**
+	 * Associative array for storing groups of cache items.
+	 *
+	 * @var array
+	 */
+	private static $cache = array();
+
+	/**
+	 * Check if a specific cache group exists.
+	 *
+	 * @param string $group The specified cache group.
+	 *
+	 * @return bool
+	 */
+	public static function exists( string $group ): bool {
+		return array_key_exists( $group, self::$cache );
+	}
+
+	/**
+	 * Get a number of items from a specific cache group.
+	 *
+	 * The retrieved items will be from the top of the group's array.
+	 *
+	 * @param string $group The specified cache group.
+	 * @param int    $limit Optional. Get up to this many items. Using 0 will return all the items in the group.
+	 *                      Default 0.
+	 *
+	 * @return array
+	 */
+	public static function get( string $group, int $limit = 0 ): array {
+		$all_items = self::get_group( $group );
+
+		if ( $limit <= 0 || count( $all_items ) <= $limit ) {
+			return $all_items;
+		}
+
+		$items = array_slice( $all_items, 0, $limit );
+
+		return $items;
+	}
+
+	/**
+	 * Remove a number of items from a specific cache group and return them.
+	 *
+	 * The items will be extracted from the top of the group's array.
+	 *
+	 * @param string $group The specified cache group.
+	 * @param int    $limit Optional. Extract up to this many items. Using 0 will return all the items in the group and
+	 *                      delete it from the cache. Default 0.
+	 *
+	 * @return array
+	 */
+	public static function extract( string $group, int $limit = 0 ): array {
+		$all_items = self::get_group( $group );
+
+		if ( $limit <= 0 || count( $all_items ) <= $limit ) {
+			self::clear( $group );
+
+			return $all_items;
+		}
+
+		$items           = array_slice( $all_items, 0, $limit );
+		$remaining_items = array_slice( $all_items, $limit );
+
+		self::set( $group, $remaining_items );
+
+		return $items;
+	}
+
+	/**
+	 * Add items to a specific cache group.
+	 *
+	 * @param string $group The specified cache group.
+	 * @param array  $items The items to add to the group.
+	 *
+	 * @return void
+	 */
+	public static function add( string $group, array $items ): void {
+		$existing_items = self::get_group( $group );
+
+		self::set( $group, array_merge( $existing_items, $items ) );
+	}
+
+	/**
+	 * Set a cache group to contain a specific set of items.
+	 *
+	 * @param string $group The specified cache group.
+	 * @param array  $items The items that will be in the group.
+	 *
+	 * @return void
+	 */
+	public static function set( string $group, array $items ): void {
+		self::$cache[ $group ] = $items;
+	}
+
+	/**
+	 * Count the number of items in a specific cache group.
+	 *
+	 * @param string $group The specified cache group.
+	 *
+	 * @return int
+	 */
+	public static function count( string $group ): int {
+		$group = self::get_group( $group );
+
+		return count( $group );
+	}
+
+	/**
+	 * Shuffle the order of the items in a specific cache group.
+	 *
+	 * @param string $group The specified cache group.
+	 *
+	 * @return void
+	 */
+	public static function shuffle( string $group ): void {
+		// Ensure group exists.
+		self::get_group( $group );
+
+		shuffle( self::$cache[ $group ] );
+	}
+
+	/**
+	 * Delete a group from the cache.
+	 *
+	 * @param string $group The specified cache group.
+	 *
+	 * @return void
+	 */
+	public static function clear( string $group ): void {
+		unset( self::$cache[ $group ] );
+	}
+
+	/**
+	 * Clear the entire cache.
+	 *
+	 * @return void
+	 */
+	public static function reset(): void {
+		self::$cache = array();
+	}
+
+	/**
+	 * Get the items in a cache group, ensuring that the group exists in the cache.
+	 *
+	 * @param string $group The specified cache group.
+	 *
+	 * @return array
+	 */
+	private static function get_group( string $group ): array {
+		if ( ! self::exists( $group ) ) {
+			self::set( $group, array() );
+		}
+
+		return self::$cache[ $group ];
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Makes it so that the products generator only assigns existing category and tag terms to new products, instead of generating them on the fly. In some rudimentary testing, this improved the performance of the products generator by about 9%.

This also introduces a new class for caching reusable data at runtime, `RandomRuntimeCache`. In this PR it is used so that we only need to query category and tag taxonomy terms once each instead of with every new product. However, the class has several other potential uses which could be implemented in separate PRs.

Fixes #119 

### How to test the changes in this Pull Request:

1. Start with a new test site with no products, product categories, or product tags.
2. Run `wp wc generate products --use-existing-terms`. This should generate 10 products. Go view the products on the Products list table. Since there are no existing terms, none of them should have categories or tags assigned to them (except the "Uncategorized" category).
3. Now generate some categories and tags. `wp wc generate terms product_cat` and `wp wc generate terms product_tag`. Go to their respective screens in WP Admin so you can see that they have been created.
4. Now generate some more products, `wp wc generate products --use-existing-terms`. This time the products should have some of the existing categories and tags assigned to them, though there is also the random chance for each product that it will get assigned `0` terms for categories and/or tags.
5. Delete the products, categories, and tags generated so far.
6. Now run `wp wc generate products` (without the `use-existing-terms` flag). This time, the script should generate some categories and tags first, and then apply them to products as they are generated.

### Changelog entry

> De-couple taxonomy term generation from product generation.
