### PR TITLE
Ensure WC emails are disabled before generating

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -84,8 +84,6 @@ class CLI extends WP_CLI_Command {
 			}
 		}
 
-		Generator\Order::disable_emails();
-
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating orders', $amount );
 
 		add_action(
@@ -133,8 +131,6 @@ class CLI extends WP_CLI_Command {
 		$time_start = microtime( true );
 
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating customers', $amount );
-
-		Generator\Customer::disable_emails();
 
 		add_action(
 			'smoothgenerator_customer_generated',

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -22,7 +22,7 @@ class Coupon extends Generator {
 	 * @return \WC_Coupon|\WP_Error Coupon object with data populated.
 	 */
 	public static function generate( $save = true, $assoc_args = array() ) {
-		self::initialize();
+		parent::maybe_initialize_generators();
 
 		$defaults = array(
 			'min' => 5,

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -13,15 +13,6 @@ use WC_Data_Store;
  * Customer data generator.
  */
 class Coupon extends Generator {
-
-	/**
-	 * Init faker library.
-	 */
-	protected static function init_faker() {
-		parent::init_faker();
-		self::$faker->addProvider( new \Bezhanov\Faker\Provider\Commerce( self::$faker ) );
-	}
-
 	/**
 	 * Create a new coupon.
 	 *
@@ -31,7 +22,7 @@ class Coupon extends Generator {
 	 * @return \WC_Coupon|\WP_Error Coupon object with data populated.
 	 */
 	public static function generate( $save = true, $assoc_args = array() ) {
-		self::init_faker();
+		self::initialize();
 
 		$defaults = array(
 			'min' => 5,

--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -20,7 +20,7 @@ class Customer extends Generator {
 	 * @return \WC_Customer|\WP_Error Customer object with data populated.
 	 */
 	public static function generate( $save = true, array $assoc_args = array() ) {
-		self::init_faker();
+		self::initialize();
 
 		$args = filter_var_array(
 			$assoc_args,
@@ -152,19 +152,5 @@ class Customer extends Generator {
 		}
 
 		return $customer_ids;
-	}
-
-	/**
-	 * Disable sending WooCommerce emails when generating objects.
-	 */
-	public static function disable_emails() {
-		$email_actions = array(
-			'woocommerce_new_customer_note',
-			'woocommerce_created_customer',
-		);
-
-		foreach ( $email_actions as $action ) {
-			remove_action( $action, array( 'WC_Emails', 'send_transactional_email' ), 10, 10 );
-		}
 	}
 }

--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -20,7 +20,7 @@ class Customer extends Generator {
 	 * @return \WC_Customer|\WP_Error Customer object with data populated.
 	 */
 	public static function generate( $save = true, array $assoc_args = array() ) {
-		self::initialize();
+		parent::maybe_initialize_generators();
 
 		$args = filter_var_array(
 			$assoc_args,

--- a/includes/Generator/Generator.php
+++ b/includes/Generator/Generator.php
@@ -71,9 +71,11 @@ abstract class Generator {
 	/**
 	 * Get ready to generate objects.
 	 *
+	 * This can be run from any generator, but it applies to all generators.
+	 *
 	 * @return void
 	 */
-	protected static function initialize() {
+	protected static function maybe_initialize_generators() {
 		if ( true !== self::$ready ) {
 			self::init_faker();
 			self::disable_emails();
@@ -99,6 +101,9 @@ abstract class Generator {
 
 	/**
 	 * Disable sending WooCommerce emails when generating objects.
+	 *
+	 * This needs to run as late in the request as possible so that the callbacks we want to remove
+	 * have actually been added.
 	 *
 	 * @return void
 	 */

--- a/includes/Generator/Generator.php
+++ b/includes/Generator/Generator.php
@@ -11,13 +11,25 @@ namespace WC\SmoothGenerator\Generator;
  * Data generator base class.
  */
 abstract class Generator {
-
+	/**
+	 * Maximum number of objects that can be generated in one batch.
+	 */
 	const MAX_BATCH_SIZE = 100;
 
+	/**
+	 * Dimension, in pixels, of generated images.
+	 */
 	const IMAGE_SIZE = 700;
 
 	/**
-	 * Holds the faker factory object.
+	 * Are we ready to generate objects?
+	 *
+	 * @var bool
+	 */
+	protected static $ready = false;
+
+	/**
+	 * Holds the Faker factory object.
 	 *
 	 * @var \Faker\Generator Factory object.
 	 */
@@ -57,11 +69,74 @@ abstract class Generator {
 	//abstract public static function batch( $amount, array $args = array() );
 
 	/**
-	 * Init faker library.
+	 * Get ready to generate objects.
+	 *
+	 * @return void
+	 */
+	protected static function initialize() {
+		if ( true !== self::$ready ) {
+			self::init_faker();
+			self::disable_emails();
+
+			// Set this to avoid notices as when you run via WP-CLI SERVER vars are not set, order emails uses this variable.
+			if ( ! isset( $_SERVER['SERVER_NAME'] ) ) {
+				$_SERVER['SERVER_NAME'] = 'localhost';
+			}
+		}
+
+		self::$ready = true;
+	}
+
+	/**
+	 * Create and store an instance of the Faker library.
 	 */
 	protected static function init_faker() {
 		if ( ! self::$faker ) {
 			self::$faker = \Faker\Factory::create( 'en_US' );
+			self::$faker->addProvider( new \Bezhanov\Faker\Provider\Commerce( self::$faker ) );
+		}
+	}
+
+	/**
+	 * Disable sending WooCommerce emails when generating objects.
+	 *
+	 * @return void
+	 */
+	public static function disable_emails() {
+		$email_actions = array(
+			// Customer emails.
+			'woocommerce_new_customer_note',
+			'woocommerce_created_customer',
+			// Order emails.
+			'woocommerce_order_status_pending_to_processing',
+			'woocommerce_order_status_pending_to_completed',
+			'woocommerce_order_status_processing_to_cancelled',
+			'woocommerce_order_status_pending_to_failed',
+			'woocommerce_order_status_pending_to_on-hold',
+			'woocommerce_order_status_failed_to_processing',
+			'woocommerce_order_status_failed_to_completed',
+			'woocommerce_order_status_failed_to_on-hold',
+			'woocommerce_order_status_cancelled_to_processing',
+			'woocommerce_order_status_cancelled_to_completed',
+			'woocommerce_order_status_cancelled_to_on-hold',
+			'woocommerce_order_status_on-hold_to_processing',
+			'woocommerce_order_status_on-hold_to_cancelled',
+			'woocommerce_order_status_on-hold_to_failed',
+			'woocommerce_order_status_completed',
+			'woocommerce_order_fully_refunded',
+			'woocommerce_order_partially_refunded',
+			// Product emails.
+			'woocommerce_low_stock',
+			'woocommerce_no_stock',
+			'woocommerce_product_on_backorder',
+		);
+
+		foreach ( $email_actions as $action ) {
+			remove_action( $action, array( 'WC_Emails', 'send_transactional_email' ) );
+		}
+
+		if ( ! has_action( 'woocommerce_allow_send_queued_transactional_email', '__return_false' ) ) {
+			add_action( 'woocommerce_allow_send_queued_transactional_email', '__return_false' );
 		}
 	}
 

--- a/includes/Generator/Generator.php
+++ b/includes/Generator/Generator.php
@@ -123,6 +123,7 @@ abstract class Generator {
 			'woocommerce_order_status_on-hold_to_cancelled',
 			'woocommerce_order_status_on-hold_to_failed',
 			'woocommerce_order_status_completed',
+			'woocommerce_order_status_failed',
 			'woocommerce_order_fully_refunded',
 			'woocommerce_order_partially_refunded',
 			// Product emails.

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -20,7 +20,7 @@ class Order extends Generator {
 	 * @return \WC_Order|false Order object with data populated or false when failed.
 	 */
 	public static function generate( $save = true, $assoc_args = array() ) {
-		self::initialize();
+		parent::maybe_initialize_generators();
 
 		$order    = new \WC_Order();
 		$customer = self::get_customer();

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -20,12 +20,7 @@ class Order extends Generator {
 	 * @return \WC_Order|false Order object with data populated or false when failed.
 	 */
 	public static function generate( $save = true, $assoc_args = array() ) {
-		// Set this to avoid notices as when you run via WP-CLI SERVER vars are not set, order emails uses this variable.
-		if ( ! isset( $_SERVER['SERVER_NAME'] ) ) {
-			$_SERVER['SERVER_NAME'] = 'localhost';
-		}
-
-		self::init_faker();
+		self::initialize();
 
 		$order    = new \WC_Order();
 		$customer = self::get_customer();
@@ -175,42 +170,9 @@ class Order extends Generator {
 			return new \WC_Customer( $user_id );
 		}
 
-		Customer::disable_emails();
 		$customer = Customer::generate( ! $guest );
 
 		return $customer;
-	}
-
-	/**
-	 * Disable sending WooCommerce emails when generating objects.
-	 */
-	public static function disable_emails() {
-		$email_actions = array(
-			'woocommerce_low_stock',
-			'woocommerce_no_stock',
-			'woocommerce_product_on_backorder',
-			'woocommerce_order_status_pending_to_processing',
-			'woocommerce_order_status_pending_to_completed',
-			'woocommerce_order_status_processing_to_cancelled',
-			'woocommerce_order_status_pending_to_failed',
-			'woocommerce_order_status_pending_to_on-hold',
-			'woocommerce_order_status_failed_to_processing',
-			'woocommerce_order_status_failed_to_completed',
-			'woocommerce_order_status_failed_to_on-hold',
-			'woocommerce_order_status_cancelled_to_processing',
-			'woocommerce_order_status_cancelled_to_completed',
-			'woocommerce_order_status_cancelled_to_on-hold',
-			'woocommerce_order_status_on-hold_to_processing',
-			'woocommerce_order_status_on-hold_to_cancelled',
-			'woocommerce_order_status_on-hold_to_failed',
-			'woocommerce_order_status_completed',
-			'woocommerce_order_fully_refunded',
-			'woocommerce_order_partially_refunded',
-		);
-
-		foreach ( $email_actions as $action ) {
-			remove_action( $action, array( 'WC_Emails', 'send_transactional_email' ), 10, 10 );
-		}
 	}
 
 	/**

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -66,14 +66,6 @@ class Product extends Generator {
 	);
 
 	/**
-	 * Init faker library.
-	 */
-	protected static function init_faker() {
-		parent::init_faker();
-		self::$faker->addProvider( new \Bezhanov\Faker\Provider\Commerce( self::$faker ) );
-	}
-
-	/**
 	 * Return a new product.
 	 *
 	 * @param bool  $save Save the object before returning or not.
@@ -81,7 +73,7 @@ class Product extends Generator {
 	 * @return \WC_Product The product object consisting of random data.
 	 */
 	public static function generate( $save = true, $assoc_args = array() ) {
-		self::init_faker();
+		self::initialize();
 
 		$type = self::get_product_type( $assoc_args );
 		switch ( $type ) {

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -73,7 +73,7 @@ class Product extends Generator {
 	 * @return \WC_Product The product object consisting of random data.
 	 */
 	public static function generate( $save = true, $assoc_args = array() ) {
-		self::initialize();
+		parent::maybe_initialize_generators();
 
 		$type = self::get_product_type( $assoc_args );
 		switch ( $type ) {

--- a/includes/Generator/Term.php
+++ b/includes/Generator/Term.php
@@ -12,14 +12,6 @@ namespace WC\SmoothGenerator\Generator;
  */
 class Term extends Generator {
 	/**
-	 * Init faker library.
-	 */
-	protected static function init_faker() {
-		parent::init_faker();
-		self::$faker->addProvider( new \Bezhanov\Faker\Provider\Commerce( self::$faker ) );
-	}
-
-	/**
 	 * Create a new taxonomy term.
 	 *
 	 * @param bool   $save     Whether to save the new term to the database.
@@ -44,7 +36,7 @@ class Term extends Generator {
 			);
 		}
 
-		self::init_faker();
+		self::initialize();
 
 		if ( $taxonomy_obj->hierarchical ) {
 			$term_name = ucwords( self::$faker->department( 3 ) );

--- a/includes/Generator/Term.php
+++ b/includes/Generator/Term.php
@@ -36,7 +36,7 @@ class Term extends Generator {
 			);
 		}
 
-		self::initialize();
+		parent::maybe_initialize_generators();
 
 		if ( $taxonomy_obj->hierarchical ) {
 			$term_name = ucwords( self::$faker->department( 3 ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This consolidates the steps that each generator class needs to take before generating objects into one `initialize` method. These steps include creating an instance of the Faker library and unhooking all the callbacks that send transactional emails. This ensures that the emails are disabled regardless of which entrypoint to Smooth Generator is used (cli or web UI).

Fixes #140

### How to test the changes in this Pull Request:

1. Install an email catcher plugin like [WP Mail Logging](https://wordpress.org/plugins/wp-mail-logging/) so you can see the outgoing emails from your test site.
2. Replicate the issue on trunk first: try generating some products and/or orders, particularly using the web UI rather than wp-cli (WP Admin > Tools > Smooth Generator). Note that emails have been sent about low/no stock when generating some orders, and that emails have been sent about order statuses when generating orders.
3. Now check out this branch and try again. This time there shouldn't be any emails sent.
4. Also try generating things from wp-cli to make sure there aren't any regressions.

### Changelog entry

> Ensure transactional emails are disabled before generating test content.
