### PR TITLE
Reduce queries while generating orders

### DIFF
--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -166,17 +166,22 @@ class Order extends Generator {
 	 * @return \WC_Customer Customer object with data populated.
 	 */
 	public static function get_customer() {
-		global $wpdb;
+		$customer = null;
 
 		if ( ! RandomRuntimeCache::exists( 'customers' ) ) {
+			global $wpdb;
 			$user_ids = $wpdb->get_col( "SELECT ID FROM {$wpdb->users} ORDER BY rand() LIMIT 100" );
 			RandomRuntimeCache::set( 'customers', $user_ids );
 		}
 
-		$customer = null;
-		$existing = (bool) wp_rand( 0, 1 );
+		$guest_chances = 1;
+		if ( RandomRuntimeCache::count( 'customers' ) < 10 ) {
+			// Chance that customer is guest increases with fewer user accounts.
+			$guest_chances = 10 - RandomRuntimeCache::count( 'customers' );
+		}
+		$guest = (bool) wp_rand( 0, $guest_chances );
 
-		if ( $existing ) {
+		if ( ! $guest ) {
 			RandomRuntimeCache::shuffle( 'customers' );
 			$customer_id = RandomRuntimeCache::get( 'customers', 1 )[0];
 			$customer    = new \WC_Customer( $customer_id );

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -7,6 +7,8 @@
 
 namespace WC\SmoothGenerator\Generator;
 
+use WC\SmoothGenerator\Util\RandomRuntimeCache;
+
 /**
  * Order data generator.
  */
@@ -29,9 +31,6 @@ class Order extends Generator {
 
 		$order    = new \WC_Order();
 		$customer = self::get_customer();
-		if ( ! $customer instanceof \WC_Customer ) {
-			return false;
-		}
 		$products = self::get_random_products( 1, 10 );
 
 		foreach ( $products as $product ) {
@@ -154,6 +153,10 @@ class Order extends Generator {
 			$order_ids[] = $order->get_id();
 		}
 
+		// In case multiple batches are being run in one request, refresh the cache data.
+		RandomRuntimeCache::clear( 'customers' );
+		RandomRuntimeCache::clear( 'products' );
+
 		return $order_ids;
 	}
 
@@ -165,18 +168,25 @@ class Order extends Generator {
 	public static function get_customer() {
 		global $wpdb;
 
-		$guest    = (bool) wp_rand( 0, 1 );
-		$existing = (bool) wp_rand( 0, 1 );
-
-		if ( $existing ) {
-			$total_users = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->users}" );
-			$offset      = wp_rand( 0, $total_users );
-			$user_id     = (int) $wpdb->get_var( "SELECT ID FROM {$wpdb->users} ORDER BY rand() LIMIT $offset, 1" ); // phpcs:ignore
-			return new \WC_Customer( $user_id );
+		if ( ! RandomRuntimeCache::exists( 'customers' ) ) {
+			$user_ids = $wpdb->get_col( "SELECT ID FROM {$wpdb->users} ORDER BY rand() LIMIT 100" );
+			RandomRuntimeCache::set( 'customers', $user_ids );
 		}
 
 		Customer::disable_emails();
-		$customer = Customer::generate( ! $guest );
+
+		$customer = null;
+		$existing = (bool) wp_rand( 0, 1 );
+
+		if ( $existing ) {
+			RandomRuntimeCache::shuffle( 'customers' );
+			$customer_id = RandomRuntimeCache::get( 'customers', 1 )[0];
+			$customer    = new \WC_Customer( $customer_id );
+		}
+
+		if ( is_null( $customer ) ) {
+			$customer = Customer::generate( false );
+		}
 
 		return $customer;
 	}
@@ -272,31 +282,25 @@ class Order extends Generator {
 	 * @return array Random list of products.
 	 */
 	protected static function get_random_products( int $min_amount = 1, int $max_amount = 4 ) {
-		global $wpdb;
+		if ( ! RandomRuntimeCache::exists( 'products' ) ) {
+			$query = new \WC_Product_Query( array(
+				'limit'   => 100,
+				'return'  => 'ids',
+				'orderby' => 'rand',
+			) );
 
-		$products = array();
+			$product_ids = $query->get_products();
 
-		$num_existing_products = (int) $wpdb->get_var(
-			"SELECT COUNT( DISTINCT ID )
-			FROM {$wpdb->posts}
-			WHERE 1=1
-			AND post_type='product'
-			AND post_status='publish'"
-		);
-
-		$num_products_to_get = wp_rand( $min_amount, $max_amount );
-
-		if ( $num_products_to_get > $num_existing_products ) {
-			$num_products_to_get = $num_existing_products;
+			RandomRuntimeCache::set( 'products', $product_ids );
 		}
 
-		$query = new \WC_Product_Query( array(
-			'limit'   => $num_products_to_get,
-			'return'  => 'ids',
-			'orderby' => 'rand',
-		) );
+		RandomRuntimeCache::shuffle( 'products' );
 
-		foreach ( $query->get_products() as $product_id ) {
+		$amount      = wp_rand( $min_amount, $max_amount );
+		$product_ids = RandomRuntimeCache::get( 'products', $amount );
+		$products    = array();
+
+		foreach ( $product_ids as $product_id ) {
 			$product = wc_get_product( $product_id );
 
 			if ( $product->is_type( 'variable' ) ) {

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -173,8 +173,6 @@ class Order extends Generator {
 			RandomRuntimeCache::set( 'customers', $user_ids );
 		}
 
-		Customer::disable_emails();
-
 		$customer = null;
 		$existing = (bool) wp_rand( 0, 1 );
 

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -141,7 +141,8 @@ class Product extends Generator {
 		}
 
 		// In case multiple batches are being run in one request, refresh the cache data.
-		RandomRuntimeCache::reset();
+		RandomRuntimeCache::clear( 'product_cat' );
+		RandomRuntimeCache::clear( 'product_tag' );
 
 		return $product_ids;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This reduces the number of queries that run during order generation by storing lists of customer and product IDs that are used in orders in a runtime cache, rather than making new queries for those IDs every time an order is generated. The runtime cache does get refreshed every 100 orders, so that a greater variety of customers and products will be used during large batches.

More crucially, this seems to mitigate the memory leak described in #152. With these changes, I was able to run the command mentioned in the issue to generate 50k orders and never encountered an out of memory error. (It still took forever, I just let it run overnight 😄)

Note that this also changes the behavior of the Orders generator so that it no longer generates new customer accounts. It will only use existing accounts or generate data for "guest" orders. Customers can be generated separately using the Customers generator before running the Orders generator.

Builds off of #119
Towards #152

### How to test the changes in this Pull Request:

1. TBD

### Changelog entry

> 
