### PR TITLE
Allow attribution on orders with no product items.

### DIFF
--- a/includes/Generator/OrderAttribution.php
+++ b/includes/Generator/OrderAttribution.php
@@ -31,15 +31,11 @@ class OrderAttribution {
 
 		$order_products = $order->get_items();
 
-		if ( empty( $order_products ) ) {
-			return;
-		}
-
 		$device_type = self::get_random_device_type();
 		$source      = 'woo.com';
 		$source_type = self::get_source_type();
 		$origin      = self::get_origin( $source_type, $source );
-		$product_url = get_permalink( $order_products[ array_rand( $order_products ) ]->get_id() );
+		$product_url = empty( $order_products ) ? '' : get_permalink( $order_products[ array_rand( $order_products ) ]->get_id() );
 		$utm_content = array( '/', 'campaign_a', 'campaign_b' );
 		$utm_content = $utm_content[ array_rand( $utm_content ) ];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Build WC Smooth generator using this branch.
2. Generate orders without having generated products first
3. Confirm your get attributional data.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
