### PR TITLE
Add date range arguments to admin UI for generating data.

### DIFF
--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -122,15 +122,6 @@ class Settings {
 					min="1"
 					<?php disabled( $current_job instanceof AsyncJob ); ?>
 				/>
-				<!-- Start date -->
-				<label for="generate_orders_start_date_input" class="screen-reader-text">Start date</label>
-				<input
-					id="generate_orders_start_date_input"
-					type="date"
-					name="start_date"
-					value="<?php echo esc_attr( date( 'Y-m-d' ) ); ?>"
-					<?php disabled( $current_job instanceof AsyncJob ); ?>
-				/>
 				<?php
 				submit_button(
 					'Generate',
@@ -141,6 +132,39 @@ class Settings {
 				);
 				?>
 			</p>
+
+			<h2>Advanced Options</h2>
+			<p>
+				<label>
+					<input
+						type="checkbox"
+						id="use_date_range"
+						name="use_date_range"
+						<?php disabled( $current_job instanceof AsyncJob ); ?>
+					/>
+					Specify date range for generation
+				</label>
+			</p>
+			<div id="date_range_inputs" style="display: none;">
+				<p>
+					<label for="generate_start_date_input">Start date</label>
+					<input
+						id="generate_start_date_input"
+						type="date"
+						name="start_date"
+						value="<?php echo esc_attr( date( 'Y-m-d' ) ); ?>"
+						<?php disabled( $current_job instanceof AsyncJob ); ?>
+					/>
+					<label for="generate_end_date_input">End date</label>
+					<input
+						id="generate_end_date_input"
+						type="date"
+						name="end_date"
+						value="<?php echo esc_attr( date( 'Y-m-d' ) ); ?>"
+						<?php disabled( $current_job instanceof AsyncJob ); ?>
+					/>
+				</p>
+			</div>
 
 			<?php
 			submit_button(
@@ -155,6 +179,24 @@ class Settings {
 		<?php
 
 		self::heartbeat_script();
+		self::date_range_toggle_script();
+	}
+
+	/**
+	 * Script to toggle date range inputs visibility.
+	 *
+	 * @return void
+	 */
+	protected static function date_range_toggle_script() {
+		?>
+		<script>
+			( function( $ ) {
+				$( '#use_date_range' ).on( 'change', function() {
+					$( '#date_range_inputs' ).toggle( this.checked );
+				} );
+			} )( jQuery );
+		</script>
+		<?php
 	}
 
 	/**
@@ -168,7 +210,7 @@ class Settings {
 			( function( $ ) {
 				const $document = $( document );
 				const $progress = $( '#smoothgenerator-progress-bar' );
-				const $controls = $( '[id^="generate_"]' );
+				const $controls = $( '[id^="generate_"], #use_date_range, #date_range_inputs input' );
 				const $cancel   = $( '#cancel_job' );
 
 				$document.on( 'ready', function () {
@@ -241,15 +283,21 @@ class Settings {
 	 * Process the generation.
 	 */
 	public static function process_page_submit() {
+		$args = array();
+		
+		if ( ! empty( $_POST['use_date_range'] ) ) {
+			$args['date-start'] = sanitize_text_field( $_POST['start_date'] );
+			$args['date-end'] = sanitize_text_field( $_POST['end_date'] );
+		}
+
 		if ( ! empty( $_POST['generate_products'] ) && ! empty( $_POST['num_products_to_generate'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_products_to_generate'] );
-			BatchProcessor::create_new_job( 'products', $num_to_generate );
+			BatchProcessor::create_new_job( 'products', $num_to_generate, $args );
 		} else if ( ! empty( $_POST['generate_orders'] ) && ! empty( $_POST['num_orders_to_generate'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_orders_to_generate'] );
-			$start_date      = sanitize_text_field( $_POST['start_date'] );
-			BatchProcessor::create_new_job( 'orders', $num_to_generate, array( 'date-start' => $start_date ) );
+			BatchProcessor::create_new_job( 'orders', $num_to_generate, $args );
 		} else if ( ! empty( $_POST['cancel_job'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			BatchProcessor::delete_current_job();

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -122,6 +122,15 @@ class Settings {
 					min="1"
 					<?php disabled( $current_job instanceof AsyncJob ); ?>
 				/>
+				<!-- Start date -->
+				<label for="generate_orders_start_date_input" class="screen-reader-text">Start date</label>
+				<input
+					id="generate_orders_start_date_input"
+					type="date"
+					name="start_date"
+					value="<?php echo esc_attr( date( 'Y-m-d' ) ); ?>"
+					<?php disabled( $current_job instanceof AsyncJob ); ?>
+				/>
 				<?php
 				submit_button(
 					'Generate',
@@ -239,7 +248,8 @@ class Settings {
 		} else if ( ! empty( $_POST['generate_orders'] ) && ! empty( $_POST['num_orders_to_generate'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_orders_to_generate'] );
-			BatchProcessor::create_new_job( 'orders', $num_to_generate );
+			$start_date      = sanitize_text_field( $_POST['start_date'] );
+			BatchProcessor::create_new_job( 'orders', $num_to_generate, array( 'date-start' => $start_date ) );
 		} else if ( ! empty( $_POST['cancel_job'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			BatchProcessor::delete_current_job();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

### Changes proposed in this Pull Request:

While generating some orders to test some reports, I realised that all orders generated via the UI have the same date. @garymurray has brought this up before, so I decided to implement it

This PR adds dates fields to the form and provides `start-date` and `end-date` args to the `generate orders` and `generate products` jobs.

### How to test the changes in this Pull Request:

![image](https://private-user-images.githubusercontent.com/4209011/424467438-b695c9dd-9778-40bf-8083-7fc5ef55c105.gif?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDIzOTM1ODYsIm5iZiI6MTc0MjM5MzI4NiwicGF0aCI6Ii80MjA5MDExLzQyNDQ2NzQzOC1iNjk1YzlkZC05Nzc4LTQwYmYtODA4My03ZmM1ZWY1NWMxMDUuZ2lmP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDMxOSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTAzMTlUMTQwODA2WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9OTNjZTQwZDQ3ZmMxMDk1ZjQ1ZDU1ZTQ0NjBjMmYwNmQwZTYwZDBjOGYzNTUzMzgxMGVlNDBkZmY5MDM5NzFkOSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.-yCvrp72_kP9WxlgI5sEwjx7HikY4tJNnd3Slab_3aQ)

1. Using a build from this branch
2. Navigate to WP admin -> Tools -> Smooth Generator. Notice the new date input in the generate orders form.
3. Confirm that this new parameter works by generating a few orders with a start date different from the current date. This should generate orders with various date between your selected start date and the current date.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add -  Add start date to admin UI for generating orders.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
