### PR TITLE
Add plugin settings link

### DIFF
--- a/wc-smooth-generator.php
+++ b/wc-smooth-generator.php
@@ -61,7 +61,7 @@ add_action( 'before_woocommerce_init', function() {
 /**
  * Show action links on the plugin screen.
  *
- * @param mixed $links Plugin Action links.
+ * @param array $links Plugin Action links.
  *
  * @return array
  */

--- a/wc-smooth-generator.php
+++ b/wc-smooth-generator.php
@@ -67,7 +67,7 @@ add_action( 'before_woocommerce_init', function() {
  */
 function wc_smooth_generator_plugin_action_links( $links ) {
 	$action_links = array(
-		'settings' => '<a href="' . admin_url( 'tools.php?page=smoothgenerator' ) . '" aria-label="View WooCommerce Smooth Generator settings">Settings</a>',
+		'settings' => '<a href="' . esc_url( admin_url( 'tools.php?page=smoothgenerator' ) ) . '" aria-label="' . esc_attr__( 'View WooCommerce Smooth Generator settings', 'wc-smooth-generator' ) . '">' . esc_html__( 'Settings', 'wc-smooth-generator' ) . '</a>',
 	);
 
 	return array_merge( $action_links, $links );

--- a/wc-smooth-generator.php
+++ b/wc-smooth-generator.php
@@ -57,3 +57,20 @@ add_action( 'before_woocommerce_init', function() {
 		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 	}
 } );
+
+/**
+ * Show action links on the plugin screen.
+ *
+ * @param mixed $links Plugin Action links.
+ *
+ * @return array
+ */
+function wc_smooth_generator_plugin_action_links( $links ) {
+	$action_links = array(
+		'settings' => '<a href="' . admin_url( 'tools.php?page=smoothgenerator' ) . '" aria-label="View WooCommerce Smooth Generator settings">Settings</a>',
+	);
+
+	return array_merge( $action_links, $links );
+}
+
+add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'wc_smooth_generator_plugin_action_links' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In the Plugins Admin Screen this PR adds a link for users to easily access the wc-smooth-generator settings.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #169 .

### How to test the changes in this Pull Request:

1. apply the pr
2. visit /wp-admin/plugins.php and see if there is a setting

<img width="670" height="292" alt="image" src="https://github.com/user-attachments/assets/41e09dbb-84ac-437b-b0ad-0a6d392ac1ce" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
Add a settings Link in plugin overview
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
