### PR TITLE
Fix order paid and completed dates to respect historical creation dates

### DIFF
--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -100,20 +100,22 @@ class Order extends Generator {
 			OrderAttribution::add_order_attribution_meta( $order, $assoc_args );
 		}
 
-		// Set paid and completed dates based on order status.
-		if ( 'completed' === $status || 'processing' === $status ) {
-			// Add random 0 to 36 hours to creation date.
-			$date_paid = date( 'Y-m-d H:i:s', strtotime( $date ) + ( wp_rand( 0, 36 ) * HOUR_IN_SECONDS ) );
-			$order->set_date_paid( $date_paid );
-			if ( 'completed' === $status ) {
-				// Add random 0 to 36 hours to paid date.
-				$date_completed = date( 'Y-m-d H:i:s', strtotime( $date_paid ) + ( wp_rand( 0, 36 ) * HOUR_IN_SECONDS ) );
-				$order->set_date_completed( $date_completed );
-			}
-		}
-
 		if ( $save ) {
 			$order->save();
+
+			// Set paid and completed dates AFTER initial save to prevent WooCommerce from overriding them.
+			// This must be done after save so the status transition doesn't reset the dates to current time.
+			if ( 'completed' === $status || 'processing' === $status ) {
+				// Add random 0 to 36 hours to creation date.
+				$date_paid = date( 'Y-m-d H:i:s', strtotime( $date ) + ( wp_rand( 0, 36 ) * HOUR_IN_SECONDS ) );
+				$order->set_date_paid( $date_paid );
+				if ( 'completed' === $status ) {
+					// Add random 0 to 36 hours to paid date.
+					$date_completed = date( 'Y-m-d H:i:s', strtotime( $date_paid ) + ( wp_rand( 0, 36 ) * HOUR_IN_SECONDS ) );
+					$order->set_date_completed( $date_completed );
+				}
+				$order->save();
+			}
 		}
 
 		/**


### PR DESCRIPTION
## Summary
Fixes an issue where orders generated with historical dates (using `--date-start` and `--date-end` flags) would have their paid and completed dates set to the current time instead of being based on the order's creation date.

## Problem
When generating orders with historical creation dates, the order generator was setting the paid and completed dates before the initial `$order->save()` call. WooCommerce's status transition hooks during the save would override these dates with the current timestamp, resulting in orders with creation dates in the past but paid/completed dates of today.

## Solution
This PR moves the date-setting logic to **after** the initial order save. By setting the dates after the order has been created and its status set, we prevent WooCommerce from overriding them. The dates are now correctly calculated relative to the order's creation date:
- Paid date: 0-36 hours after creation date
- Completed date: 0-36 hours after paid date

## Testing
Generate orders with historical dates and verify that paid and completed dates are now set relative to the creation date rather than the current time:

```bash
wp wc generate orders 10 --date-start=2024-01-01 --date-end=2024-12-31 --status=completed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)