### PR TITLE
Optimize batch order generation performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Generate orders with random dates between `--date-start` and `--date-end`.
 Generate orders with a specific status.
 - `wp wc generate orders <nr of orders> --status=completed`
 
+Apply coupons to a percentage of generated orders (0.0-1.0). If no coupons exist, 6 will be created automatically (3 fixed cart, 3 percentage).
+- `wp wc generate orders <nr of orders> --coupon-ratio=0.5`
+
+Refund a percentage of completed orders (0.0-1.0). Refunds can be full or partial, and 25% of partial refunds will receive a second partial refund.
+- `wp wc generate orders <nr of orders> --status=completed --refund-ratio=0.3`
+
 #### Order Attribution
 
 Order Attribution represents the origin of data for an order. By default, random values are generated and assigned to the order. Orders with a creation date before 2024-01-09 will not have attribution metadata added, as the feature was not available in WooCommerce at that time.
@@ -51,6 +57,9 @@ Generate coupons with a minimum discount amount.
 
 Generate coupons with a maximum discount amount.
 - `wp wc generate coupons <nr of coupons> --max=50`
+
+Generate coupons with a specific discount type. Options are `fixed_cart` or `percent`. If not specified, a random type will be chosen.
+- `wp wc generate coupons <nr of coupons> --discount_type=percent --min=5 --max=25`
 
 ### Customers
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Generate orders with random dates between `--date-start` and `--date-end`.
 Generate orders with a specific status.
 - `wp wc generate orders <nr of orders> --status=completed`
 
-Apply coupons to a percentage of generated orders (0.0-1.0). If no coupons exist, 6 will be created automatically (3 fixed cart, 3 percentage).
+Apply coupons to a percentage of generated orders (0.0-1.0). If no coupons exist, 6 will be created automatically (3 fixed cart, 3 percentage). Note: `--coupons` flag is equivalent to `--coupon-ratio=1.0`.
 - `wp wc generate orders <nr of orders> --coupon-ratio=0.5`
 
 Refund a percentage of completed orders (0.0-1.0). Refunds will be split evenly between partial and full, and 25% of partial refunds will receive a second partial refund.

--- a/README.md
+++ b/README.md
@@ -35,9 +35,13 @@ Generate orders with a specific status.
 - `wp wc generate orders <nr of orders> --status=completed`
 
 Apply coupons to a percentage of generated orders (0.0-1.0). If no coupons exist, 6 will be created automatically (3 fixed cart, 3 percentage). Note: `--coupons` flag is equivalent to `--coupon-ratio=1.0`.
+
+**Important:** Decimal ratios are converted to percentages using integer rounding. For example, `0.505` becomes 50% (not 50.5%) because the random generation uses integer comparison. Use whole percentages like `0.50` for precise 50% ratios.
 - `wp wc generate orders <nr of orders> --coupon-ratio=0.5`
 
 Refund a percentage of completed orders (0.0-1.0). Refunds will be split evenly between partial and full, and 25% of partial refunds will receive a second partial refund.
+
+**Note:** The same decimal ratio behavior applies to refund ratios as described above for coupon ratios.
 - `wp wc generate orders <nr of orders> --status=completed --refund-ratio=0.3`
 
 #### Order Attribution

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Generate coupons with a minimum discount amount.
 Generate coupons with a maximum discount amount.
 - `wp wc generate coupons <nr of coupons> --max=50`
 
-Generate coupons with a specific discount type. Options are `fixed_cart` or `percent`. If not specified, a random type will be chosen.
+Generate coupons with a specific discount type. Options are `fixed_cart` or `percent`. If not specified, defaults to WooCommerce default (fixed_cart).
 - `wp wc generate coupons <nr of coupons> --discount_type=percent --min=5 --max=25`
 
 ### Customers

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Generate orders with a specific status.
 Apply coupons to a percentage of generated orders (0.0-1.0). If no coupons exist, 6 will be created automatically (3 fixed cart, 3 percentage).
 - `wp wc generate orders <nr of orders> --coupon-ratio=0.5`
 
-Refund a percentage of completed orders (0.0-1.0). Refunds can be full or partial, and 25% of partial refunds will receive a second partial refund.
+Refund a percentage of completed orders (0.0-1.0). Refunds will be split evenly between partial and full, and 25% of partial refunds will receive a second partial refund.
 - `wp wc generate orders <nr of orders> --status=completed --refund-ratio=0.3`
 
 #### Order Attribution

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -320,6 +320,12 @@ WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'ord
 			'optional'    => true,
 		),
 		array(
+			'name'        => 'coupon-ratio',
+			'type'        => 'assoc',
+			'description' => 'Decimal ratio (0.0-1.0) of orders that should have coupons applied. If no coupons exist, 6 will be created (3 fixed value, 3 percentage).',
+			'optional'    => true,
+		),
+		array(
 			'name'        => 'skip-order-attribution',
 			'type'        => 'flag',
 			'description' => 'Skip adding order attribution meta to the generated orders.',

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -393,8 +393,15 @@ WP_CLI::add_command( 'wc generate coupons', array( 'WC\SmoothGenerator\CLI', 'co
 			'optional'    => true,
 			'default'     => 100,
 		),
+		array(
+			'name'        => 'discount_type',
+			'type'        => 'assoc',
+			'description' => 'The type of discount for the coupon. If not specified, a random type will be chosen.',
+			'optional'    => true,
+			'options'     => array( 'fixed_cart', 'percent' ),
+		),
 	),
-	'longdesc'  => "## EXAMPLES\n\nwc generate coupons 10\n\nwc generate coupons 50 --min=1 --max=50",
+	'longdesc'  => "## EXAMPLES\n\nwc generate coupons 10\n\nwc generate coupons 50 --min=1 --max=50\n\nwc generate coupons 20 --discount_type=percent --min=5 --max=25",
 ) );
 
 WP_CLI::add_command( 'wc generate terms', array( 'WC\SmoothGenerator\CLI', 'terms' ), array(

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -322,13 +322,13 @@ WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'ord
 		array(
 			'name'        => 'coupon-ratio',
 			'type'        => 'assoc',
-			'description' => 'Decimal ratio (0.0-1.0) of orders that should have coupons applied. If no coupons exist, 6 will be created (3 fixed value, 3 percentage).',
+			'description' => 'Decimal ratio (0.0-1.0) of orders that should have coupons applied. If no coupons exist, 6 will be created (3 fixed value, 3 percentage). Note: Decimal values are converted to percentages using integer rounding (e.g., 0.505 becomes 50%).',
 			'optional'    => true,
 		),
 		array(
 			'name'        => 'refund-ratio',
 			'type'        => 'assoc',
-			'description' => 'Decimal ratio (0.0-1.0) of completed orders that should be refunded (wholly or partially).',
+			'description' => 'Decimal ratio (0.0-1.0) of completed orders that should be refunded (wholly or partially). Note: Decimal values are converted to percentages using integer rounding (e.g., 0.505 becomes 50%).',
 			'optional'    => true,
 		),
 		array(

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -396,7 +396,7 @@ WP_CLI::add_command( 'wc generate coupons', array( 'WC\SmoothGenerator\CLI', 'co
 		array(
 			'name'        => 'discount_type',
 			'type'        => 'assoc',
-			'description' => 'The type of discount for the coupon. If not specified, a random type will be chosen.',
+			'description' => 'The type of discount for the coupon. If not specified, defaults to WooCommerce default (fixed_cart).',
 			'optional'    => true,
 			'options'     => array( 'fixed_cart', 'percent' ),
 		),

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -316,7 +316,7 @@ WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'ord
 		array(
 			'name'        => 'coupons',
 			'type'        => 'flag',
-			'description' => 'Create and apply a coupon to each generated order.',
+			'description' => 'Create and apply a coupon to each generated order. Equivalent to --coupon-ratio=1.0.',
 			'optional'    => true,
 		),
 		array(

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -326,6 +326,12 @@ WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'ord
 			'optional'    => true,
 		),
 		array(
+			'name'        => 'refund-ratio',
+			'type'        => 'assoc',
+			'description' => 'Decimal ratio (0.0-1.0) of completed orders that should be refunded (wholly or partially).',
+			'optional'    => true,
+		),
+		array(
 			'name'        => 'skip-order-attribution',
 			'type'        => 'flag',
 			'description' => 'Skip adding order attribution meta to the generated orders.',

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -148,20 +148,27 @@ class Coupon extends Generator {
 	/**
 	 * Get a random existing coupon.
 	 *
+	 * @param array|null $cached_coupon_ids Optional array of coupon IDs to use instead of querying.
 	 * @return \WC_Coupon|false Coupon object or false if none available.
 	 */
-	public static function get_random() {
-		// Note: Using posts_per_page=-1 loads all coupons into memory for random selection.
-		// For stores with thousands of coupons, consider using direct SQL with RAND() for better performance.
-		// This approach was chosen for consistency with WordPress APIs and to avoid raw SQL queries.
-		$coupon_ids = get_posts(
-			array(
-				'post_type'      => 'shop_coupon',
-				'post_status'    => 'publish',
-				'posts_per_page' => -1,
-				'fields'         => 'ids',
-			)
-		);
+	public static function get_random( $cached_coupon_ids = null ) {
+		// Use cached IDs if provided (batch mode optimization)
+		if ( null !== $cached_coupon_ids && ! empty( $cached_coupon_ids ) ) {
+			$coupon_ids = $cached_coupon_ids;
+		} else {
+			// Fallback to querying for coupon IDs
+			// Note: Using posts_per_page=-1 loads all coupons into memory for random selection.
+			// For stores with thousands of coupons, consider using direct SQL with RAND() for better performance.
+			// This approach was chosen for consistency with WordPress APIs and to avoid raw SQL queries.
+			$coupon_ids = get_posts(
+				array(
+					'post_type'      => 'shop_coupon',
+					'post_status'    => 'publish',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+				)
+			);
+		}
 
 		if ( empty( $coupon_ids ) ) {
 			return false;

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -132,39 +132,22 @@ class Coupon extends Generator {
 	 * @return \WC_Coupon|false Coupon object or false if none available.
 	 */
 	public static function get_random() {
-		global $wpdb;
-
-		// Check if any coupons exist
-		$coupon_count = (int) $wpdb->get_var(
-			"SELECT COUNT(*)
-			FROM {$wpdb->posts}
-			WHERE post_type = 'shop_coupon'
-			AND post_status = 'publish'"
-		);
-
-		if ( $coupon_count === 0 ) {
-			return false;
-		}
-
-		// Get a random coupon
-		$offset    = wp_rand( 0, $coupon_count - 1 );
-		$coupon_id = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT ID
-				FROM {$wpdb->posts}
-				WHERE post_type = 'shop_coupon'
-				AND post_status = 'publish'
-				ORDER BY ID
-				LIMIT %d, 1",
-				$offset
+		$coupon_ids = get_posts(
+			array(
+				'post_type'      => 'shop_coupon',
+				'post_status'    => 'publish',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
 			)
 		);
 
-		if ( $coupon_id ) {
-			return new \WC_Coupon( $coupon_id );
+		if ( empty( $coupon_ids ) ) {
+			return false;
 		}
 
-		return false;
+		$random_coupon_id = $coupon_ids[ array_rand( $coupon_ids ) ];
+
+		return new \WC_Coupon( $random_coupon_id );
 	}
 }
 

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -80,11 +80,6 @@ class Coupon extends Generator {
 			);
 		}
 
-		// If no discount type specified, randomly choose one for backwards compatibility
-		if ( empty( $discount_type ) ) {
-			$discount_type = wp_rand( 0, 1 ) === 0 ? 'fixed_cart' : 'percent';
-		}
-
 		$code        = substr( self::$faker->promotionCode( 1 ), 0, -1 ); // Omit the random digit.
 		$amount      = self::$faker->numberBetween( $min, $max );
 		$coupon_code = sprintf(
@@ -93,12 +88,18 @@ class Coupon extends Generator {
 			$amount
 		);
 
+		$props = array(
+			'code'   => $coupon_code,
+			'amount' => $amount,
+		);
+
+		// Only set discount_type if explicitly provided
+		if ( ! empty( $discount_type ) ) {
+			$props['discount_type'] = $discount_type;
+		}
+
 		$coupon = new \WC_Coupon( $coupon_code );
-		$coupon->set_props( array(
-			'code'          => $coupon_code,
-			'amount'        => $amount,
-			'discount_type' => $discount_type,
-		) );
+		$coupon->set_props( $props );
 
 		if ( $save ) {
 			$data_store = WC_Data_Store::load( 'coupon' );

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -151,6 +151,9 @@ class Coupon extends Generator {
 	 * @return \WC_Coupon|false Coupon object or false if none available.
 	 */
 	public static function get_random() {
+		// Note: Using posts_per_page=-1 loads all coupons into memory for random selection.
+		// For stores with thousands of coupons, consider using direct SQL with RAND() for better performance.
+		// This approach was chosen for consistency with WordPress APIs and to avoid raw SQL queries.
 		$coupon_ids = get_posts(
 			array(
 				'post_type'      => 'shop_coupon',

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -25,12 +25,15 @@ class Coupon extends Generator {
 		parent::maybe_initialize_generators();
 
 		$defaults = array(
-			'min' => 5,
-			'max' => 100,
+			'min'           => 5,
+			'max'           => 100,
+			'discount_type' => '',
 		);
 
+		$args = wp_parse_args( $assoc_args, $defaults );
+
 		list( 'min' => $min, 'max' => $max ) = filter_var_array(
-			wp_parse_args( $assoc_args, $defaults ),
+			$args,
 			array(
 				'min' => array(
 					'filter'  => FILTER_VALIDATE_INT,
@@ -68,6 +71,20 @@ class Coupon extends Generator {
 			);
 		}
 
+		// Validate discount_type if provided
+		$discount_type = ! empty( $args['discount_type'] ) ? $args['discount_type'] : '';
+		if ( ! empty( $discount_type ) && ! in_array( $discount_type, array( 'fixed_cart', 'percent' ), true ) ) {
+			return new \WP_Error(
+				'smoothgenerator_coupon_invalid_discount_type',
+				'The discount_type must be either "fixed_cart" or "percent".'
+			);
+		}
+
+		// If no discount type specified, randomly choose one for backwards compatibility
+		if ( empty( $discount_type ) ) {
+			$discount_type = wp_rand( 0, 1 ) === 0 ? 'fixed_cart' : 'percent';
+		}
+
 		$code        = substr( self::$faker->promotionCode( 1 ), 0, -1 ); // Omit the random digit.
 		$amount      = self::$faker->numberBetween( $min, $max );
 		$coupon_code = sprintf(
@@ -78,8 +95,9 @@ class Coupon extends Generator {
 
 		$coupon = new \WC_Coupon( $coupon_code );
 		$coupon->set_props( array(
-			'code'   => $coupon_code,
-			'amount' => $amount,
+			'code'          => $coupon_code,
+			'amount'        => $amount,
+			'discount_type' => $discount_type,
 		) );
 
 		if ( $save ) {

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -24,11 +24,11 @@ class Coupon extends Generator {
 	public static function generate( $save = true, $assoc_args = array() ) {
 		parent::maybe_initialize_generators();
 
-		$defaults = array(
-			'min'           => 5,
-			'max'           => 100,
-			'discount_type' => '',
-		);
+	$defaults = array(
+		'min'           => 5,
+		'max'           => 100,
+		'discount_type' => 'fixed_cart',
+	);
 
 		$args = wp_parse_args( $assoc_args, $defaults );
 

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -151,7 +151,7 @@ class Coupon extends Generator {
 	 * @return \WC_Coupon|false Coupon object or false if none available.
 	 */
 	public static function get_random() {
-		// Note: Using posts_per_page=-1 loads all coupons into memory for random selection.
+		// Note: Using posts_per_page=-1 loads all coupon IDs into memory for random selection.
 		// For stores with thousands of coupons, consider using direct SQL with RAND() for better performance.
 		// This approach was chosen for consistency with WordPress APIs and to avoid raw SQL queries.
 		$coupon_ids = get_posts(

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -125,5 +125,46 @@ class Coupon extends Generator {
 
 		return $coupon_ids;
 	}
+
+	/**
+	 * Get a random existing coupon.
+	 *
+	 * @return \WC_Coupon|false Coupon object or false if none available.
+	 */
+	public static function get_random() {
+		global $wpdb;
+
+		// Check if any coupons exist
+		$coupon_count = (int) $wpdb->get_var(
+			"SELECT COUNT(*)
+			FROM {$wpdb->posts}
+			WHERE post_type = 'shop_coupon'
+			AND post_status = 'publish'"
+		);
+
+		if ( $coupon_count === 0 ) {
+			return false;
+		}
+
+		// Get a random coupon
+		$offset    = wp_rand( 0, $coupon_count - 1 );
+		$coupon_id = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT ID
+				FROM {$wpdb->posts}
+				WHERE post_type = 'shop_coupon'
+				AND post_status = 'publish'
+				ORDER BY ID
+				LIMIT %d, 1",
+				$offset
+			)
+		);
+
+		if ( $coupon_id ) {
+			return new \WC_Coupon( $coupon_id );
+		}
+
+		return false;
+	}
 }
 

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -46,9 +46,15 @@ class Order extends Generator {
 		$order    = new \WC_Order();
 		$customer = self::get_customer();
 		if ( ! $customer instanceof \WC_Customer ) {
+			error_log( 'Order generation failed: Could not generate or retrieve customer' );
 			return false;
 		}
 		$products = self::get_random_products( 1, 10 );
+
+		if ( empty( $products ) ) {
+			error_log( 'Order generation failed: No products available to add to order' );
+			return false;
+		}
 
 		foreach ( $products as $product ) {
 			$quantity = self::$faker->numberBetween( 1, 10 );
@@ -135,15 +141,22 @@ class Order extends Generator {
 		if ( $include_coupon ) {
 			$coupon = self::get_or_create_coupon();
 			if ( $coupon ) {
-				$order->apply_coupon( $coupon );
-				// Recalculate totals after applying coupon
-				$order->calculate_totals( true );
+				$apply_result = $order->apply_coupon( $coupon );
+				if ( is_wp_error( $apply_result ) ) {
+					error_log( 'Coupon application failed: ' . $apply_result->get_error_message() . ' (Coupon: ' . $coupon->get_code() . ')' );
+				} else {
+					// Recalculate totals after applying coupon
+					$order->calculate_totals( true );
+				}
 			}
 		}
 
 		// Orders created before 2024-01-09 represents orders created before the attribution feature was added.
 		if ( ! ( strtotime( $date ) < strtotime( '2024-01-09' ) ) ) {
-			OrderAttribution::add_order_attribution_meta( $order, $assoc_args );
+			$attribution_result = OrderAttribution::add_order_attribution_meta( $order, $assoc_args );
+			if ( $attribution_result && is_wp_error( $attribution_result ) ) {
+				error_log( 'Order attribution meta addition failed: ' . $attribution_result->get_error_message() );
+			}
 		}
 
 		// Set paid and completed dates based on order status.
@@ -159,7 +172,11 @@ class Order extends Generator {
 		}
 
 		if ( $save ) {
-			$order->save();
+			$save_result = $order->save();
+			if ( is_wp_error( $save_result ) ) {
+				error_log( 'Order save failed: ' . $save_result->get_error_message() );
+				return false;
+			}
 
 			// Handle --refund-ratio parameter for completed orders
 			if ( isset( $assoc_args['refund-ratio'] ) && 'completed' === $status ) {
@@ -185,7 +202,7 @@ class Order extends Generator {
 					$first_refund = self::create_refund( $order );
 
 					// Some partial refunds get a second refund (always partial)
-					if ( $first_refund && wp_rand( 1, 100 ) <= self::SECOND_REFUND_PROBABILITY ) {
+					if ( $first_refund && is_object( $first_refund ) && wp_rand( 1, 100 ) <= self::SECOND_REFUND_PROBABILITY ) {
 						self::create_refund( $order, true, $first_refund );
 					}
 				}
@@ -215,13 +232,18 @@ class Order extends Generator {
 	public static function batch( $amount, array $args = array() ) {
 		$amount = self::validate_batch_amount( $amount );
 		if ( is_wp_error( $amount ) ) {
+			error_log( 'Batch generation failed: ' . $amount->get_error_message() );
 			return $amount;
 		}
 
 		$order_ids = array();
 
 		for ( $i = 1; $i <= $amount; $i ++ ) {
-			$order       = self::generate( true, $args );
+			$order = self::generate( true, $args );
+			if ( ! $order ) {
+				error_log( "Batch generation failed: Order {$i} of {$amount} could not be generated" );
+				continue;
+			}
 			$order_ids[] = $order->get_id();
 		}
 
@@ -247,6 +269,10 @@ class Order extends Generator {
 		}
 
 		$customer = Customer::generate( ! $guest );
+
+		if ( ! $customer instanceof \WC_Customer ) {
+			error_log( 'Customer generation failed: Customer::generate() returned invalid result' );
+		}
 
 		return $customer;
 	}
@@ -322,6 +348,11 @@ class Order extends Generator {
 			AND post_status='publish'"
 		);
 
+		if ( $num_existing_products === 0 ) {
+			error_log( 'No published products found in database' );
+			return array();
+		}
+
 		$num_products_to_get = wp_rand( $min_amount, $max_amount );
 
 		if ( $num_products_to_get > $num_existing_products ) {
@@ -334,8 +365,19 @@ class Order extends Generator {
 			'orderby' => 'rand',
 		) );
 
-		foreach ( $query->get_products() as $product_id ) {
+		$product_ids = $query->get_products();
+		if ( empty( $product_ids ) ) {
+			error_log( 'WC_Product_Query returned no product IDs' );
+			return array();
+		}
+
+		foreach ( $product_ids as $product_id ) {
 			$product = wc_get_product( $product_id );
+
+			if ( ! $product ) {
+				error_log( "Failed to retrieve product with ID: {$product_id}" );
+				continue;
+			}
 
 			if ( $product->is_type( 'variable' ) ) {
 				$available_variations = $product->get_available_variations();
@@ -343,9 +385,12 @@ class Order extends Generator {
 					continue;
 				}
 				$index      = self::$faker->numberBetween( 0, count( $available_variations ) - 1 );
-				$products[] = new \WC_Product_Variation( $available_variations[ $index ]['variation_id'] );
+				$variation = new \WC_Product_Variation( $available_variations[ $index ]['variation_id'] );
+				if ( $variation && $variation->exists() ) {
+					$products[] = $variation;
+				}
 			} else {
-				$products[] = new \WC_Product( $product_id );
+				$products[] = $product;
 			}
 		}
 
@@ -374,10 +419,18 @@ class Order extends Generator {
 			// Create 3 percentage coupons (5%-25%)
 			$percent_result = Coupon::batch( 3, array( 'min' => 5, 'max' => 25, 'discount_type' => 'percent' ) );
 
-			// If coupon creation failed, return false
-			if ( is_wp_error( $fixed_result ) || is_wp_error( $percent_result ) ) {
-				return false;
+		// If coupon creation failed, return false
+		if ( is_wp_error( $fixed_result ) || is_wp_error( $percent_result ) ) {
+			$error_message = 'Coupon creation failed: ';
+			if ( is_wp_error( $fixed_result ) ) {
+				$error_message .= 'Fixed coupons error: ' . $fixed_result->get_error_message() . ' ';
 			}
+			if ( is_wp_error( $percent_result ) ) {
+				$error_message .= 'Percentage coupons error: ' . $percent_result->get_error_message();
+			}
+			error_log( $error_message );
+			return false;
+		}
 
 			// Now get a random coupon from the ones we just created
 			$coupon = Coupon::get_random();

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -98,7 +98,7 @@ class Order extends Generator {
 		$include_coupon = ! empty( $assoc_args['coupons'] );
 
 		// Handle --coupon-ratio parameter
-		if ( ! empty( $assoc_args['coupon-ratio'] ) ) {
+		if ( isset( $assoc_args['coupon-ratio'] ) ) {
 			$coupon_ratio = floatval( $assoc_args['coupon-ratio'] );
 
 			// Validate ratio is between 0.0 and 1.0
@@ -146,7 +146,7 @@ class Order extends Generator {
 			$order->save();
 
 			// Handle --refund-ratio parameter for completed orders
-			if ( ! empty( $assoc_args['refund-ratio'] ) && 'completed' === $status ) {
+			if ( isset( $assoc_args['refund-ratio'] ) && 'completed' === $status ) {
 				$refund_ratio = floatval( $assoc_args['refund-ratio'] );
 
 				// Validate ratio is between 0.0 and 1.0
@@ -412,8 +412,8 @@ class Order extends Generator {
 				$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
 				$remaining_qty = $original_qty - $refunded_qty;
 
-				// Skip if nothing left to refund
-				if ( $remaining_qty <= 0 ) {
+				// Skip if nothing left to refund or invalid quantity
+				if ( $remaining_qty <= 0 || $original_qty <= 0 ) {
 					continue;
 				}
 
@@ -465,8 +465,8 @@ class Order extends Generator {
 					$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
 					$remaining_qty = $original_qty - $refunded_qty;
 
-					// Skip if nothing left to refund
-					if ( $remaining_qty <= 0 ) {
+					// Skip if nothing left to refund or invalid quantity
+					if ( $remaining_qty <= 0 || $original_qty <= 0 ) {
 						continue;
 					}
 
@@ -499,8 +499,8 @@ class Order extends Generator {
 					$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
 					$remaining_qty = $original_qty - $refunded_qty;
 
-					// Skip if nothing left to refund or if only 1 remaining
-					if ( $remaining_qty <= 1 ) {
+					// Skip if nothing left to refund, if only 1 remaining, or invalid quantity
+					if ( $remaining_qty <= 1 || $original_qty <= 0 ) {
 						continue;
 					}
 
@@ -541,8 +541,8 @@ class Order extends Generator {
 						$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
 						$remaining_qty = $original_qty - $refunded_qty;
 
-						// Skip if nothing left to refund
-						if ( $remaining_qty <= 0 ) {
+						// Skip if nothing left to refund or invalid quantity
+						if ( $remaining_qty <= 0 || $original_qty <= 0 ) {
 							continue;
 						}
 
@@ -615,7 +615,6 @@ class Order extends Generator {
 			while ( $refund_amount >= $max_partial_refund && count( $line_items ) > 1 ) {
 				// Remove a random item from the refund
 				$item_id_to_remove = array_rand( $line_items );
-				$removed_item = $line_items[ $item_id_to_remove ];
 				unset( $line_items[ $item_id_to_remove ] );
 
 				// Recalculate refund amount and counts

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -521,8 +521,45 @@ class Order extends Generator {
 			}
 		}
 
+		// For full refunds, use the order's actual remaining total to avoid rounding discrepancies
+		if ( $is_full_refund ) {
+			$refund_amount = $order->get_total() - $order->get_total_refunded();
+		}
+
 		// Round refund amount to 2 decimal places for currency precision
 		$refund_amount = round( $refund_amount, 2 );
+
+		// For partial refunds, ensure refund is < 50% of order total by removing items if needed
+		if ( ! $is_full_refund ) {
+			$max_partial_refund = $order->get_total() * 0.5;
+
+			// If refund exceeds 50%, remove items until it's under 50%
+			while ( $refund_amount >= $max_partial_refund && count( $line_items ) > 1 ) {
+				// Remove a random item from the refund
+				$item_id_to_remove = array_rand( $line_items );
+				$removed_item = $line_items[ $item_id_to_remove ];
+				unset( $line_items[ $item_id_to_remove ] );
+
+				// Recalculate refund amount and counts
+				$refund_amount = 0;
+				$total_items = 0;
+				$total_qty = 0;
+
+				foreach ( $line_items as $item_id => $item_data ) {
+					$refund_amount += abs( $item_data['refund_total'] );
+					$total_items++;
+					$total_qty += $item_data['qty'];
+
+					if ( ! empty( $item_data['refund_tax'] ) ) {
+						foreach ( $item_data['refund_tax'] as $tax_amount ) {
+							$refund_amount += abs( $tax_amount );
+						}
+					}
+				}
+
+				$refund_amount = round( $refund_amount, 2 );
+			}
+		}
 
 		// Calculate maximum refundable amount (order total minus already refunded)
 		$max_refund = $order->get_total() - $order->get_total_refunded();

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -488,11 +488,25 @@ class Order extends Generator {
 			}
 		}
 
+		// Calculate the total refund amount from line items
+		$refund_amount = 0;
+		foreach ( $line_items as $item_id => $item_data ) {
+			// Add item total (already negative)
+			$refund_amount += abs( $item_data['refund_total'] );
+
+			// Add tax amounts (already negative)
+			if ( ! empty( $item_data['refund_tax'] ) ) {
+				foreach ( $item_data['refund_tax'] as $tax_amount ) {
+					$refund_amount += abs( $tax_amount );
+				}
+			}
+		}
+
 		// Create the refund
 		$refund = wc_create_refund(
 			array(
 				'order_id'   => $order->get_id(),
-				'amount'     => null, // Let WooCommerce calculate the amount from line items
+				'amount'     => $refund_amount,
 				'reason'     => $is_full_refund ? 'Full refund' : 'Partial refund',
 				'line_items' => $line_items,
 			)

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -518,7 +518,7 @@ class Order extends Generator {
 		$total_qty     = 0;
 
 		foreach ( $line_items as $item_id => $item_data ) {
-			// Add item total (already negative)
+			// Add item total: refund amounts are stored as negative, convert to positive for total calculation
 			$refund_amount += abs( $item_data['refund_total'] );
 
 			// Count items and quantities

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -147,9 +147,9 @@ class Order extends Generator {
 				if ( $should_refund ) {
 					$is_partial = self::create_refund( $order );
 
-					// 25% of partial refunds get a second refund
+					// 25% of partial refunds get a second refund (always partial)
 					if ( $is_partial && wp_rand( 1, 100 ) <= 25 ) {
-						self::create_refund( $order );
+						self::create_refund( $order, true );
 					}
 				}
 			}
@@ -386,15 +386,22 @@ class Order extends Generator {
 	 * Create a refund for an order (either full or partial).
 	 *
 	 * @param \WC_Order $order The order to refund.
+	 * @param bool      $force_partial Force partial refund only.
 	 * @return bool True if partial refund, false if full refund or null on failure.
 	 */
-	protected static function create_refund( $order ) {
+	protected static function create_refund( $order, $force_partial = false ) {
 		if ( ! $order instanceof \WC_Order ) {
 			return false;
 		}
 
-		// 50% chance of full refund, 50% chance of partial refund
-		$is_full_refund = (bool) wp_rand( 0, 1 );
+		// Check if order already has refunds
+		$existing_refunds = $order->get_refunds();
+		if ( ! empty( $existing_refunds ) ) {
+			$force_partial = true;
+		}
+
+		// 50% chance of full refund, 50% chance of partial refund (unless forced)
+		$is_full_refund = $force_partial ? false : (bool) wp_rand( 0, 1 );
 
 		$line_items = array();
 

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -336,28 +336,22 @@ class Order extends Generator {
 
 		// If no coupons exist, create 6 (3 fixed, 3 percentage)
 		if ( $coupon_count === 0 ) {
-			// Create 3 fixed value coupons
+			// Create 3 fixed cart coupons
 			for ( $i = 0; $i < 3; $i++ ) {
-				$coupon = new \WC_Coupon();
-				$amount = self::$faker->numberBetween( 5, 50 );
-				$code   = 'fixed' . $amount . '-' . self::$faker->lexify( '???' );
-
-				$coupon->set_code( $code );
-				$coupon->set_discount_type( 'fixed_cart' );
-				$coupon->set_amount( $amount );
-				$coupon->save();
+				$coupon = Coupon::generate( false, array( 'min' => 5, 'max' => 50 ) );
+				if ( ! is_wp_error( $coupon ) ) {
+					$coupon->set_discount_type( 'fixed_cart' );
+					$coupon->save();
+				}
 			}
 
 			// Create 3 percentage coupons
 			for ( $i = 0; $i < 3; $i++ ) {
-				$coupon = new \WC_Coupon();
-				$amount = self::$faker->numberBetween( 5, 25 );
-				$code   = 'percent' . $amount . '-' . self::$faker->lexify( '???' );
-
-				$coupon->set_code( $code );
-				$coupon->set_discount_type( 'percent' );
-				$coupon->set_amount( $amount );
-				$coupon->save();
+				$coupon = Coupon::generate( false, array( 'min' => 5, 'max' => 25 ) );
+				if ( ! is_wp_error( $coupon ) ) {
+					$coupon->set_discount_type( 'percent' );
+					$coupon->save();
+				}
 			}
 
 			$coupon_count = 6;

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -360,7 +360,7 @@ class Order extends Generator {
 			$force_partial = true;
 		}
 
-		// 50% chance of full refund, 50% chance of partial refund (unless forced)
+		// Refunds will be split evenly between partial and full (unless forced)
 		$is_full_refund = $force_partial ? false : (bool) wp_rand( 0, 1 );
 
 		$line_items = array();

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -378,27 +378,110 @@ class Order extends Generator {
 			return null;
 		}
 
-		$order_total = $order->get_total();
-
 		// 50% chance of full refund, 50% chance of partial refund
 		$is_full_refund = (bool) wp_rand( 0, 1 );
 
+		$line_items = array();
+
 		if ( $is_full_refund ) {
-			// Full refund
-			$refund_amount = $order_total;
+			// Full refund - include all line items and fees
+			foreach ( $order->get_items( array( 'line_item', 'fee' ) ) as $item_id => $item ) {
+				$line_items[ $item_id ] = array(
+					'qty'          => $item->get_quantity(),
+					'refund_total' => $item->get_total() * -1,
+					'refund_tax'   => array_map(
+						function( $tax ) {
+							return $tax * -1;
+						},
+						$item->get_taxes()['total']
+					),
+				);
+			}
 		} else {
-			// Partial refund (between 20% and 80% of order total)
-			$refund_percentage = self::$faker->numberBetween( 20, 80 ) / 100;
-			$refund_amount     = round( $order_total * $refund_percentage, 2 );
+			// Partial refund - randomly select items or partial quantities
+			$items = $order->get_items( array( 'line_item', 'fee' ) );
+
+			// Decide whether to refund full items or partial quantities
+			$refund_full_items = (bool) wp_rand( 0, 1 );
+
+			if ( $refund_full_items && count( $items ) > 1 ) {
+				// Refund a random subset of items completely
+				$items_array  = array_values( $items );
+				$num_to_refund = wp_rand( 1, count( $items_array ) - 1 );
+				$items_to_refund = array_rand( $items_array, $num_to_refund );
+
+				// array_rand returns int if count is 1, array otherwise
+				if ( ! is_array( $items_to_refund ) ) {
+					$items_to_refund = array( $items_to_refund );
+				}
+
+				foreach ( $items_to_refund as $index ) {
+					$item    = $items_array[ $index ];
+					$item_id = $item->get_id();
+
+					$line_items[ $item_id ] = array(
+						'qty'          => $item->get_quantity(),
+						'refund_total' => $item->get_total() * -1,
+						'refund_tax'   => array_map(
+							function( $tax ) {
+								return $tax * -1;
+							},
+							$item->get_taxes()['total']
+						),
+					);
+				}
+			} else {
+				// Refund partial quantities of items
+				foreach ( $items as $item_id => $item ) {
+					$quantity = $item->get_quantity();
+
+					// Only refund line items with quantity > 1
+					if ( 'line_item' === $item->get_type() && $quantity > 1 ) {
+						// Refund between 1 and quantity-1 items
+						$refund_qty = wp_rand( 1, $quantity - 1 );
+						$refund_amount = ( $item->get_total() / $quantity ) * $refund_qty;
+
+						$line_items[ $item_id ] = array(
+							'qty'          => $refund_qty,
+							'refund_total' => $refund_amount * -1,
+							'refund_tax'   => array_map(
+								function( $tax ) use ( $quantity, $refund_qty ) {
+									return ( $tax / $quantity ) * $refund_qty * -1;
+								},
+								$item->get_taxes()['total']
+							),
+						);
+						break; // Only refund one item partially
+					}
+				}
+
+				// If no items were added (all quantities were 1), refund one complete item
+				if ( empty( $line_items ) && count( $items ) > 0 ) {
+					$items_array = array_values( $items );
+					$item        = $items_array[ array_rand( $items_array ) ];
+					$item_id     = $item->get_id();
+
+					$line_items[ $item_id ] = array(
+						'qty'          => $item->get_quantity(),
+						'refund_total' => $item->get_total() * -1,
+						'refund_tax'   => array_map(
+							function( $tax ) {
+								return $tax * -1;
+							},
+							$item->get_taxes()['total']
+						),
+					);
+				}
+			}
 		}
 
 		// Create the refund
 		$refund = wc_create_refund(
 			array(
 				'order_id'   => $order->get_id(),
-				'amount'     => $refund_amount,
+				'amount'     => null, // Let WooCommerce calculate the amount from line items
 				'reason'     => $is_full_refund ? 'Full refund' : 'Partial refund',
-				'line_items' => array(),
+				'line_items' => $line_items,
 			)
 		);
 

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -89,10 +89,25 @@ class Order extends Generator {
 
 		$order->set_date_created( $date );
 
+		// Handle legacy --coupons flag
 		$include_coupon = ! empty( $assoc_args['coupons'] );
+
+		// Handle --coupon-ratio parameter
+		if ( ! empty( $assoc_args['coupon-ratio'] ) ) {
+			$coupon_ratio = floatval( $assoc_args['coupon-ratio'] );
+			// Apply coupon based on ratio
+			if ( $coupon_ratio > 0 && ( $coupon_ratio >= 1.0 || ( mt_rand() / mt_getrandmax() ) < $coupon_ratio ) ) {
+				$include_coupon = true;
+			} else {
+				$include_coupon = false;
+			}
+		}
+
 		if ( $include_coupon ) {
-			$coupon = Coupon::generate( true );
-			$order->apply_coupon( $coupon );
+			$coupon = self::get_or_create_coupon();
+			if ( $coupon ) {
+				$order->apply_coupon( $coupon );
+			}
 		}
 
 		// Orders created before 2024-01-09	represents orders created before the attribution feature was added.
@@ -274,5 +289,72 @@ class Order extends Generator {
 		}
 
 		return $products;
+	}
+
+	/**
+	 * Get a random existing coupon or create coupons if none exist.
+	 * If no coupons exist, creates 6 coupons: 3 fixed value and 3 percentage.
+	 *
+	 * @return \WC_Coupon|null Coupon object or null if none available.
+	 */
+	protected static function get_or_create_coupon() {
+		global $wpdb;
+
+		// Check if any coupons exist
+		$coupon_count = (int) $wpdb->get_var(
+			"SELECT COUNT(*)
+			FROM {$wpdb->posts}
+			WHERE post_type = 'shop_coupon'
+			AND post_status = 'publish'"
+		);
+
+		// If no coupons exist, create 6 (3 fixed, 3 percentage)
+		if ( $coupon_count === 0 ) {
+			// Create 3 fixed value coupons
+			for ( $i = 0; $i < 3; $i++ ) {
+				$coupon = new \WC_Coupon();
+				$amount = self::$faker->numberBetween( 5, 50 );
+				$code   = 'fixed' . $amount . '-' . self::$faker->lexify( '???' );
+
+				$coupon->set_code( $code );
+				$coupon->set_discount_type( 'fixed_cart' );
+				$coupon->set_amount( $amount );
+				$coupon->save();
+			}
+
+			// Create 3 percentage coupons
+			for ( $i = 0; $i < 3; $i++ ) {
+				$coupon = new \WC_Coupon();
+				$amount = self::$faker->numberBetween( 5, 25 );
+				$code   = 'percent' . $amount . '-' . self::$faker->lexify( '???' );
+
+				$coupon->set_code( $code );
+				$coupon->set_discount_type( 'percent' );
+				$coupon->set_amount( $amount );
+				$coupon->save();
+			}
+
+			$coupon_count = 6;
+		}
+
+		// Get a random coupon
+		$offset    = wp_rand( 0, $coupon_count - 1 );
+		$coupon_id = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT ID
+				FROM {$wpdb->posts}
+				WHERE post_type = 'shop_coupon'
+				AND post_status = 'publish'
+				ORDER BY ID
+				LIMIT %d, 1",
+				$offset
+			)
+		);
+
+		if ( $coupon_id ) {
+			return new \WC_Coupon( $coupon_id );
+		}
+
+		return null;
 	}
 }

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -389,7 +389,7 @@ class Order extends Generator {
 	 *
 	 * @param \WC_Order $order The order to refund.
 	 * @param bool      $force_partial Force partial refund only.
-	 * @return bool True if partial refund, false if full refund or null on failure.
+	 * @return bool True if partial refund, false if full refund or on failure.
 	 */
 	protected static function create_refund( $order, $force_partial = false ) {
 		if ( ! $order instanceof \WC_Order ) {

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -329,23 +329,11 @@ class Order extends Generator {
 
 		// If no coupons exist, create 6 (3 fixed, 3 percentage)
 		if ( false === $coupon ) {
-			// Create 3 fixed cart coupons
-			for ( $i = 0; $i < 3; $i++ ) {
-				$new_coupon = Coupon::generate( false, array( 'min' => 5, 'max' => 50 ) );
-				if ( ! is_wp_error( $new_coupon ) ) {
-					$new_coupon->set_discount_type( 'fixed_cart' );
-					$new_coupon->save();
-				}
-			}
+			// Create 3 fixed cart coupons ($5-$50)
+			Coupon::batch( 3, array( 'min' => 5, 'max' => 50, 'discount_type' => 'fixed_cart' ) );
 
-			// Create 3 percentage coupons
-			for ( $i = 0; $i < 3; $i++ ) {
-				$new_coupon = Coupon::generate( false, array( 'min' => 5, 'max' => 25 ) );
-				if ( ! is_wp_error( $new_coupon ) ) {
-					$new_coupon->set_discount_type( 'percent' );
-					$new_coupon->save();
-				}
-			}
+			// Create 3 percentage coupons (5%-25%)
+			Coupon::batch( 3, array( 'min' => 5, 'max' => 25, 'discount_type' => 'percent' ) );
 
 			// Now get a random coupon from the ones we just created
 			$coupon = Coupon::get_random();

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -386,15 +386,19 @@ class Order extends Generator {
 		if ( $is_full_refund ) {
 			// Full refund - include all line items and fees
 			foreach ( $order->get_items( array( 'line_item', 'fee' ) ) as $item_id => $item ) {
+				$taxes      = $item->get_taxes();
+				$refund_tax = array();
+
+				if ( ! empty( $taxes['total'] ) ) {
+					foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
+						$refund_tax[ $tax_id ] = $tax_amount * -1;
+					}
+				}
+
 				$line_items[ $item_id ] = array(
 					'qty'          => $item->get_quantity(),
 					'refund_total' => $item->get_total() * -1,
-					'refund_tax'   => array_map(
-						function( $tax ) {
-							return $tax * -1;
-						},
-						$item->get_taxes()['total']
-					),
+					'refund_tax'   => $refund_tax,
 				);
 			}
 		} else {
@@ -416,18 +420,21 @@ class Order extends Generator {
 				}
 
 				foreach ( $items_to_refund as $index ) {
-					$item    = $items_array[ $index ];
-					$item_id = $item->get_id();
+					$item       = $items_array[ $index ];
+					$item_id    = $item->get_id();
+					$taxes      = $item->get_taxes();
+					$refund_tax = array();
+
+					if ( ! empty( $taxes['total'] ) ) {
+						foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
+							$refund_tax[ $tax_id ] = $tax_amount * -1;
+						}
+					}
 
 					$line_items[ $item_id ] = array(
 						'qty'          => $item->get_quantity(),
 						'refund_total' => $item->get_total() * -1,
-						'refund_tax'   => array_map(
-							function( $tax ) {
-								return $tax * -1;
-							},
-							$item->get_taxes()['total']
-						),
+						'refund_tax'   => $refund_tax,
 					);
 				}
 			} else {
@@ -438,18 +445,21 @@ class Order extends Generator {
 					// Only refund line items with quantity > 1
 					if ( 'line_item' === $item->get_type() && $quantity > 1 ) {
 						// Refund between 1 and quantity-1 items
-						$refund_qty = wp_rand( 1, $quantity - 1 );
+						$refund_qty    = wp_rand( 1, $quantity - 1 );
 						$refund_amount = ( $item->get_total() / $quantity ) * $refund_qty;
+						$taxes         = $item->get_taxes();
+						$refund_tax    = array();
+
+						if ( ! empty( $taxes['total'] ) ) {
+							foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
+								$refund_tax[ $tax_id ] = ( $tax_amount / $quantity ) * $refund_qty * -1;
+							}
+						}
 
 						$line_items[ $item_id ] = array(
 							'qty'          => $refund_qty,
 							'refund_total' => $refund_amount * -1,
-							'refund_tax'   => array_map(
-								function( $tax ) use ( $quantity, $refund_qty ) {
-									return ( $tax / $quantity ) * $refund_qty * -1;
-								},
-								$item->get_taxes()['total']
-							),
+							'refund_tax'   => $refund_tax,
 						);
 						break; // Only refund one item partially
 					}
@@ -460,16 +470,19 @@ class Order extends Generator {
 					$items_array = array_values( $items );
 					$item        = $items_array[ array_rand( $items_array ) ];
 					$item_id     = $item->get_id();
+					$taxes       = $item->get_taxes();
+					$refund_tax  = array();
+
+					if ( ! empty( $taxes['total'] ) ) {
+						foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
+							$refund_tax[ $tax_id ] = $tax_amount * -1;
+						}
+					}
 
 					$line_items[ $item_id ] = array(
 						'qty'          => $item->get_quantity(),
 						'refund_total' => $item->get_total() * -1,
-						'refund_tax'   => array_map(
-							function( $tax ) {
-								return $tax * -1;
-							},
-							$item->get_taxes()['total']
-						),
+						'refund_tax'   => $refund_tax,
 					);
 				}
 			}

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -493,6 +493,11 @@ class Order extends Generator {
 			}
 		}
 
+		// If no line items to refund, return false
+		if ( empty( $line_items ) ) {
+			return false;
+		}
+
 		// Calculate the total refund amount from line items and count items
 		$refund_amount = 0;
 		$total_items   = 0;

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -340,6 +340,11 @@ class Order extends Generator {
 				$num_products_to_get = $num_existing_products;
 			}
 
+			// Safety check: ensure we have products to select
+			if ( $num_products_to_get <= 0 ) {
+				return $products;
+			}
+
 			// Get random product IDs from cache
 			$random_keys = array_rand( self::$batch_product_ids, $num_products_to_get );
 			if ( ! is_array( $random_keys ) ) {

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -13,6 +13,11 @@ namespace WC\SmoothGenerator\Generator;
 class Order extends Generator {
 
 	/**
+	 * Probability (percentage) that a partial refund will receive a second refund.
+	 */
+	const SECOND_REFUND_PROBABILITY = 25;
+
+	/**
 	 * Return a new order.
 	 *
 	 * @param bool  $save Save the object before returning or not.
@@ -95,8 +100,14 @@ class Order extends Generator {
 		// Handle --coupon-ratio parameter
 		if ( ! empty( $assoc_args['coupon-ratio'] ) ) {
 			$coupon_ratio = floatval( $assoc_args['coupon-ratio'] );
+
+			// Validate ratio is between 0.0 and 1.0
+			if ( $coupon_ratio < 0.0 || $coupon_ratio > 1.0 ) {
+				$coupon_ratio = max( 0.0, min( 1.0, $coupon_ratio ) );
+			}
+
 			// Apply coupon based on ratio
-			if ( $coupon_ratio > 0 && ( $coupon_ratio >= 1.0 || ( mt_rand() / mt_getrandmax() ) < $coupon_ratio ) ) {
+			if ( $coupon_ratio > 0 && ( $coupon_ratio >= 1.0 || ( (float) wp_rand() / (float) getrandmax() ) < $coupon_ratio ) ) {
 				$include_coupon = true;
 			} else {
 				$include_coupon = false;
@@ -112,7 +123,7 @@ class Order extends Generator {
 			}
 		}
 
-		// Orders created before 2024-01-09	represents orders created before the attribution feature was added.
+		// Orders created before 2024-01-09 represents orders created before the attribution feature was added.
 		if ( ! ( strtotime( $date ) < strtotime( '2024-01-09' ) ) ) {
 			OrderAttribution::add_order_attribution_meta( $order, $assoc_args );
 		}
@@ -135,6 +146,12 @@ class Order extends Generator {
 			// Handle --refund-ratio parameter for completed orders
 			if ( ! empty( $assoc_args['refund-ratio'] ) && 'completed' === $status ) {
 				$refund_ratio = floatval( $assoc_args['refund-ratio'] );
+
+				// Validate ratio is between 0.0 and 1.0
+				if ( $refund_ratio < 0.0 || $refund_ratio > 1.0 ) {
+					$refund_ratio = max( 0.0, min( 1.0, $refund_ratio ) );
+				}
+
 				$should_refund = false;
 
 				if ( $refund_ratio >= 1.0 ) {
@@ -142,15 +159,15 @@ class Order extends Generator {
 					$should_refund = true;
 				} elseif ( $refund_ratio > 0 ) {
 					// Use random chance for ratios between 0 and 1
-					$random = mt_rand() / mt_getrandmax();
+					$random = (float) wp_rand() / (float) getrandmax();
 					$should_refund = $random < $refund_ratio;
 				}
 
 				if ( $should_refund ) {
 					$is_partial = self::create_refund( $order );
 
-					// 25% of partial refunds get a second refund (always partial)
-					if ( $is_partial && wp_rand( 1, 100 ) <= 25 ) {
+					// Some partial refunds get a second refund (always partial)
+					if ( $is_partial && wp_rand( 1, 100 ) <= self::SECOND_REFUND_PROBABILITY ) {
 						self::create_refund( $order, true );
 					}
 				}
@@ -330,10 +347,15 @@ class Order extends Generator {
 		// If no coupons exist, create 6 (3 fixed, 3 percentage)
 		if ( false === $coupon ) {
 			// Create 3 fixed cart coupons ($5-$50)
-			Coupon::batch( 3, array( 'min' => 5, 'max' => 50, 'discount_type' => 'fixed_cart' ) );
+			$fixed_result = Coupon::batch( 3, array( 'min' => 5, 'max' => 50, 'discount_type' => 'fixed_cart' ) );
 
 			// Create 3 percentage coupons (5%-25%)
-			Coupon::batch( 3, array( 'min' => 5, 'max' => 25, 'discount_type' => 'percent' ) );
+			$percent_result = Coupon::batch( 3, array( 'min' => 5, 'max' => 25, 'discount_type' => 'percent' ) );
+
+			// If coupon creation failed, return false
+			if ( is_wp_error( $fixed_result ) || is_wp_error( $percent_result ) ) {
+				return false;
+			}
 
 			// Now get a random coupon from the ones we just created
 			$coupon = Coupon::get_random();

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -384,6 +384,21 @@ class Order extends Generator {
 			$force_partial = true;
 		}
 
+		// Calculate already refunded quantities per item
+		$refunded_qty_by_item = array();
+		foreach ( $existing_refunds as $existing_refund ) {
+			foreach ( $existing_refund->get_items( array( 'line_item', 'fee' ) ) as $refund_item ) {
+				$item_id = $refund_item->get_meta( '_refunded_item_id' );
+				if ( ! $item_id ) {
+					continue;
+				}
+				if ( ! isset( $refunded_qty_by_item[ $item_id ] ) ) {
+					$refunded_qty_by_item[ $item_id ] = 0;
+				}
+				$refunded_qty_by_item[ $item_id ] += abs( $refund_item->get_quantity() );
+			}
+		}
+
 		// Refunds will be split evenly between partial and full (unless forced)
 		$is_full_refund = $force_partial ? false : (bool) wp_rand( 0, 1 );
 
@@ -392,18 +407,34 @@ class Order extends Generator {
 		if ( $is_full_refund ) {
 			// Full refund - include all line items and fees
 			foreach ( $order->get_items( array( 'line_item', 'fee' ) ) as $item_id => $item ) {
+				// Calculate remaining quantity after previous refunds
+				$original_qty = $item->get_quantity();
+				$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
+				$remaining_qty = $original_qty - $refunded_qty;
+
+				// Skip if nothing left to refund
+				if ( $remaining_qty <= 0 ) {
+					continue;
+				}
+
 				$taxes      = $item->get_taxes();
 				$refund_tax = array();
 
 				if ( ! empty( $taxes['total'] ) ) {
 					foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
-						$refund_tax[ $tax_id ] = $tax_amount * -1;
+						// Prorate tax based on remaining quantity
+						$tax_per_unit = $tax_amount / $original_qty;
+						$refund_tax[ $tax_id ] = ( $tax_per_unit * $remaining_qty ) * -1;
 					}
 				}
 
+				// Prorate the refund total based on remaining quantity
+				$total_per_unit = $item->get_total() / $original_qty;
+				$refund_total = $total_per_unit * $remaining_qty;
+
 				$line_items[ $item_id ] = array(
-					'qty'          => $item->get_quantity(),
-					'refund_total' => $item->get_total() * -1,
+					'qty'          => $remaining_qty,
+					'refund_total' => $refund_total * -1,
 					'refund_tax'   => $refund_tax,
 				);
 			}
@@ -428,37 +459,62 @@ class Order extends Generator {
 				foreach ( $items_to_refund as $index ) {
 					$item       = $items_array[ $index ];
 					$item_id    = $item->get_id();
+
+					// Calculate remaining quantity after previous refunds
+					$original_qty = $item->get_quantity();
+					$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
+					$remaining_qty = $original_qty - $refunded_qty;
+
+					// Skip if nothing left to refund
+					if ( $remaining_qty <= 0 ) {
+						continue;
+					}
+
 					$taxes      = $item->get_taxes();
 					$refund_tax = array();
 
 					if ( ! empty( $taxes['total'] ) ) {
 						foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
-							$refund_tax[ $tax_id ] = $tax_amount * -1;
+							// Prorate tax based on remaining quantity
+							$tax_per_unit = $tax_amount / $original_qty;
+							$refund_tax[ $tax_id ] = ( $tax_per_unit * $remaining_qty ) * -1;
 						}
 					}
 
+					// Prorate the refund total based on remaining quantity
+					$total_per_unit = $item->get_total() / $original_qty;
+					$refund_total = $total_per_unit * $remaining_qty;
+
 					$line_items[ $item_id ] = array(
-						'qty'          => $item->get_quantity(),
-						'refund_total' => $item->get_total() * -1,
+						'qty'          => $remaining_qty,
+						'refund_total' => $refund_total * -1,
 						'refund_tax'   => $refund_tax,
 					);
 				}
 			} else {
 				// Refund partial quantities of items
 				foreach ( $items as $item_id => $item ) {
-					$quantity = $item->get_quantity();
+					// Calculate remaining quantity after previous refunds
+					$original_qty = $item->get_quantity();
+					$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
+					$remaining_qty = $original_qty - $refunded_qty;
 
-					// Only refund line items with quantity > 1
-					if ( 'line_item' === $item->get_type() && $quantity > 1 ) {
-						// Refund between 1 and quantity-1 items
-						$refund_qty    = wp_rand( 1, $quantity - 1 );
-						$refund_amount = ( $item->get_total() / $quantity ) * $refund_qty;
+					// Skip if nothing left to refund or if only 1 remaining
+					if ( $remaining_qty <= 1 ) {
+						continue;
+					}
+
+					// Only refund line items with remaining quantity > 1
+					if ( 'line_item' === $item->get_type() ) {
+						// Refund between 1 and remaining_qty-1 items
+						$refund_qty    = wp_rand( 1, $remaining_qty - 1 );
+						$refund_amount = ( $item->get_total() / $original_qty ) * $refund_qty;
 						$taxes         = $item->get_taxes();
 						$refund_tax    = array();
 
 						if ( ! empty( $taxes['total'] ) ) {
 							foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
-								$refund_tax[ $tax_id ] = ( $tax_amount / $quantity ) * $refund_qty * -1;
+								$refund_tax[ $tax_id ] = ( $tax_amount / $original_qty ) * $refund_qty * -1;
 							}
 						}
 
@@ -471,25 +527,47 @@ class Order extends Generator {
 					}
 				}
 
-				// If no items were added (all quantities were 1), refund one complete item
+				// If no items were added, refund one complete remaining item
 				if ( empty( $line_items ) && count( $items ) > 0 ) {
+					// Find an item with remaining quantity
 					$items_array = array_values( $items );
-					$item        = $items_array[ array_rand( $items_array ) ];
-					$item_id     = $item->get_id();
-					$taxes       = $item->get_taxes();
-					$refund_tax  = array();
+					shuffle( $items_array );
 
-					if ( ! empty( $taxes['total'] ) ) {
-						foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
-							$refund_tax[ $tax_id ] = $tax_amount * -1;
+					foreach ( $items_array as $item ) {
+						$item_id = $item->get_id();
+
+						// Calculate remaining quantity after previous refunds
+						$original_qty = $item->get_quantity();
+						$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
+						$remaining_qty = $original_qty - $refunded_qty;
+
+						// Skip if nothing left to refund
+						if ( $remaining_qty <= 0 ) {
+							continue;
 						}
-					}
 
-					$line_items[ $item_id ] = array(
-						'qty'          => $item->get_quantity(),
-						'refund_total' => $item->get_total() * -1,
-						'refund_tax'   => $refund_tax,
-					);
+						$taxes      = $item->get_taxes();
+						$refund_tax = array();
+
+						if ( ! empty( $taxes['total'] ) ) {
+							foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
+								// Prorate tax based on remaining quantity
+								$tax_per_unit = $tax_amount / $original_qty;
+								$refund_tax[ $tax_id ] = ( $tax_per_unit * $remaining_qty ) * -1;
+							}
+						}
+
+						// Prorate the refund total based on remaining quantity
+						$total_per_unit = $item->get_total() / $original_qty;
+						$refund_total = $total_per_unit * $remaining_qty;
+
+						$line_items[ $item_id ] = array(
+							'qty'          => $remaining_qty,
+							'refund_total' => $refund_total * -1,
+							'refund_tax'   => $refund_tax,
+						);
+						break; // Only refund one item
+					}
 				}
 			}
 		}

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -165,11 +165,12 @@ class Order extends Generator {
 				}
 
 				if ( $should_refund ) {
-					$is_partial = self::create_refund( $order );
+					// Create first refund with date within 2 months of completion
+					$first_refund = self::create_refund( $order );
 
 					// Some partial refunds get a second refund (always partial)
-					if ( $is_partial && wp_rand( 1, 100 ) <= self::SECOND_REFUND_PROBABILITY ) {
-						self::create_refund( $order, true );
+					if ( $first_refund && wp_rand( 1, 100 ) <= self::SECOND_REFUND_PROBABILITY ) {
+						self::create_refund( $order, true, $first_refund );
 					}
 				}
 			}
@@ -368,11 +369,12 @@ class Order extends Generator {
 	/**
 	 * Create a refund for an order (either full or partial).
 	 *
-	 * @param \WC_Order $order The order to refund.
-	 * @param bool      $force_partial Force partial refund only.
-	 * @return bool True if partial refund, false if full refund or on failure.
+	 * @param \WC_Order      $order The order to refund.
+	 * @param bool           $force_partial Force partial refund only.
+	 * @param \WC_Order_Refund|null $previous_refund Previous refund to base date on (for second refunds).
+	 * @return \WC_Order_Refund|false Refund object on success, false on failure.
 	 */
-	protected static function create_refund( $order, $force_partial = false ) {
+	protected static function create_refund( $order, $force_partial = false, $previous_refund = null ) {
 		if ( ! $order instanceof \WC_Order ) {
 			error_log( "Error: Order is not an instance of \WC_Order: " . print_r( $order, true ) );
 			return false;
@@ -672,6 +674,21 @@ class Order extends Generator {
 			);
 		}
 
+		// Calculate refund date
+		if ( $previous_refund ) {
+			// Second refund: within 1 month of first refund
+			$base_date = $previous_refund->get_date_created();
+			$max_days = 30; // 1 month
+		} else {
+			// First refund: within 2 months of order completion
+			$base_date = $order->get_date_completed();
+			$max_days = 60; // 2 months
+		}
+
+		// Generate random date within the allowed timeframe
+		$random_days = wp_rand( 0, $max_days );
+		$refund_date = date( 'Y-m-d H:i:s', strtotime( $base_date->date( 'Y-m-d H:i:s' ) ) + ( $random_days * DAY_IN_SECONDS ) );
+
 		// Create the refund
 		$refund = wc_create_refund(
 			array(
@@ -679,6 +696,7 @@ class Order extends Generator {
 				'amount'     => $refund_amount,
 				'reason'     => $reason,
 				'line_items' => $line_items,
+				'date_created' => $refund_date,
 			)
 		);
 		if ( is_wp_error( $refund ) ) {
@@ -701,6 +719,6 @@ class Order extends Generator {
 			$order->save();
 		}
 
-		return ! $is_full_refund;
+		return $refund;
 	}
 }

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -18,6 +18,22 @@ class Order extends Generator {
 	const SECOND_REFUND_PROBABILITY = 25;
 
 	/**
+	 * Maximum ratio of order total that can be refunded in a partial refund.
+	 * Ensures partial refunds don't exceed 50% of order total.
+	 */
+	const MAX_PARTIAL_REFUND_RATIO = 0.5;
+
+	/**
+	 * Maximum days after order completion for first refund (2 months).
+	 */
+	const FIRST_REFUND_MAX_DAYS = 60;
+
+	/**
+	 * Maximum days after first refund for second refund (1 month).
+	 */
+	const SECOND_REFUND_MAX_DAYS = 30;
+
+	/**
 	 * Return a new order.
 	 *
 	 * @param bool  $save Save the object before returning or not.
@@ -348,6 +364,10 @@ class Order extends Generator {
 
 		// If no coupons exist, create 6 (3 fixed, 3 percentage)
 		if ( false === $coupon ) {
+			if ( class_exists( 'WP_CLI' ) ) {
+				\WP_CLI::log( 'No coupons found. Creating 6 coupons (3 fixed cart $5-$50, 3 percentage 5%-25%)...' );
+			}
+
 			// Create 3 fixed cart coupons ($5-$50)
 			$fixed_result = Coupon::batch( 3, array( 'min' => 5, 'max' => 50, 'discount_type' => 'fixed_cart' ) );
 
@@ -386,270 +406,59 @@ class Order extends Generator {
 			$force_partial = true;
 		}
 
-		// Calculate already refunded quantities per item
-		$refunded_qty_by_item = array();
-		foreach ( $existing_refunds as $existing_refund ) {
-			foreach ( $existing_refund->get_items( array( 'line_item', 'fee' ) ) as $refund_item ) {
-				$item_id = $refund_item->get_meta( '_refunded_item_id' );
-				if ( ! $item_id ) {
-					continue;
-				}
-				if ( ! isset( $refunded_qty_by_item[ $item_id ] ) ) {
-					$refunded_qty_by_item[ $item_id ] = 0;
-				}
-				$refunded_qty_by_item[ $item_id ] += abs( $refund_item->get_quantity() );
-			}
-		}
+		// Calculate already refunded quantities
+		$refunded_qty_by_item = self::calculate_refunded_quantities( $existing_refunds );
 
-		// Refunds will be split evenly between partial and full (unless forced)
+		// Determine refund type (full or partial)
 		$is_full_refund = $force_partial ? false : (bool) wp_rand( 0, 1 );
 
-		$line_items = array();
+		// Build refund line items
+		$line_items = $is_full_refund
+			? self::build_full_refund_items( $order, $refunded_qty_by_item )
+			: self::build_partial_refund_items( $order, $refunded_qty_by_item );
 
-		if ( $is_full_refund ) {
-			// Full refund - include all line items and fees
-			foreach ( $order->get_items( array( 'line_item', 'fee' ) ) as $item_id => $item ) {
-				// Calculate remaining quantity after previous refunds
-				$original_qty = $item->get_quantity();
-				$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
-				$remaining_qty = $original_qty - $refunded_qty;
-
-				// Skip if nothing left to refund or invalid quantity
-				if ( $remaining_qty <= 0 || $original_qty <= 0 ) {
-					continue;
-				}
-
-				$taxes      = $item->get_taxes();
-				$refund_tax = array();
-
-				if ( ! empty( $taxes['total'] ) ) {
-					foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
-						// Prorate tax based on remaining quantity
-						$tax_per_unit = $tax_amount / $original_qty;
-						$refund_tax[ $tax_id ] = ( $tax_per_unit * $remaining_qty ) * -1;
-					}
-				}
-
-				// Prorate the refund total based on remaining quantity
-				$total_per_unit = $item->get_total() / $original_qty;
-				$refund_total = $total_per_unit * $remaining_qty;
-
-				$line_items[ $item_id ] = array(
-					'qty'          => $remaining_qty,
-					'refund_total' => $refund_total * -1,
-					'refund_tax'   => $refund_tax,
-				);
-			}
-		} else {
-			// Partial refund - randomly select items or partial quantities
-			$items = $order->get_items( array( 'line_item', 'fee' ) );
-
-			// Decide whether to refund full items or partial quantities
-			$refund_full_items = (bool) wp_rand( 0, 1 );
-
-			if ( $refund_full_items && count( $items ) > 2 ) {
-				// Refund a random subset of items completely (requires at least 3 items)
-				$items_array  = array_values( $items );
-				$num_to_refund = wp_rand( 1, count( $items_array ) - 1 );
-				$items_to_refund = array_rand( $items_array, $num_to_refund );
-
-				// Ensure $items_to_refund is always an array for consistent iteration
-				if ( ! is_array( $items_to_refund ) ) {
-					$items_to_refund = array( $items_to_refund );
-				}
-
-				foreach ( $items_to_refund as $index ) {
-					$item       = $items_array[ $index ];
-					$item_id    = $item->get_id();
-
-					// Calculate remaining quantity after previous refunds
-					$original_qty = $item->get_quantity();
-					$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
-					$remaining_qty = $original_qty - $refunded_qty;
-
-					// Skip if nothing left to refund or invalid quantity
-					if ( $remaining_qty <= 0 || $original_qty <= 0 ) {
-						continue;
-					}
-
-					$taxes      = $item->get_taxes();
-					$refund_tax = array();
-
-					if ( ! empty( $taxes['total'] ) ) {
-						foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
-							// Prorate tax based on remaining quantity
-							$tax_per_unit = $tax_amount / $original_qty;
-							$refund_tax[ $tax_id ] = ( $tax_per_unit * $remaining_qty ) * -1;
-						}
-					}
-
-					// Prorate the refund total based on remaining quantity
-					$total_per_unit = $item->get_total() / $original_qty;
-					$refund_total = $total_per_unit * $remaining_qty;
-
-					$line_items[ $item_id ] = array(
-						'qty'          => $remaining_qty,
-						'refund_total' => $refund_total * -1,
-						'refund_tax'   => $refund_tax,
-					);
-				}
-			} else {
-				// Refund partial quantities of items
-				foreach ( $items as $item_id => $item ) {
-					// Calculate remaining quantity after previous refunds
-					$original_qty = $item->get_quantity();
-					$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
-					$remaining_qty = $original_qty - $refunded_qty;
-
-					// Skip if nothing left to refund, if only 1 remaining, or invalid quantity
-					if ( $remaining_qty <= 1 || $original_qty <= 0 ) {
-						continue;
-					}
-
-					// Only refund line items with remaining quantity > 1
-					if ( 'line_item' === $item->get_type() ) {
-						// Refund between 1 and remaining_qty-1 items
-						$refund_qty    = wp_rand( 1, $remaining_qty - 1 );
-						$refund_amount = ( $item->get_total() / $original_qty ) * $refund_qty;
-						$taxes         = $item->get_taxes();
-						$refund_tax    = array();
-
-						if ( ! empty( $taxes['total'] ) ) {
-							foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
-								$refund_tax[ $tax_id ] = ( $tax_amount / $original_qty ) * $refund_qty * -1;
-							}
-						}
-
-						$line_items[ $item_id ] = array(
-							'qty'          => $refund_qty,
-							'refund_total' => $refund_amount * -1,
-							'refund_tax'   => $refund_tax,
-						);
-						break; // Only refund one item partially
-					}
-				}
-
-				// If no items were added, refund one complete remaining item
-				if ( empty( $line_items ) && count( $items ) > 0 ) {
-					// Find an item with remaining quantity
-					$items_array = array_values( $items );
-					shuffle( $items_array );
-
-					foreach ( $items_array as $item ) {
-						$item_id = $item->get_id();
-
-						// Calculate remaining quantity after previous refunds
-						$original_qty = $item->get_quantity();
-						$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
-						$remaining_qty = $original_qty - $refunded_qty;
-
-						// Skip if nothing left to refund or invalid quantity
-						if ( $remaining_qty <= 0 || $original_qty <= 0 ) {
-							continue;
-						}
-
-						$taxes      = $item->get_taxes();
-						$refund_tax = array();
-
-						if ( ! empty( $taxes['total'] ) ) {
-							foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
-								// Prorate tax based on remaining quantity
-								$tax_per_unit = $tax_amount / $original_qty;
-								$refund_tax[ $tax_id ] = ( $tax_per_unit * $remaining_qty ) * -1;
-							}
-						}
-
-						// Prorate the refund total based on remaining quantity
-						$total_per_unit = $item->get_total() / $original_qty;
-						$refund_total = $total_per_unit * $remaining_qty;
-
-						$line_items[ $item_id ] = array(
-							'qty'          => $remaining_qty,
-							'refund_total' => $refund_total * -1,
-							'refund_tax'   => $refund_tax,
-						);
-						break; // Only refund one item
-					}
-				}
-			}
-		}
-
-		// Ensure we have items to refund - if not, log and return false
+		// Ensure we have items to refund
 		if ( empty( $line_items ) ) {
-			error_log( sprintf( 'Refund skipped for order %d: No line items to refund. Order has %d items.', $order->get_id(), count( $order->get_items( array( 'line_item', 'fee' ) ) ) ) );
+			error_log( sprintf(
+				'Refund skipped for order %d: No line items to refund. Order has %d items.',
+				$order->get_id(),
+				count( $order->get_items( array( 'line_item', 'fee' ) ) )
+			) );
 			return false;
 		}
 
-		// Calculate the total refund amount from line items and count items
-		$refund_amount = 0;
-		$total_items   = 0;
-		$total_qty     = 0;
+		// Calculate refund totals
+		$totals = self::calculate_refund_totals( $line_items );
+		$refund_amount = $totals['amount'];
+		$total_items = $totals['total_items'];
+		$total_qty = $totals['total_qty'];
 
-		foreach ( $line_items as $item_id => $item_data ) {
-			// Add item total: refund amounts are stored as negative, convert to positive for total calculation
-			$refund_amount += abs( $item_data['refund_total'] );
-
-			// Count items and quantities
-			$total_items++;
-			$total_qty += $item_data['qty'];
-
-			// Add tax amounts (already negative)
-			if ( ! empty( $item_data['refund_tax'] ) ) {
-				foreach ( $item_data['refund_tax'] as $tax_amount ) {
-					$refund_amount += abs( $tax_amount );
-				}
-			}
-		}
-
-		// For full refunds, use the order's actual remaining total to avoid rounding discrepancies
+		// For full refunds, use order's actual remaining total to avoid rounding discrepancies
 		if ( $is_full_refund ) {
-			$refund_amount = $order->get_total() - $order->get_total_refunded();
+			$refund_amount = round( $order->get_total() - $order->get_total_refunded(), 2 );
 		}
 
-		// Round refund amount to 2 decimal places for currency precision
-		$refund_amount = round( $refund_amount, 2 );
-
-		// For partial refunds, ensure refund is < 50% of order total by removing items if needed
+		// For partial refunds, ensure refund is < 50% of order total
 		if ( ! $is_full_refund ) {
-			$max_partial_refund = $order->get_total() * 0.5;
+			$max_partial_refund = $order->get_total() * self::MAX_PARTIAL_REFUND_RATIO;
 
-			// If refund exceeds 50%, remove items until it's under 50%
+			// Remove items until refund is under threshold
 			while ( $refund_amount >= $max_partial_refund && count( $line_items ) > 1 ) {
-				// Remove a random item from the refund
-				$item_id_to_remove = array_rand( $line_items );
-				unset( $line_items[ $item_id_to_remove ] );
-
-				// Recalculate refund amount and counts
-				$refund_amount = 0;
-				$total_items = 0;
-				$total_qty = 0;
-
-				foreach ( $line_items as $item_id => $item_data ) {
-					$refund_amount += abs( $item_data['refund_total'] );
-					$total_items++;
-					$total_qty += $item_data['qty'];
-
-					if ( ! empty( $item_data['refund_tax'] ) ) {
-						foreach ( $item_data['refund_tax'] as $tax_amount ) {
-							$refund_amount += abs( $tax_amount );
-						}
-					}
-				}
-
-				$refund_amount = round( $refund_amount, 2 );
+				unset( $line_items[ array_rand( $line_items ) ] );
+				$totals = self::calculate_refund_totals( $line_items );
+				$refund_amount = $totals['amount'];
+				$total_items = $totals['total_items'];
+				$total_qty = $totals['total_qty'];
 			}
 		}
 
-		// Calculate maximum refundable amount (order total minus already refunded)
-		$max_refund = $order->get_total() - $order->get_total_refunded();
-		$max_refund = round( $max_refund, 2 );
-
-		// Cap refund amount to maximum available (prevents rounding errors from exceeding order total)
+		// Cap refund amount to maximum available
+		$max_refund = round( $order->get_total() - $order->get_total_refunded(), 2 );
 		if ( $refund_amount > $max_refund ) {
 			$refund_amount = $max_refund;
 		}
 
-		// Validate refund amount is greater than 0
+		// Validate refund amount
 		if ( $refund_amount <= 0 ) {
 			error_log( sprintf(
 				'Refund skipped for order %d: Invalid refund amount (%s). Order total: %s, Already refunded: %s',
@@ -662,43 +471,30 @@ class Order extends Generator {
 		}
 
 		// Create refund reason
-		if ( $is_full_refund ) {
-			$reason = 'Full refund';
-		} else {
-			$reason = sprintf(
+		$reason = $is_full_refund
+			? 'Full refund'
+			: sprintf(
 				'Partial refund - %d %s, %d %s',
 				$total_items,
 				$total_items === 1 ? 'product' : 'products',
 				$total_qty,
 				$total_qty === 1 ? 'item' : 'items'
 			);
-		}
 
 		// Calculate refund date
-		if ( $previous_refund ) {
-			// Second refund: within 1 month of first refund
-			$base_date = $previous_refund->get_date_created();
-			$max_days = 30; // 1 month
-		} else {
-			// First refund: within 2 months of order completion
-			$base_date = $order->get_date_completed();
-			$max_days = 60; // 2 months
-		}
-
-		// Generate random date within the allowed timeframe
-		$random_days = wp_rand( 0, $max_days );
-		$refund_date = date( 'Y-m-d H:i:s', strtotime( $base_date->date( 'Y-m-d H:i:s' ) ) + ( $random_days * DAY_IN_SECONDS ) );
+		$refund_date = self::calculate_refund_date( $order, $previous_refund );
 
 		// Create the refund
 		$refund = wc_create_refund(
 			array(
-				'order_id'   => $order->get_id(),
-				'amount'     => $refund_amount,
-				'reason'     => $reason,
-				'line_items' => $line_items,
+				'order_id'     => $order->get_id(),
+				'amount'       => $refund_amount,
+				'reason'       => $reason,
+				'line_items'   => $line_items,
 				'date_created' => $refund_date,
 			)
 		);
+
 		if ( is_wp_error( $refund ) ) {
 			error_log( sprintf(
 				"Refund creation failed for order %d:\nError: %s\nCalculated Amount: %s\nOrder Total: %s\nOrder Refunded Total: %s\nReason: %s\nLine Items: %s",
@@ -720,5 +516,225 @@ class Order extends Generator {
 		}
 
 		return $refund;
+	}
+
+	/**
+	 * Calculate already refunded quantities per item from existing refunds.
+	 *
+	 * @param array $existing_refunds Array of existing refund objects.
+	 * @return array Associative array of item_id => refunded_quantity.
+	 */
+	protected static function calculate_refunded_quantities( $existing_refunds ) {
+		$refunded_qty_by_item = array();
+
+		foreach ( $existing_refunds as $existing_refund ) {
+			foreach ( $existing_refund->get_items( array( 'line_item', 'fee' ) ) as $refund_item ) {
+				$item_id = $refund_item->get_meta( '_refunded_item_id' );
+				if ( ! $item_id ) {
+					continue;
+				}
+				if ( ! isset( $refunded_qty_by_item[ $item_id ] ) ) {
+					$refunded_qty_by_item[ $item_id ] = 0;
+				}
+				$refunded_qty_by_item[ $item_id ] += abs( $refund_item->get_quantity() );
+			}
+		}
+
+		return $refunded_qty_by_item;
+	}
+
+	/**
+	 * Build a refund line item with proper tax and total calculations.
+	 *
+	 * @param \WC_Order_Item $item Order item to refund.
+	 * @param int            $refund_qty Quantity to refund.
+	 * @param int            $original_qty Original quantity of the item.
+	 * @return array Refund line item data.
+	 */
+	protected static function build_refund_line_item( $item, $refund_qty, $original_qty ) {
+		$taxes      = $item->get_taxes();
+		$refund_tax = array();
+
+		// Prorate tax based on refund quantity
+		if ( ! empty( $taxes['total'] ) && $original_qty > 0 ) {
+			foreach ( $taxes['total'] as $tax_id => $tax_amount ) {
+				$tax_per_unit = $tax_amount / $original_qty;
+				$refund_tax[ $tax_id ] = ( $tax_per_unit * $refund_qty ) * -1;
+			}
+		}
+
+		// Prorate the refund total based on refund quantity
+		$total_per_unit = $original_qty > 0 ? $item->get_total() / $original_qty : 0;
+		$refund_total = $total_per_unit * $refund_qty;
+
+		return array(
+			'qty'          => $refund_qty,
+			'refund_total' => $refund_total * -1,
+			'refund_tax'   => $refund_tax,
+		);
+	}
+
+	/**
+	 * Build line items for a full refund.
+	 *
+	 * @param \WC_Order $order Order to refund.
+	 * @param array     $refunded_qty_by_item Already refunded quantities.
+	 * @return array Refund line items.
+	 */
+	protected static function build_full_refund_items( $order, $refunded_qty_by_item ) {
+		$line_items = array();
+
+		foreach ( $order->get_items( array( 'line_item', 'fee' ) ) as $item_id => $item ) {
+			$original_qty = $item->get_quantity();
+			$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
+			$remaining_qty = $original_qty - $refunded_qty;
+
+			// Skip if nothing left to refund or invalid quantity
+			if ( $remaining_qty <= 0 || $original_qty <= 0 ) {
+				continue;
+			}
+
+			$line_items[ $item_id ] = self::build_refund_line_item( $item, $remaining_qty, $original_qty );
+		}
+
+		return $line_items;
+	}
+
+	/**
+	 * Build line items for a partial refund.
+	 *
+	 * @param \WC_Order $order Order to refund.
+	 * @param array     $refunded_qty_by_item Already refunded quantities.
+	 * @return array Refund line items.
+	 */
+	protected static function build_partial_refund_items( $order, $refunded_qty_by_item ) {
+		$items = $order->get_items( array( 'line_item', 'fee' ) );
+		$line_items = array();
+
+		// Decide whether to refund full items or partial quantities
+		$refund_full_items = (bool) wp_rand( 0, 1 );
+
+		if ( $refund_full_items && count( $items ) > 2 ) {
+			// Refund a random subset of items completely (requires at least 3 items)
+			$items_array  = array_values( $items );
+			$num_to_refund = wp_rand( 1, count( $items_array ) - 1 );
+			$items_to_refund = array_rand( $items_array, $num_to_refund );
+
+			// Ensure $items_to_refund is always an array for consistent iteration
+			if ( ! is_array( $items_to_refund ) ) {
+				$items_to_refund = array( $items_to_refund );
+			}
+
+			foreach ( $items_to_refund as $index ) {
+				$item = $items_array[ $index ];
+				$item_id = $item->get_id();
+				$original_qty = $item->get_quantity();
+				$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
+				$remaining_qty = $original_qty - $refunded_qty;
+
+				// Skip if nothing left to refund or invalid quantity
+				if ( $remaining_qty <= 0 || $original_qty <= 0 ) {
+					continue;
+				}
+
+				$line_items[ $item_id ] = self::build_refund_line_item( $item, $remaining_qty, $original_qty );
+			}
+		} else {
+			// Refund partial quantities of items
+			foreach ( $items as $item_id => $item ) {
+				$original_qty = $item->get_quantity();
+				$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
+				$remaining_qty = $original_qty - $refunded_qty;
+
+				// Skip if nothing left to refund, if only 1 remaining, or invalid quantity
+				if ( $remaining_qty <= 1 || $original_qty <= 0 ) {
+					continue;
+				}
+
+				// Only refund line items with remaining quantity > 1
+				if ( 'line_item' === $item->get_type() ) {
+					$refund_qty = wp_rand( 1, $remaining_qty - 1 );
+					$line_items[ $item_id ] = self::build_refund_line_item( $item, $refund_qty, $original_qty );
+					break; // Only refund one item partially
+				}
+			}
+
+			// If no items were added, refund one complete remaining item
+			if ( empty( $line_items ) && count( $items ) > 0 ) {
+				$items_array = array_values( $items );
+				shuffle( $items_array );
+
+				foreach ( $items_array as $item ) {
+					$item_id = $item->get_id();
+					$original_qty = $item->get_quantity();
+					$refunded_qty = isset( $refunded_qty_by_item[ $item_id ] ) ? $refunded_qty_by_item[ $item_id ] : 0;
+					$remaining_qty = $original_qty - $refunded_qty;
+
+					// Skip if nothing left to refund or invalid quantity
+					if ( $remaining_qty <= 0 || $original_qty <= 0 ) {
+						continue;
+					}
+
+					$line_items[ $item_id ] = self::build_refund_line_item( $item, $remaining_qty, $original_qty );
+					break; // Only refund one item
+				}
+			}
+		}
+
+		return $line_items;
+	}
+
+	/**
+	 * Calculate total refund amount and item counts from line items.
+	 *
+	 * @param array $line_items Refund line items.
+	 * @return array Array containing 'amount', 'total_items', and 'total_qty'.
+	 */
+	protected static function calculate_refund_totals( $line_items ) {
+		$refund_amount = 0;
+		$total_items   = 0;
+		$total_qty     = 0;
+
+		foreach ( $line_items as $item_data ) {
+			// Add item total: refund amounts are stored as negative, convert to positive for total calculation
+			$refund_amount += abs( $item_data['refund_total'] );
+			$total_items++;
+			$total_qty += $item_data['qty'];
+
+			// Add tax amounts
+			if ( ! empty( $item_data['refund_tax'] ) ) {
+				foreach ( $item_data['refund_tax'] as $tax_amount ) {
+					$refund_amount += abs( $tax_amount );
+				}
+			}
+		}
+
+		return array(
+			'amount'      => round( $refund_amount, 2 ),
+			'total_items' => $total_items,
+			'total_qty'   => $total_qty,
+		);
+	}
+
+	/**
+	 * Calculate a realistic refund date based on order completion or previous refund.
+	 *
+	 * @param \WC_Order             $order Order being refunded.
+	 * @param \WC_Order_Refund|null $previous_refund Previous refund (for second refunds).
+	 * @return string Refund date in 'Y-m-d H:i:s' format.
+	 */
+	protected static function calculate_refund_date( $order, $previous_refund = null ) {
+		if ( $previous_refund ) {
+			// Second refund: within 1 month of first refund
+			$base_date = $previous_refund->get_date_created();
+			$max_days = self::SECOND_REFUND_MAX_DAYS;
+		} else {
+			// First refund: within 2 months of order completion
+			$base_date = $order->get_date_completed();
+			$max_days = self::FIRST_REFUND_MAX_DAYS;
+		}
+
+		$random_days = wp_rand( 0, $max_days );
+		return date( 'Y-m-d H:i:s', strtotime( $base_date->date( 'Y-m-d H:i:s' ) ) + ( $random_days * DAY_IN_SECONDS ) );
 	}
 }

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -521,13 +521,26 @@ class Order extends Generator {
 			}
 		}
 
+		// Round refund amount to 2 decimal places for currency precision
+		$refund_amount = round( $refund_amount, 2 );
+
+		// Calculate maximum refundable amount (order total minus already refunded)
+		$max_refund = $order->get_total() - $order->get_total_refunded();
+		$max_refund = round( $max_refund, 2 );
+
+		// Cap refund amount to maximum available (prevents rounding errors from exceeding order total)
+		if ( $refund_amount > $max_refund ) {
+			$refund_amount = $max_refund;
+		}
+
 		// Validate refund amount is greater than 0
 		if ( $refund_amount <= 0 ) {
 			error_log( sprintf(
-				'Refund skipped for order %d: Invalid refund amount (%s). Order total: %s',
+				'Refund skipped for order %d: Invalid refund amount (%s). Order total: %s, Already refunded: %s',
 				$order->get_id(),
 				$refund_amount,
-				$order->get_total()
+				$order->get_total(),
+				$order->get_total_refunded()
 			) );
 			return false;
 		}
@@ -556,10 +569,12 @@ class Order extends Generator {
 		);
 		if ( is_wp_error( $refund ) ) {
 			error_log( sprintf(
-				"Refund creation failed for order %d:\nError: %s\nAmount: %s\nReason: %s\nLine Items: %s",
+				"Refund creation failed for order %d:\nError: %s\nCalculated Amount: %s\nOrder Total: %s\nOrder Refunded Total: %s\nReason: %s\nLine Items: %s",
 				$order->get_id(),
 				$refund->get_error_message(),
 				$refund_amount,
+				$order->get_total(),
+				$order->get_total_refunded(),
 				$reason,
 				print_r( $line_items, true )
 			) );

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -18,6 +18,27 @@ class Order extends Generator {
 	const SECOND_REFUND_PROBABILITY = 25;
 
 	/**
+	 * Cached product IDs for batch operations.
+	 *
+	 * @var array|null
+	 */
+	protected static $batch_product_ids = null;
+
+	/**
+	 * Cached coupon IDs for batch operations.
+	 *
+	 * @var array|null
+	 */
+	protected static $batch_coupon_ids = null;
+
+	/**
+	 * Cached customer IDs for batch operations.
+	 *
+	 * @var array|null
+	 */
+	protected static $batch_customer_ids = null;
+
+	/**
 	 * Return a new order.
 	 *
 	 * @param bool  $save Save the object before returning or not.
@@ -202,12 +223,18 @@ class Order extends Generator {
 			return $amount;
 		}
 
+		// Initialize batch cache to avoid repeated queries
+		self::init_batch_cache( $args );
+
 		$order_ids = array();
 
 		for ( $i = 1; $i <= $amount; $i ++ ) {
 			$order       = self::generate( true, $args );
 			$order_ids[] = $order->get_id();
 		}
+
+		// Clear batch cache after generation
+		self::clear_batch_cache();
 
 		return $order_ids;
 	}
@@ -224,9 +251,15 @@ class Order extends Generator {
 		$existing = (bool) wp_rand( 0, 1 );
 
 		if ( $existing ) {
-			$total_users = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->users}" );
-			$offset      = wp_rand( 0, $total_users );
-			$user_id     = (int) $wpdb->get_var( "SELECT ID FROM {$wpdb->users} ORDER BY rand() LIMIT $offset, 1" ); // phpcs:ignore
+			// Use cached customer IDs if available (batch mode)
+			if ( null !== self::$batch_customer_ids && ! empty( self::$batch_customer_ids ) ) {
+				$user_id = self::$batch_customer_ids[ array_rand( self::$batch_customer_ids ) ];
+			} else {
+				// Fallback to direct query for single order generation
+				$total_users = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->users}" );
+				$offset      = wp_rand( 0, $total_users );
+				$user_id     = (int) $wpdb->get_var( "SELECT ID FROM {$wpdb->users} ORDER BY rand() LIMIT $offset, 1" ); // phpcs:ignore
+			}
 			return new \WC_Customer( $user_id );
 		}
 
@@ -298,27 +331,51 @@ class Order extends Generator {
 
 		$products = array();
 
-		$num_existing_products = (int) $wpdb->get_var(
-			"SELECT COUNT( DISTINCT ID )
-			FROM {$wpdb->posts}
-			WHERE 1=1
-			AND post_type='product'
-			AND post_status='publish'"
-		);
+		// Use cached product IDs if available (batch mode)
+		if ( null !== self::$batch_product_ids && ! empty( self::$batch_product_ids ) ) {
+			$num_existing_products = count( self::$batch_product_ids );
+			$num_products_to_get   = wp_rand( $min_amount, $max_amount );
 
-		$num_products_to_get = wp_rand( $min_amount, $max_amount );
+			if ( $num_products_to_get > $num_existing_products ) {
+				$num_products_to_get = $num_existing_products;
+			}
 
-		if ( $num_products_to_get > $num_existing_products ) {
-			$num_products_to_get = $num_existing_products;
+			// Get random product IDs from cache
+			$random_keys = array_rand( self::$batch_product_ids, $num_products_to_get );
+			if ( ! is_array( $random_keys ) ) {
+				$random_keys = array( $random_keys );
+			}
+
+			$product_ids = array();
+			foreach ( $random_keys as $key ) {
+				$product_ids[] = self::$batch_product_ids[ $key ];
+			}
+		} else {
+			// Fallback to direct query for single order generation
+			$num_existing_products = (int) $wpdb->get_var(
+				"SELECT COUNT( DISTINCT ID )
+				FROM {$wpdb->posts}
+				WHERE 1=1
+				AND post_type='product'
+				AND post_status='publish'"
+			);
+
+			$num_products_to_get = wp_rand( $min_amount, $max_amount );
+
+			if ( $num_products_to_get > $num_existing_products ) {
+				$num_products_to_get = $num_existing_products;
+			}
+
+			$query = new \WC_Product_Query( array(
+				'limit'   => $num_products_to_get,
+				'return'  => 'ids',
+				'orderby' => 'rand',
+			) );
+
+			$product_ids = $query->get_products();
 		}
 
-		$query = new \WC_Product_Query( array(
-			'limit'   => $num_products_to_get,
-			'return'  => 'ids',
-			'orderby' => 'rand',
-		) );
-
-		foreach ( $query->get_products() as $product_id ) {
+		foreach ( $product_ids as $product_id ) {
 			$product = wc_get_product( $product_id );
 
 			if ( $product->is_type( 'variable' ) ) {
@@ -343,8 +400,8 @@ class Order extends Generator {
 	 * @return \WC_Coupon|false Coupon object or false if none available.
 	 */
 	protected static function get_or_create_coupon() {
-		// Try to get a random existing coupon
-		$coupon = Coupon::get_random();
+		// Try to get a random existing coupon (pass cached IDs if available)
+		$coupon = Coupon::get_random( self::$batch_coupon_ids );
 
 		// If no coupons exist, create 6 (3 fixed, 3 percentage)
 		if ( false === $coupon ) {
@@ -359,8 +416,13 @@ class Order extends Generator {
 				return false;
 			}
 
+			// Update batch cache with newly created coupon IDs
+			if ( null !== self::$batch_coupon_ids ) {
+				self::$batch_coupon_ids = array_merge( self::$batch_coupon_ids, $fixed_result, $percent_result );
+			}
+
 			// Now get a random coupon from the ones we just created
-			$coupon = Coupon::get_random();
+			$coupon = Coupon::get_random( self::$batch_coupon_ids );
 		}
 
 		return $coupon;
@@ -720,5 +782,47 @@ class Order extends Generator {
 		}
 
 		return $refund;
+	}
+
+	/**
+	 * Initialize batch cache by pre-loading IDs for products, coupons, and customers.
+	 * This significantly improves performance when generating multiple orders by avoiding
+	 * repeated database queries.
+	 *
+	 * @param array $args Arguments passed to batch generation (used to determine what to cache).
+	 * @return void
+	 */
+	protected static function init_batch_cache( $args ) {
+		global $wpdb;
+
+		// Load all product IDs once
+		self::$batch_product_ids = $wpdb->get_col(
+			"SELECT ID FROM {$wpdb->posts}
+			WHERE post_type='product'
+			AND post_status='publish'"
+		);
+
+		// Load coupon IDs if coupon ratio is set
+		if ( isset( $args['coupon-ratio'] ) || isset( $args['coupons'] ) ) {
+			self::$batch_coupon_ids = $wpdb->get_col(
+				"SELECT ID FROM {$wpdb->posts}
+				WHERE post_type='shop_coupon'
+				AND post_status='publish'"
+			);
+		}
+
+		// Load customer IDs
+		self::$batch_customer_ids = $wpdb->get_col( "SELECT ID FROM {$wpdb->users}" );
+	}
+
+	/**
+	 * Clear batch cache after batch generation is complete.
+	 *
+	 * @return void
+	 */
+	protected static function clear_batch_cache() {
+		self::$batch_product_ids  = null;
+		self::$batch_coupon_ids   = null;
+		self::$batch_customer_ids = null;
 	}
 }

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -374,6 +374,7 @@ class Order extends Generator {
 	 */
 	protected static function create_refund( $order, $force_partial = false ) {
 		if ( ! $order instanceof \WC_Order ) {
+			error_log( "Error: Order is not an instance of \WC_Order: " . print_r( $order, true ) );
 			return false;
 		}
 
@@ -493,8 +494,9 @@ class Order extends Generator {
 			}
 		}
 
-		// If no line items to refund, return false
+		// Ensure we have items to refund - if not, log and return false
 		if ( empty( $line_items ) ) {
+			error_log( sprintf( 'Refund skipped for order %d: No line items to refund. Order has %d items.', $order->get_id(), count( $order->get_items( array( 'line_item', 'fee' ) ) ) ) );
 			return false;
 		}
 
@@ -541,8 +543,15 @@ class Order extends Generator {
 				'line_items' => $line_items,
 			)
 		);
-
 		if ( is_wp_error( $refund ) ) {
+			error_log( sprintf(
+				"Refund creation failed for order %d:\nError: %s\nAmount: %s\nReason: %s\nLine Items: %s",
+				$order->get_id(),
+				$refund->get_error_message(),
+				$refund_amount,
+				$reason,
+				print_r( $line_items, true )
+			) );
 			return false;
 		}
 

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -133,9 +133,24 @@ class Order extends Generator {
 			// Handle --refund-ratio parameter for completed orders
 			if ( ! empty( $assoc_args['refund-ratio'] ) && 'completed' === $status ) {
 				$refund_ratio = floatval( $assoc_args['refund-ratio'] );
-				// Apply refund based on ratio
-				if ( $refund_ratio > 0 && ( $refund_ratio >= 1.0 || ( mt_rand() / mt_getrandmax() ) < $refund_ratio ) ) {
-					self::create_refund( $order );
+				$should_refund = false;
+
+				if ( $refund_ratio >= 1.0 ) {
+					// Always refund if ratio is 1.0 or higher
+					$should_refund = true;
+				} elseif ( $refund_ratio > 0 ) {
+					// Use random chance for ratios between 0 and 1
+					$random = mt_rand() / mt_getrandmax();
+					$should_refund = $random < $refund_ratio;
+				}
+
+				if ( $should_refund ) {
+					$is_partial = self::create_refund( $order );
+
+					// 25% of partial refunds get a second refund
+					if ( $is_partial && wp_rand( 1, 100 ) <= 25 ) {
+						self::create_refund( $order );
+					}
 				}
 			}
 		}
@@ -371,11 +386,11 @@ class Order extends Generator {
 	 * Create a refund for an order (either full or partial).
 	 *
 	 * @param \WC_Order $order The order to refund.
-	 * @return \WC_Order_Refund|null The refund object or null on failure.
+	 * @return bool True if partial refund, false if full refund or null on failure.
 	 */
 	protected static function create_refund( $order ) {
 		if ( ! $order instanceof \WC_Order ) {
-			return null;
+			return false;
 		}
 
 		// 50% chance of full refund, 50% chance of partial refund
@@ -488,11 +503,18 @@ class Order extends Generator {
 			}
 		}
 
-		// Calculate the total refund amount from line items
+		// Calculate the total refund amount from line items and count items
 		$refund_amount = 0;
+		$total_items   = 0;
+		$total_qty     = 0;
+
 		foreach ( $line_items as $item_id => $item_data ) {
 			// Add item total (already negative)
 			$refund_amount += abs( $item_data['refund_total'] );
+
+			// Count items and quantities
+			$total_items++;
+			$total_qty += $item_data['qty'];
 
 			// Add tax amounts (already negative)
 			if ( ! empty( $item_data['refund_tax'] ) ) {
@@ -502,18 +524,29 @@ class Order extends Generator {
 			}
 		}
 
+		// Create refund reason
+		if ( $is_full_refund ) {
+			$reason = 'Full refund';
+		} else {
+			$reason = sprintf(
+				'Partial refund - %d %s',
+				$total_items,
+				$total_items === 1 ? 'item' : 'items'
+			);
+		}
+
 		// Create the refund
 		$refund = wc_create_refund(
 			array(
 				'order_id'   => $order->get_id(),
 				'amount'     => $refund_amount,
-				'reason'     => $is_full_refund ? 'Full refund' : 'Partial refund',
+				'reason'     => $reason,
 				'line_items' => $line_items,
 			)
 		);
 
 		if ( is_wp_error( $refund ) ) {
-			return null;
+			return false;
 		}
 
 		// Update order status to refunded if it's a full refund
@@ -522,6 +555,6 @@ class Order extends Generator {
 			$order->save();
 		}
 
-		return $refund;
+		return ! $is_full_refund;
 	}
 }

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -129,6 +129,15 @@ class Order extends Generator {
 
 		if ( $save ) {
 			$order->save();
+
+			// Handle --refund-ratio parameter for completed orders
+			if ( ! empty( $assoc_args['refund-ratio'] ) && 'completed' === $status ) {
+				$refund_ratio = floatval( $assoc_args['refund-ratio'] );
+				// Apply refund based on ratio
+				if ( $refund_ratio > 0 && ( $refund_ratio >= 1.0 || ( mt_rand() / mt_getrandmax() ) < $refund_ratio ) ) {
+					self::create_refund( $order );
+				}
+			}
 		}
 
 		/**
@@ -356,5 +365,53 @@ class Order extends Generator {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Create a refund for an order (either full or partial).
+	 *
+	 * @param \WC_Order $order The order to refund.
+	 * @return \WC_Order_Refund|null The refund object or null on failure.
+	 */
+	protected static function create_refund( $order ) {
+		if ( ! $order instanceof \WC_Order ) {
+			return null;
+		}
+
+		$order_total = $order->get_total();
+
+		// 50% chance of full refund, 50% chance of partial refund
+		$is_full_refund = (bool) wp_rand( 0, 1 );
+
+		if ( $is_full_refund ) {
+			// Full refund
+			$refund_amount = $order_total;
+		} else {
+			// Partial refund (between 20% and 80% of order total)
+			$refund_percentage = self::$faker->numberBetween( 20, 80 ) / 100;
+			$refund_amount     = round( $order_total * $refund_percentage, 2 );
+		}
+
+		// Create the refund
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => $refund_amount,
+				'reason'     => $is_full_refund ? 'Full refund' : 'Partial refund',
+				'line_items' => array(),
+			)
+		);
+
+		if ( is_wp_error( $refund ) ) {
+			return null;
+		}
+
+		// Update order status to refunded if it's a full refund
+		if ( $is_full_refund ) {
+			$order->set_status( 'refunded' );
+			$order->save();
+		}
+
+		return $refund;
 	}
 }

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -521,6 +521,17 @@ class Order extends Generator {
 			}
 		}
 
+		// Validate refund amount is greater than 0
+		if ( $refund_amount <= 0 ) {
+			error_log( sprintf(
+				'Refund skipped for order %d: Invalid refund amount (%s). Order total: %s',
+				$order->get_id(),
+				$refund_amount,
+				$order->get_total()
+			) );
+			return false;
+		}
+
 		// Create refund reason
 		if ( $is_full_refund ) {
 			$reason = 'Full refund';

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -107,6 +107,8 @@ class Order extends Generator {
 			$coupon = self::get_or_create_coupon();
 			if ( $coupon ) {
 				$order->apply_coupon( $coupon );
+				// Recalculate totals after applying coupon
+				$order->calculate_totals( true );
 			}
 		}
 

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -321,61 +321,37 @@ class Order extends Generator {
 	 * Get a random existing coupon or create coupons if none exist.
 	 * If no coupons exist, creates 6 coupons: 3 fixed value and 3 percentage.
 	 *
-	 * @return \WC_Coupon|null Coupon object or null if none available.
+	 * @return \WC_Coupon|false Coupon object or false if none available.
 	 */
 	protected static function get_or_create_coupon() {
-		global $wpdb;
-
-		// Check if any coupons exist
-		$coupon_count = (int) $wpdb->get_var(
-			"SELECT COUNT(*)
-			FROM {$wpdb->posts}
-			WHERE post_type = 'shop_coupon'
-			AND post_status = 'publish'"
-		);
+		// Try to get a random existing coupon
+		$coupon = Coupon::get_random();
 
 		// If no coupons exist, create 6 (3 fixed, 3 percentage)
-		if ( $coupon_count === 0 ) {
+		if ( false === $coupon ) {
 			// Create 3 fixed cart coupons
 			for ( $i = 0; $i < 3; $i++ ) {
-				$coupon = Coupon::generate( false, array( 'min' => 5, 'max' => 50 ) );
-				if ( ! is_wp_error( $coupon ) ) {
-					$coupon->set_discount_type( 'fixed_cart' );
-					$coupon->save();
+				$new_coupon = Coupon::generate( false, array( 'min' => 5, 'max' => 50 ) );
+				if ( ! is_wp_error( $new_coupon ) ) {
+					$new_coupon->set_discount_type( 'fixed_cart' );
+					$new_coupon->save();
 				}
 			}
 
 			// Create 3 percentage coupons
 			for ( $i = 0; $i < 3; $i++ ) {
-				$coupon = Coupon::generate( false, array( 'min' => 5, 'max' => 25 ) );
-				if ( ! is_wp_error( $coupon ) ) {
-					$coupon->set_discount_type( 'percent' );
-					$coupon->save();
+				$new_coupon = Coupon::generate( false, array( 'min' => 5, 'max' => 25 ) );
+				if ( ! is_wp_error( $new_coupon ) ) {
+					$new_coupon->set_discount_type( 'percent' );
+					$new_coupon->save();
 				}
 			}
 
-			$coupon_count = 6;
+			// Now get a random coupon from the ones we just created
+			$coupon = Coupon::get_random();
 		}
 
-		// Get a random coupon
-		$offset    = wp_rand( 0, $coupon_count - 1 );
-		$coupon_id = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT ID
-				FROM {$wpdb->posts}
-				WHERE post_type = 'shop_coupon'
-				AND post_status = 'publish'
-				ORDER BY ID
-				LIMIT %d, 1",
-				$offset
-			)
-		);
-
-		if ( $coupon_id ) {
-			return new \WC_Coupon( $coupon_id );
-		}
-
-		return null;
+		return $coupon;
 	}
 
 	/**

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -529,9 +529,11 @@ class Order extends Generator {
 			$reason = 'Full refund';
 		} else {
 			$reason = sprintf(
-				'Partial refund - %d %s',
+				'Partial refund - %d %s, %d %s',
 				$total_items,
-				$total_items === 1 ? 'item' : 'items'
+				$total_items === 1 ? 'product' : 'products',
+				$total_qty,
+				$total_qty === 1 ? 'item' : 'items'
 			);
 		}
 

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -432,13 +432,13 @@ class Order extends Generator {
 			// Decide whether to refund full items or partial quantities
 			$refund_full_items = (bool) wp_rand( 0, 1 );
 
-			if ( $refund_full_items && count( $items ) > 1 ) {
-				// Refund a random subset of items completely
+			if ( $refund_full_items && count( $items ) > 2 ) {
+				// Refund a random subset of items completely (requires at least 3 items)
 				$items_array  = array_values( $items );
 				$num_to_refund = wp_rand( 1, count( $items_array ) - 1 );
 				$items_to_refund = array_rand( $items_array, $num_to_refund );
 
-				// array_rand returns int if count is 1, array otherwise
+				// Ensure $items_to_refund is always an array for consistent iteration
 				if ( ! is_array( $items_to_refund ) ) {
 					$items_to_refund = array( $items_to_refund );
 				}

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -107,7 +107,9 @@ class Order extends Generator {
 			}
 
 			// Apply coupon based on ratio
-			if ( $coupon_ratio > 0 && ( $coupon_ratio >= 1.0 || ( (float) wp_rand() / (float) getrandmax() ) < $coupon_ratio ) ) {
+			if ( $coupon_ratio >= 1.0 ) {
+				$include_coupon = true;
+			} elseif ( $coupon_ratio > 0 && wp_rand( 1, 100 ) <= ( $coupon_ratio * 100 ) ) {
 				$include_coupon = true;
 			} else {
 				$include_coupon = false;
@@ -157,10 +159,9 @@ class Order extends Generator {
 				if ( $refund_ratio >= 1.0 ) {
 					// Always refund if ratio is 1.0 or higher
 					$should_refund = true;
-				} elseif ( $refund_ratio > 0 ) {
+				} elseif ( $refund_ratio > 0 && wp_rand( 1, 100 ) <= ( $refund_ratio * 100 ) ) {
 					// Use random chance for ratios between 0 and 1
-					$random = (float) wp_rand() / (float) getrandmax();
-					$should_refund = $random < $refund_ratio;
+					$should_refund = true;
 				}
 
 				if ( $should_refund ) {


### PR DESCRIPTION
## Summary
Optimizes batch order generation by pre-fetching product, coupon, and customer IDs once per batch instead of querying the database for every single order.

Builds on: #182 

## Problem
When generating orders in batch, the generator was executing repeated queries for:
- Customer selection: 2 queries per order (COUNT + random SELECT)
- Product selection: 1-2 queries per order (COUNT + random query)
- Coupon selection: 1 query per order when using --coupon-ratio

For a batch of 100 orders with coupons, this resulted in ~300 database queries.

## Solution
Added batch-level caching that pre-fetches all IDs with just 3 queries at the start, then uses array_rand() for random selection throughout the batch.

## Performance Impact
- **1000 orders**: 2.5 minutes → 1.1 minutes (56% faster)
- **100 orders**: ~300 queries → 3 queries
- Scales better with larger batches

## Compatibility
Maintains full backward compatibility. Single order generation continues to work as before without using the cache.