### PR TITLE
Optimize order date generation

### DIFF
--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -34,20 +34,14 @@ class Order extends Generator {
 	const SECOND_REFUND_MAX_DAYS = 30;
 
 	/**
-	 * Pre-generated dates for batch order creation (ensures chronological order by ID).
-	 *
-	 * @var array|null
-	 */
-	protected static $batch_dates = null;
-
-	/**
 	 * Return a new order.
 	 *
-	 * @param bool  $save Save the object before returning or not.
-	 * @param array $assoc_args Arguments passed via the CLI for additional customization.
+	 * @param bool        $save Save the object before returning or not.
+	 * @param array       $assoc_args Arguments passed via the CLI for additional customization.
+	 * @param string|null $date Optional date string (Y-m-d) to use for order creation. If not provided, will be generated.
 	 * @return \WC_Order|false Order object with data populated or false when failed.
 	 */
-	public static function generate( $save = true, $assoc_args = array() ) {
+	public static function generate( $save = true, $assoc_args = array(), $date = null ) {
 		parent::maybe_initialize_generators();
 
 		$order    = new \WC_Order();
@@ -118,7 +112,10 @@ class Order extends Generator {
 		$order->set_status( $status );
 		$order->calculate_totals( true );
 
-		$date  = self::get_date_created( $assoc_args );
+		// Use provided date or generate one
+		if ( null === $date ) {
+			$date = self::get_date_created( $assoc_args );
+		}
 		$date .= ' ' . wp_rand( 0, 23 ) . ':00:00';
 
 		$order->set_date_created( $date );
@@ -245,23 +242,23 @@ class Order extends Generator {
 
 		// Pre-generate dates if date-start is provided
 		// This ensures chronological order: lower order IDs = earlier dates
+		$dates = null;
 		if ( ! empty( $args['date-start'] ) ) {
-			self::$batch_dates = self::generate_batch_dates( $amount, $args );
+			$dates = self::generate_batch_dates( $amount, $args );
 		}
 
 		$order_ids = array();
 
 		for ( $i = 1; $i <= $amount; $i ++ ) {
-			$order = self::generate( true, $args );
+			// Use pre-generated date if available, otherwise pass null to generate one
+			$date = ( null !== $dates && ! empty( $dates ) ) ? array_shift( $dates ) : null;
+			$order = self::generate( true, $args, $date );
 			if ( ! $order instanceof \WC_Order ) {
 				error_log( "Batch generation failed: Order {$i} of {$amount} could not be generated" );
 				continue;
 			}
 			$order_ids[] = $order->get_id();
 		}
-
-		// Clear batch dates after generation
-		self::$batch_dates = null;
 
 		return $order_ids;
 	}
@@ -299,18 +296,10 @@ class Order extends Generator {
 	 * between `date-start` and the current date. You can pass an `end-date` and a random date between start
 	 * and end will be chosen.
 	 *
-	 * In batch mode with date-start set, dates are pre-generated and sorted chronologically,
-	 * ensuring lower order IDs have earlier or equal dates.
-	 *
 	 * @param array $assoc_args CLI arguments.
 	 * @return string Date string (Y-m-d)
 	 */
 	protected static function get_date_created( $assoc_args ) {
-		// In batch mode, pop next date from pre-generated sorted array
-		if ( null !== self::$batch_dates && ! empty( self::$batch_dates ) ) {
-			return array_shift( self::$batch_dates );
-		}
-
 		$current = date( 'Y-m-d', time() );
 		if ( ! empty( $assoc_args['date-start'] ) && empty( $assoc_args['date-end'] ) ) {
 			$start = $assoc_args['date-start'];

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -34,6 +34,13 @@ class Order extends Generator {
 	const SECOND_REFUND_MAX_DAYS = 30;
 
 	/**
+	 * Pre-generated dates for batch order creation (ensures chronological order by ID).
+	 *
+	 * @var array|null
+	 */
+	protected static $batch_dates = null;
+
+	/**
 	 * Return a new order.
 	 *
 	 * @param bool  $save Save the object before returning or not.
@@ -236,16 +243,25 @@ class Order extends Generator {
 			return $amount;
 		}
 
+		// Pre-generate dates if date-start is provided
+		// This ensures chronological order: lower order IDs = earlier dates
+		if ( ! empty( $args['date-start'] ) ) {
+			self::$batch_dates = self::generate_batch_dates( $amount, $args );
+		}
+
 		$order_ids = array();
 
 		for ( $i = 1; $i <= $amount; $i ++ ) {
 			$order = self::generate( true, $args );
-			if ( ! $order ) {
+			if ( ! $order instanceof \WC_Order ) {
 				error_log( "Batch generation failed: Order {$i} of {$amount} could not be generated" );
 				continue;
 			}
 			$order_ids[] = $order->get_id();
 		}
+
+		// Clear batch dates after generation
+		self::$batch_dates = null;
 
 		return $order_ids;
 	}
@@ -283,10 +299,18 @@ class Order extends Generator {
 	 * between `date-start` and the current date. You can pass an `end-date` and a random date between start
 	 * and end will be chosen.
 	 *
+	 * In batch mode with date-start set, dates are pre-generated and sorted chronologically,
+	 * ensuring lower order IDs have earlier or equal dates.
+	 *
 	 * @param array $assoc_args CLI arguments.
 	 * @return string Date string (Y-m-d)
 	 */
 	protected static function get_date_created( $assoc_args ) {
+		// In batch mode, pop next date from pre-generated sorted array
+		if ( null !== self::$batch_dates && ! empty( self::$batch_dates ) ) {
+			return array_shift( self::$batch_dates );
+		}
+
 		$current = date( 'Y-m-d', time() );
 		if ( ! empty( $assoc_args['date-start'] ) && empty( $assoc_args['date-end'] ) ) {
 			$start = $assoc_args['date-start'];
@@ -298,14 +322,19 @@ class Order extends Generator {
 			return $current;
 		}
 
-		$dates = array();
-		$date  = strtotime( $start );
-		while ( $date <= strtotime( $end ) ) {
-			$dates[] = date( 'Y-m-d', $date );
-			$date    = strtotime( '+1 day', $date );
+		// Use timestamp-based random selection for single order generation
+		$start_timestamp = strtotime( $start );
+		$end_timestamp   = strtotime( $end );
+		$days_between    = (int) ( ( $end_timestamp - $start_timestamp ) / DAY_IN_SECONDS );
+
+		// If start and end are the same day, return that date (time will be randomized in generate())
+		if ( 0 === $days_between ) {
+			return date( 'Y-m-d', $start_timestamp );
 		}
 
-		return $dates[ array_rand( $dates ) ];
+		// Generate random offset in days and add to start timestamp
+		$random_days = wp_rand( 0, $days_between );
+		return date( 'Y-m-d', $start_timestamp + ( $random_days * DAY_IN_SECONDS ) );
 	}
 
 	/**
@@ -789,5 +818,48 @@ class Order extends Generator {
 
 		$random_days = wp_rand( 0, $max_days );
 		return date( 'Y-m-d H:i:s', strtotime( $base_date->date( 'Y-m-d H:i:s' ) ) + ( $random_days * DAY_IN_SECONDS ) );
+	}
+
+	/**
+	 * Generate an array of sorted dates for batch order creation.
+	 * Ensures chronological order when creating multiple orders.
+	 *
+	 * @param int   $count Number of dates to generate.
+	 * @param array $args  Arguments containing date-start and optional date-end.
+	 * @return array Sorted array of date strings (Y-m-d).
+	 */
+	protected static function generate_batch_dates( $count, $args ) {
+		$current = date( 'Y-m-d', time() );
+
+		if ( ! empty( $args['date-start'] ) && empty( $args['date-end'] ) ) {
+			$start = $args['date-start'];
+			$end   = $current;
+		} elseif ( ! empty( $args['date-start'] ) && ! empty( $args['date-end'] ) ) {
+			$start = $args['date-start'];
+			$end   = $args['date-end'];
+		} else {
+			// No date range specified, return array of current dates
+			return array_fill( 0, $count, $current );
+		}
+
+		$start_timestamp = strtotime( $start );
+		$end_timestamp   = strtotime( $end );
+		$days_between    = (int) ( ( $end_timestamp - $start_timestamp ) / DAY_IN_SECONDS );
+
+		// If start and end dates are the same, return array of that date
+		if ( 0 === $days_between ) {
+			return array_fill( 0, $count, date( 'Y-m-d', $start_timestamp ) );
+		}
+
+		$dates = array();
+		for ( $i = 0; $i < $count; $i++ ) {
+			$random_days = wp_rand( 0, $days_between );
+			$dates[] = date( 'Y-m-d', $start_timestamp + ( $random_days * DAY_IN_SECONDS ) );
+		}
+
+		// Sort chronologically so lower order IDs get earlier dates
+		sort( $dates );
+
+		return $dates;
 	}
 }


### PR DESCRIPTION
Replaces inefficient date array building with direct timestamp calculation.

Builds on: https://github.com/woocommerce/wc-smooth-generator/pull/182

## Problem
For each order, the old code built an array of all dates in the range (e.g., 664 dates for 2 years), then used array_rand(). For 500 orders over 2 years, this created 332,000 unnecessary date strings.

## Solution
Calculate random offset directly using timestamps instead of building arrays.

## Impact
- Instant date calculation vs building 664-element arrays per order
- Eliminates wasted memory allocation
- Same uniform random distribution
- Orders are created in chronological order (smaller order ID = earlier order)

## Tests

**Test 1: Batch generation with date range produces chronological orders**
```bash
wp wc generate orders 10 --date-start=2024-01-01 --date-end=2024-12-31
```
Expected: Order dates should be in ascending or equal order (no date inversions where later ID has earlier date)

**Test 2: Same-day date range edge case**
```bash
wp wc generate orders 5 --date-start=2024-06-15 --date-end=2024-06-15
```
Expected: All orders created with date 2024-06-15 (different times, randomized)

**Test 3: Error handling for failed order generation**
```bash
# Attempt to create orders when no products exist (should skip failed orders gracefully)
wp wc generate orders 5
```
Expected: Error logged but batch continues; indicates 0 orders generated in the end.

**Test 4: Large multi-year batch maintains chronological order**
```bash
wp wc generate orders 100 --date-start=2023-01-01 --date-end=2024-12-31
```
Expected: Date range covers the specified period with proper distribution