### PR TITLE
Fix: Add error handling when no orders are generated

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -115,6 +115,10 @@ class CLI extends WP_CLI_Command {
 		$execution_time = round( ( $time_end - $time_start ), 2 );
 		$display_time   = $execution_time < 60 ? $execution_time . ' seconds' : human_time_diff( $time_start, $time_end );
 
+		if ( $generated === 0 && $amount > 0 ) {
+			WP_CLI::error( 'No orders were generated. Make sure there are published products in your store.' );
+		}
+
 		WP_CLI::success( $generated . ' orders generated in ' . $display_time );
 	}
 


### PR DESCRIPTION
## Summary
- Adds error notification when order generation fails due to missing published products
- Makes this failure case more visible than the current "Success: 0 orders generated..." message which can easily be overlooked

## Test plan
- Run order generation command **with no published products**
    `wp wc generate orders 10`
- Verify clear error message is displayed
    `# Error: No orders were generated. Make sure there are published products in your store.`
- Run order generation command with 0 requested orders
    `wp wc generate orders 0`
- No error message since 0 orders was expected.
    `# Success: 0 orders generated in 0 seconds`
- Add products and then generate orders to see the success message
    ```bash
    wp wc generate products 10
    wp wc generate orders 20
    # Success: 20 orders generated in 3.53 seconds
    ```