### PR TITLE
Change woo.com to woocommerce.com in attribution source

### DIFF
--- a/includes/Generator/OrderAttribution.php
+++ b/includes/Generator/OrderAttribution.php
@@ -32,7 +32,7 @@ class OrderAttribution {
 		$order_products = $order->get_items();
 
 		$device_type = self::get_random_device_type();
-		$source      = 'woo.com';
+		$source      = 'woocommerce.com';
 		$source_type = self::get_source_type();
 		$origin      = self::get_origin( $source_type, $source );
 		$product_url = empty( $order_products ) ? '' : get_permalink( $order_products[ array_rand( $order_products ) ]->get_id() );
@@ -89,7 +89,7 @@ class OrderAttribution {
 		switch ( $source_type ) {
 			case 'utm':
 				$utm = array(
-					'https://woo.com/',
+					'https://woocommerce.com/',
 					'https://twitter.com',
 				);
 				return $utm[ array_rand( $utm ) ];
@@ -101,7 +101,7 @@ class OrderAttribution {
 				return $organic[ array_rand( $organic ) ];
 			case 'referral':
 				$refferal = array(
-					'https://woo.com/',
+					'https://woocommerce.com/',
 					'https://facebook.com',
 					'https://twitter.com',
 					'https://chatgpt.com',
@@ -203,7 +203,7 @@ class OrderAttribution {
 				return $organic[ array_rand( $organic ) ];
 			case 'referral':
 				$refferal = array(
-					'woo.com',
+					'woocommerce.com',
 					'facebook.com',
 					'twitter.com',
 					'chatgpt.com',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates all references from `woo.com` to `woocommerce.com` in the order attribution source data. The changes ensure that generated order attribution data uses the correct WooCommerce domain name:

- Default source value (line 35)
- UTM referrer array (line 92)
- Referral referrer array (line 104)
- Referral source array (line 206)

### How to test the changes in this Pull Request:

1. Generate test orders using the `wp wc generate orders 100`
2. Check the order attribution meta data for generated orders
3. Verify that attribution sources now `woo.com` no longer appears in the referrer URLs and source values (`woocommerce.com` instead)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Updated order attribution source references from `woo.com` to `woocommerce.com`

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.