### PR TITLE
Fix GitHub Actions MySQL setup to use service containers

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -37,6 +37,16 @@ jobs:
                 php: ['7.4', '8.0', '8.2', '8.4']
                 wp-version: ['latest']
 
+        services:
+            mysql:
+                image: mysql:8.0
+                env:
+                    MYSQL_ROOT_PASSWORD: root
+                    MYSQL_DATABASE: wordpress_test
+                ports:
+                    - 3306:3306
+                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
@@ -48,13 +58,6 @@ jobs:
                   extensions: mbstring, intl, mysql
                   coverage: none
                   tools: composer
-
-            - name: Setup MySQL
-              uses: mirromutth/mysql-action@v1.1
-              with:
-                  mysql version: '8.0'
-                  mysql database: 'wordpress_test'
-                  mysql root password: 'root'
 
             - name: Install Composer dependencies
               run: composer install --prefer-dist --no-progress


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Replaces the outdated `mirromutth/mysql-action@v1.1` with GitHub's built-in service containers for MySQL. The action was failing with "docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44" because it uses an outdated Docker client API that's no longer supported by GitHub Actions runners.

Service containers are the recommended approach for GitHub Actions and provide better compatibility and reliability.

### How to test the changes in this Pull Request:

1. Push any change to a PHP file or test-related file to trigger the workflow
2. Verify that the "Setup MySQL" step no longer appears in the workflow
3. Confirm that the MySQL service container starts successfully
4. Verify that all PHP unit tests run and pass across all matrix combinations

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Fixed GitHub Actions MySQL setup by replacing outdated mysql-action with service containers to resolve Docker API version compatibility issue.