### PR TITLE
Improve CI tooling and PHP 8.5 compatibility

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -82,9 +82,12 @@ jobs:
     PHPCS:
         name: PHPCS
         runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request'
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -95,5 +98,14 @@ jobs:
             - name: Install Composer dependencies
               run: composer install --prefer-dist --no-progress
 
-            - name: Run PHPCS
-              run: composer run phpcs
+            - name: Run PHPCS on changed files
+              run: |
+                  git fetch origin ${{ github.base_ref }}
+                  CHANGED_FILES=$(git diff --name-only --diff-filter=ACM origin/${{ github.base_ref }}...HEAD -- '*.php')
+                  if [ -n "$CHANGED_FILES" ]; then
+                      echo "Running PHPCS on changed files:"
+                      echo "$CHANGED_FILES"
+                      vendor/bin/phpcs-changed --git --git-base origin/${{ github.base_ref }} -s
+                  else
+                      echo "No PHP files changed"
+                  fi

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -99,13 +99,4 @@ jobs:
               run: composer install --prefer-dist --no-progress
 
             - name: Run PHPCS on changed files
-              run: |
-                  git fetch origin ${{ github.base_ref }}
-                  CHANGED_FILES=$(git diff --name-only --diff-filter=ACM origin/${{ github.base_ref }}...HEAD -- '*.php')
-                  if [ -n "$CHANGED_FILES" ]; then
-                      echo "Running PHPCS on changed files:"
-                      echo "$CHANGED_FILES"
-                      vendor/bin/phpcs-changed --git --git-base origin/${{ github.base_ref }} -s
-                  else
-                      echo "No PHP files changed"
-                  fi
+              run: vendor/bin/phpcs-changed --git --git-base origin/${{ github.base_ref }} -s

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -34,7 +34,7 @@ jobs:
             WP_TESTS_DIR: '/tmp/wordpress/tests/phpunit'
         strategy:
             matrix:
-                php: ['7.4', '8.0', '8.2', '8.4']
+                php: ['7.4', '8.2', '8.5']
                 wp-version: ['latest']
 
         services:
@@ -78,3 +78,22 @@ jobs:
 
             - name: Run PHP unit tests
               run: composer test-unit
+
+    PHPCS:
+        name: PHPCS
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.2'
+                  tools: composer
+
+            - name: Install Composer dependencies
+              run: composer install --prefer-dist --no-progress
+
+            - name: Run PHPCS
+              run: composer run phpcs

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -98,5 +98,14 @@ jobs:
             - name: Install Composer dependencies
               run: composer install --prefer-dist --no-progress
 
+            - name: Fetch base branch
+              run: git fetch origin ${{ github.base_ref }}
+
             - name: Run PHPCS on changed files
-              run: vendor/bin/phpcs-changed --git --git-base origin/${{ github.base_ref }} -s
+              run: |
+                  CHANGED_PHP=$(git diff --name-only --diff-filter=ACM origin/${{ github.base_ref }}...HEAD -- '*.php' | wc -l)
+                  if [ "$CHANGED_PHP" -gt 0 ]; then
+                      vendor/bin/phpcs-changed --git --git-base origin/${{ github.base_ref }} -s
+                  else
+                      echo "No PHP files changed, skipping PHPCS"
+                  fi

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -98,14 +98,12 @@ jobs:
             - name: Install Composer dependencies
               run: composer install --prefer-dist --no-progress
 
-            - name: Fetch base branch
-              run: git fetch origin ${{ github.base_ref }}
+            - name: Get Changed Files
+              id: changed-files
+              uses: tj-actions/changed-files@v41
+              with:
+                  files: '**/*.php'
 
             - name: Run PHPCS on changed files
-              run: |
-                  CHANGED_PHP=$(git diff --name-only --diff-filter=ACM origin/${{ github.base_ref }}...HEAD -- '*.php' | wc -l)
-                  if [ "$CHANGED_PHP" -gt 0 ]; then
-                      vendor/bin/phpcs-changed --git --git-base origin/${{ github.base_ref }} -s
-                  else
-                      echo "No PHP files changed, skipping PHPCS"
-                  fi
+              if: steps.changed-files.outputs.any_changed == 'true'
+              run: vendor/bin/phpcs-changed -s --git --git-base ${{ github.event.pull_request.base.sha }} ${{ steps.changed-files.outputs.all_changed_files }}

--- a/includes/Generator/Generator.php
+++ b/includes/Generator/Generator.php
@@ -306,7 +306,7 @@ abstract class Generator {
 		ob_start();
 		imagepng( $image );
 		$file = ob_get_clean();
-		imagedestroy( $image );
+		// imagedestroy() has no effect since PHP 8.0 and is deprecated in PHP 8.5.
 		$upload = wp_upload_bits( 'img-' . $seed . '.png', null, $file );
 
 		if ( empty( $upload['error'] ) ) {

--- a/includes/Generator/Generator.php
+++ b/includes/Generator/Generator.php
@@ -306,7 +306,8 @@ abstract class Generator {
 		ob_start();
 		imagepng( $image );
 		$file = ob_get_clean();
-		// imagedestroy() has no effect since PHP 8.0 and is deprecated in PHP 8.5.
+		// Unset image to free memory early. imagedestroy() has no effect since PHP 8.0 and is deprecated in PHP 8.5.
+		unset( $image );
 		$upload = wp_upload_bits( 'img-' . $seed . '.png', null, $file );
 
 		if ( empty( $upload['error'] ) ) {


### PR DESCRIPTION
## Summary

Enhances CI tooling and resolves PHP 8.5 compatibility issues.

## Changes

1. **Remove deprecated imagedestroy() call** - Eliminates PHP 8.5 deprecation warnings
2. **Update CI matrix** - Test against PHP 7.4, 8.2, and 8.5 (removed 8.0 and 8.4)
3. **Add PHPCS to CI** - Automated code standards checking on changed files PRs

## Details

### PHP 8.5 Compatibility
PHP 8.5 deprecated the `imagedestroy()` function because it has had no effect since PHP 8.0 (images are automatically destroyed when they go out of scope). This change removes the unnecessary call and adds a comment explaining why.

### CI Improvements
- Updated PHP version matrix to test the minimum (7.4), a stable version (8.2), and the latest (8.5)
- Added dedicated PHPCS job to ensure code quality standards are maintained

## Test Plan

- [x] Run PHPUnit tests in PHP 8.5 environment
- [x] Verify no imagedestroy() deprecation warnings appear
- [x] Confirm image generation still works correctly
- [x] Verify CI workflow syntax is valid