### PR TITLE
Add bookings generator for WooCommerce Bookings extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,18 @@ wp wc generate products 25 --type=simple
 
 # Generate variable products using only existing categories and tags
 wp wc generate products 10 --type=variable --use-existing-terms
+
+# Generate bookable products (requires WooCommerce Bookings)
+wp wc generate products 5 --type=booking
+
+# Generate bookable service products (virtual, short-duration)
+wp wc generate products 5 --type=booking-service
 ```
 
 | Option | Description |
 |---|---|
 | `<amount>` | Number of products to generate. Default: `10` |
-| `--type=<type>` | Product type: `simple` or `variable`. Default: random mix |
+| `--type=<type>` | Product type: `simple`, `variable`, `booking`, or `booking-service`. Default: random mix of simple/variable. `booking` and `booking-service` require [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/) |
 | `--use-existing-terms` | Only use existing categories and tags instead of generating new ones |
 
 ### Orders
@@ -184,6 +190,12 @@ $customer = Generator\Customer::generate( true, [ 'country' => 'US', 'type' => '
 // Generate and save a booking (returns booking ID or WP_Error). Requires WooCommerce Bookings.
 $booking_id = Generator\Booking::generate( true, [ 'status' => 'confirmed' ] );
 
+// Generate and save a bookable product (returns WC_Product_Booking or WP_Error). Requires WooCommerce Bookings.
+$booking_product = Generator\Product::generate( true, [ 'type' => 'booking' ] );
+
+// Generate and save a bookable service product (returns WC_Product_Booking or WP_Error). Requires WooCommerce Bookings.
+$service_product = Generator\Product::generate( true, [ 'type' => 'booking-service' ] );
+
 // Generate and save a coupon (returns WC_Coupon or WP_Error).
 $coupon = Generator\Coupon::generate( true, [ 'min' => 5, 'max' => 25, 'discount_type' => 'percent' ] );
 
@@ -199,6 +211,9 @@ use WC\SmoothGenerator\Generator;
 // Generate 50 products (returns array of product IDs or WP_Error).
 // Max batch size: 100.
 $product_ids = Generator\Product::batch( 50, [ 'type' => 'variable', 'use-existing-terms' => true ] );
+
+// Generate 10 bookable products. Requires WooCommerce Bookings.
+$booking_product_ids = Generator\Product::batch( 10, [ 'type' => 'booking' ] );
 
 // Generate 100 orders with date range and coupons.
 $order_ids = Generator\Order::batch( 100, [
@@ -241,7 +256,7 @@ Each generator fires an action after creating an object:
 
 ### Product generator
 
-Creates simple or variable products with:
+Creates simple, variable, booking, or booking-service products with:
 
 - Name, SKU, global unique ID, featured status
 - Price, sale price, sale date scheduling
@@ -253,6 +268,21 @@ Creates simple or variable products with:
 - Virtual/downloadable flags, dimensions, weight
 - Cost of Goods Sold (if WooCommerce COGS is enabled)
 - Reviews allowed toggle, purchase notes, menu order
+
+**Booking products** (requires [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/)):
+
+- Hourly or daily duration with realistic names (consultations, rentals, venues)
+- Person support with min/max counts and cost multiplier (~40% of products)
+- Resource assignment with named resources like rooms and stations (~30% of products)
+- Configurable availability windows (30-180 days)
+- Cancellation settings
+
+**Booking-service products** (requires [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/)):
+
+- Virtual, short-duration services (haircuts, repairs, grooming)
+- Minute-based (15-60 min) or short hour-based (1-2 hrs) durations
+- No persons or resources (simple appointment-style bookings)
+- Short availability windows (14-60 days)
 
 ### Order generator
 

--- a/README.md
+++ b/README.md
@@ -45,14 +45,17 @@ wp wc generate products 10 --type=variable --use-existing-terms
 # Generate bookable products (requires WooCommerce Bookings)
 wp wc generate products 5 --type=booking
 
-# Generate bookable service products (virtual, short-duration)
-wp wc generate products 5 --type=booking-service
+# Generate bookable service products (requires WooCommerce Bookings + experimental features)
+wp wc generate products 5 --type=bookable-service
+
+# Generate bookable event products (requires WooCommerce Bookings + experimental features)
+wp wc generate products 5 --type=bookable-event
 ```
 
 | Option | Description |
 |---|---|
 | `<amount>` | Number of products to generate. Default: `10` |
-| `--type=<type>` | Product type: `simple`, `variable`, `booking`, or `booking-service`. Default: random mix of simple/variable. `booking` and `booking-service` require [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/) |
+| `--type=<type>` | Product type: `simple`, `variable`, `booking`, `bookable-service`, or `bookable-event`. Default: random mix of simple/variable. `booking` requires [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/). `bookable-service` and `bookable-event` also require `WC_BOOKINGS_EXPERIMENTAL_ENABLED` |
 | `--use-existing-terms` | Only use existing categories and tags instead of generating new ones |
 
 ### Orders
@@ -193,8 +196,13 @@ $booking_id = Generator\Booking::generate( true, [ 'status' => 'confirmed' ] );
 // Generate and save a bookable product (returns WC_Product_Booking or WP_Error). Requires WooCommerce Bookings.
 $booking_product = Generator\Product::generate( true, [ 'type' => 'booking' ] );
 
-// Generate and save a bookable service product (returns WC_Product_Booking or WP_Error). Requires WooCommerce Bookings.
-$service_product = Generator\Product::generate( true, [ 'type' => 'booking-service' ] );
+// Generate and save a bookable service product (returns WC_Product_Bookable_Service or WP_Error).
+// Requires WooCommerce Bookings + WC_BOOKINGS_EXPERIMENTAL_ENABLED.
+$service_product = Generator\Product::generate( true, [ 'type' => 'bookable-service' ] );
+
+// Generate and save a bookable event product (returns WC_Product_Bookable_Event or WP_Error).
+// Requires WooCommerce Bookings + WC_BOOKINGS_EXPERIMENTAL_ENABLED.
+$event_product = Generator\Product::generate( true, [ 'type' => 'bookable-event' ] );
 
 // Generate and save a coupon (returns WC_Coupon or WP_Error).
 $coupon = Generator\Coupon::generate( true, [ 'min' => 5, 'max' => 25, 'discount_type' => 'percent' ] );
@@ -256,7 +264,7 @@ Each generator fires an action after creating an object:
 
 ### Product generator
 
-Creates simple, variable, booking, or booking-service products with:
+Creates simple, variable, booking, bookable-service, or bookable-event products with:
 
 - Name, SKU, global unique ID, featured status
 - Price, sale price, sale date scheduling
@@ -277,12 +285,22 @@ Creates simple, variable, booking, or booking-service products with:
 - Configurable availability windows (30-180 days)
 - Cancellation settings
 
-**Booking-service products** (requires [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/)):
+**Bookable-service products** (requires [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/) + `WC_BOOKINGS_EXPERIMENTAL_ENABLED`):
 
-- Virtual, short-duration services (haircuts, repairs, grooming)
-- Minute-based (15-60 min) or short hour-based (1-2 hrs) durations
+- Uses the real `WC_Product_Bookable_Service` class
+- Virtual, fixed-duration services in minutes (haircuts, repairs, grooming)
+- Duration always in minutes (15-60 min), enforced by the product class
+- Default date availability set to non-available (per class defaults)
 - No persons or resources (simple appointment-style bookings)
 - Short availability windows (14-60 days)
+
+**Bookable-event products** (requires [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/) + `WC_BOOKINGS_EXPERIMENTAL_ENABLED`):
+
+- Uses the real `WC_Product_Bookable_Event` class
+- Events with ticket-style bookings (concerts, workshops, conferences)
+- Hour-based durations (1-4 hours)
+- Person/attendee support with cost multiplier
+- Availability windows (30-120 days)
 
 ### Order generator
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ wp wc generate orders 50 --status=completed --refund-ratio=0.3
 Requires the [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/) extension.
 
 ```bash
-# Generate 10 bookings (creates bookable products automatically if none exist)
+# Generate 10 bookings (requires at least one existing bookable product)
 wp wc generate bookings
 
 # Generate bookings with a specific date range
@@ -321,7 +321,7 @@ Creates orders with realistic data:
 Requires the [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/) extension. Creates bookings with:
 
 - Checks for WooCommerce Bookings dependency before proceeding
-- Auto-creates varied bookable products (hourly services, daily rentals, group workshops) if none exist
+- Returns a clear error if no bookable products exist (create them first with `wp wc generate products --type=booking`)
 - Random booking dates within a configurable range
 - Weighted status distribution: paid (35%), confirmed (25%), complete (20%), unpaid (10%), pending-confirmation (5%), cancelled (5%)
 - Person counts based on product configuration

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WooCommerce Smooth Generator
 
-Generate realistic WooCommerce products, orders, customers, coupons, and taxonomy terms for development, testing, and demos.
+Generate realistic WooCommerce products, orders, customers, coupons, taxonomy terms, and bookings for development, testing, and demos.
 
 WP-CLI is the primary interface. A limited WP Admin UI is also available at Dashboard > Tools > WooCommerce Smooth Generator.
 
@@ -24,6 +24,7 @@ composer install --no-dev
 - PHP 7.4+
 - WordPress (tested up to 6.9)
 - WooCommerce 5.0+
+- [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/) (optional, required for booking generation)
 
 ## WP-CLI commands
 
@@ -81,6 +82,33 @@ wp wc generate orders 50 --status=completed --refund-ratio=0.3
 **Batch distribution:** When generating multiple orders, coupon and refund counts are deterministic (selection without replacement). For odd totals, `round()` distributes coupons and remainders go to multi-partial refunds. Single-order generation uses probabilistic distribution.
 
 **Order attribution:** Random attribution metadata (device type, UTM parameters, referrer, session data) is added by default. Orders dated before 2024-01-09 skip attribution, since the feature didn't exist in WooCommerce yet.
+
+### Bookings
+
+Requires the [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/) extension.
+
+```bash
+# Generate 10 bookings (creates bookable products automatically if none exist)
+wp wc generate bookings
+
+# Generate bookings with a specific date range
+wp wc generate bookings 50 --date-start=2026-04-01 --date-end=2026-06-30
+
+# Generate confirmed bookings for a specific bookable product
+wp wc generate bookings 20 --status=confirmed --product-id=42
+
+# Generate bookings without associated WooCommerce orders
+wp wc generate bookings 30 --no-orders
+```
+
+| Option | Description |
+|---|---|
+| `<amount>` | Number of bookings to generate. Default: `10` |
+| `--date-start=<date>` | Earliest booking date (YYYY-MM-DD). Default: 14 days ago |
+| `--date-end=<date>` | Latest booking date (YYYY-MM-DD). Default: 42 days from now |
+| `--status=<status>` | Booking status: `unpaid`, `pending-confirmation`, `confirmed`, `paid`, `cancelled`, or `complete`. Default: weighted random mix |
+| `--product-id=<id>` | Use a specific bookable product for all bookings |
+| `--no-orders` | Skip creating associated WooCommerce orders (orders are created by default) |
 
 ### Customers
 
@@ -153,6 +181,9 @@ $order = Generator\Order::generate( true, [ 'status' => 'completed' ] );
 // Generate and save a customer (returns WC_Customer or WP_Error).
 $customer = Generator\Customer::generate( true, [ 'country' => 'US', 'type' => 'person' ] );
 
+// Generate and save a booking (returns booking ID or WP_Error). Requires WooCommerce Bookings.
+$booking_id = Generator\Booking::generate( true, [ 'status' => 'confirmed' ] );
+
 // Generate and save a coupon (returns WC_Coupon or WP_Error).
 $coupon = Generator\Coupon::generate( true, [ 'min' => 5, 'max' => 25, 'discount_type' => 'percent' ] );
 
@@ -178,6 +209,13 @@ $order_ids = Generator\Order::batch( 100, [
     'refund-ratio' => '0.2',
 ] );
 
+// Generate 20 bookings with associated orders.
+$booking_ids = Generator\Booking::batch( 20, [
+    'date-start'  => '2026-04-01',
+    'date-end'    => '2026-06-30',
+    'with-orders' => true,
+] );
+
 // Generate 25 customers.
 $customer_ids = Generator\Customer::batch( 25, [ 'country' => 'ES' ] );
 
@@ -194,6 +232,7 @@ Each generator fires an action after creating an object:
 
 - `smoothgenerator_product_generated` -- after a product is saved
 - `smoothgenerator_order_generated` -- after an order is saved
+- `smoothgenerator_booking_generated` -- after a booking is saved (requires WooCommerce Bookings)
 - `smoothgenerator_customer_generated` -- after a customer is saved
 - `smoothgenerator_coupon_generated` -- after a coupon is saved
 - `smoothgenerator_term_generated` -- after a term is saved
@@ -228,6 +267,19 @@ Creates orders with realistic data:
 - Order attribution: device type, UTM parameters, referrer, session data
 - Extra fees (~20% chance per order)
 - Paid and completed dates based on status
+
+### Booking generator
+
+Requires the [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/) extension. Creates bookings with:
+
+- Checks for WooCommerce Bookings dependency before proceeding
+- Auto-creates varied bookable products (hourly services, daily rentals, group workshops) if none exist
+- Random booking dates within a configurable range
+- Weighted status distribution: paid (35%), confirmed (25%), complete (20%), unpaid (10%), pending-confirmation (5%), cancelled (5%)
+- Person counts based on product configuration
+- Resource assignment from product's available resources
+- Associated WooCommerce orders with mapped statuses (optional)
+- Customer assignment from existing customers or auto-created ones
 
 ### Customer generator
 

--- a/composer.lock
+++ b/composer.lock
@@ -539,76 +539,6 @@
             "time": "2025-11-11T04:32:07+00:00"
         },
         {
-            "name": "doctrine/instantiator",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:15:36+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
             "source": {
@@ -1234,16 +1164,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.32",
+            "version": "10.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
                 "shasum": ""
             },
             "require": {
@@ -1251,18 +1181,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-text-template": "^2.0.4",
-                "sebastian/code-unit-reverse-lookup": "^2.0.3",
-                "sebastian/complexity": "^2.0.3",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/lines-of-code": "^1.0.4",
-                "sebastian/version": "^3.0.2",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
                 "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.6"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -1271,7 +1201,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.2.x-dev"
+                    "dev-main": "10.1.x-dev"
                 }
             },
             "autoload": {
@@ -1300,7 +1230,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
             },
             "funding": [
                 {
@@ -1308,32 +1238,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-22T04:23:01+00:00"
+            "time": "2024-08-22T04:31:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1360,7 +1290,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
             },
             "funding": [
                 {
@@ -1368,28 +1299,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -1397,7 +1328,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1423,7 +1354,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -1431,32 +1362,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1482,7 +1413,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
             },
             "funding": [
                 {
@@ -1490,32 +1422,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1541,7 +1473,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -1549,24 +1481,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.34",
+            "version": "10.5.63",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
-                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/33198268dad71e926626b618f3ec3966661e4d90",
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -1576,27 +1507,26 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.32",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.4",
-                "phpunit/php-timer": "^5.0.3",
-                "sebastian/cli-parser": "^1.0.2",
-                "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.10",
-                "sebastian/diff": "^4.0.6",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.8",
-                "sebastian/global-state": "^5.0.8",
-                "sebastian/object-enumerator": "^4.0.4",
-                "sebastian/resource-operations": "^3.0.4",
-                "sebastian/type": "^3.2.1",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.5",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -1604,7 +1534,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "10.5-dev"
                 }
             },
             "autoload": {
@@ -1636,7 +1566,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.63"
             },
             "funding": [
                 {
@@ -1660,32 +1590,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T05:45:00+00:00"
+            "time": "2026-01-27T05:48:37+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1708,7 +1638,8 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
             },
             "funding": [
                 {
@@ -1716,32 +1647,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:27:43+00:00"
+            "time": "2024-03-02T07:12:49+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1764,7 +1695,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -1772,32 +1703,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1819,7 +1750,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -1827,34 +1758,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.10",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
-                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1893,7 +1826,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
             },
             "funding": [
                 {
@@ -1913,33 +1847,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:22:56+00:00"
+            "time": "2026-01-24T09:25:16+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.3",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1962,7 +1896,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
             },
             "funding": [
                 {
@@ -1970,33 +1905,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:19:30+00:00"
+            "time": "2023-12-21T08:37:17+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.6",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -2028,7 +1963,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
             },
             "funding": [
                 {
@@ -2036,27 +1972,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:30:58+00:00"
+            "time": "2024-03-02T07:15:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -2064,7 +2000,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.1-dev"
                 }
             },
             "autoload": {
@@ -2083,7 +2019,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -2091,7 +2027,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
             },
             "funding": [
                 {
@@ -2099,34 +2036,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2024-03-23T08:47:14+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.8",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
-                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -2168,7 +2105,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
             },
             "funding": [
                 {
@@ -2188,38 +2126,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:03:27+00:00"
+            "time": "2025-09-24T06:09:11+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.8",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
-                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2238,59 +2173,48 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T07:10:35+00:00"
+            "time": "2024-03-02T07:19:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.4",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2313,7 +2237,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
             },
             "funding": [
                 {
@@ -2321,34 +2246,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:20:34+00:00"
+            "time": "2023-12-21T08:38:20+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2370,7 +2295,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2378,32 +2303,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2425,7 +2350,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2433,32 +2358,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.6",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
-                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2488,7 +2413,8 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
             },
             "funding": [
                 {
@@ -2508,86 +2434,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:57:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-14T16:00:52+00:00"
+            "time": "2025-08-10T07:50:56+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2610,7 +2482,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -2618,29 +2490,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2663,7 +2535,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
             },
             "funding": [
                 {
@@ -2671,7 +2543,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "sirbrillig/phpcs-changed",

--- a/composer.lock
+++ b/composer.lock
@@ -539,6 +539,76 @@
             "time": "2025-11-11T04:32:07+00:00"
         },
         {
+            "name": "doctrine/instantiator",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:15:36+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
             "source": {
@@ -1164,16 +1234,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.16",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
-                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
@@ -1181,18 +1251,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=8.1",
-                "phpunit/php-file-iterator": "^4.1.0",
-                "phpunit/php-text-template": "^3.0.1",
-                "sebastian/code-unit-reverse-lookup": "^3.0.0",
-                "sebastian/complexity": "^3.2.0",
-                "sebastian/environment": "^6.1.0",
-                "sebastian/lines-of-code": "^2.0.2",
-                "sebastian/version": "^4.0.1",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
                 "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.1"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -1201,7 +1271,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1.x-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -1230,7 +1300,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -1238,32 +1308,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-22T04:31:57+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.1.0",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1290,8 +1360,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
             },
             "funding": [
                 {
@@ -1299,28 +1368,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T06:24:48+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "4.0.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -1328,7 +1397,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -1354,7 +1423,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
             },
             "funding": [
                 {
@@ -1362,32 +1431,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:56:09+00:00"
+            "time": "2020-09-28T05:58:55+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "3.0.1",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1413,8 +1482,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
             },
             "funding": [
                 {
@@ -1422,32 +1490,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T14:07:24+00:00"
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "6.0.0",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1473,7 +1541,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
             },
             "funding": [
                 {
@@ -1481,23 +1549,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:57:52+00:00"
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.63",
+            "version": "9.6.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "33198268dad71e926626b618f3ec3966661e4d90"
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/33198268dad71e926626b618f3ec3966661e4d90",
-                "reference": "33198268dad71e926626b618f3ec3966661e4d90",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -1507,26 +1576,27 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.16",
-                "phpunit/php-file-iterator": "^4.1.0",
-                "phpunit/php-invoker": "^4.0.0",
-                "phpunit/php-text-template": "^3.0.1",
-                "phpunit/php-timer": "^6.0.0",
-                "sebastian/cli-parser": "^2.0.1",
-                "sebastian/code-unit": "^2.0.0",
-                "sebastian/comparator": "^5.0.5",
-                "sebastian/diff": "^5.1.1",
-                "sebastian/environment": "^6.1.0",
-                "sebastian/exporter": "^5.1.4",
-                "sebastian/global-state": "^6.0.2",
-                "sebastian/object-enumerator": "^5.0.0",
-                "sebastian/recursion-context": "^5.0.1",
-                "sebastian/type": "^4.0.0",
-                "sebastian/version": "^4.0.1"
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -1534,7 +1604,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -1566,7 +1636,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.63"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
             },
             "funding": [
                 {
@@ -1590,32 +1660,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T05:48:37+00:00"
+            "time": "2026-01-27T05:45:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "2.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
-                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -1638,8 +1708,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
             },
             "funding": [
                 {
@@ -1647,32 +1716,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:12:49+00:00"
+            "time": "2024-03-02T06:27:43+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "2.0.0",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -1695,7 +1764,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
             },
             "funding": [
                 {
@@ -1703,32 +1772,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:43+00:00"
+            "time": "2020-10-26T13:08:54+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "3.0.0",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1750,7 +1819,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
             },
             "funding": [
                 {
@@ -1758,36 +1827,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:59:15+00:00"
+            "time": "2020-09-28T05:30:19+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.5",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
-                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
-                "ext-dom": "*",
-                "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/diff": "^5.0",
-                "sebastian/exporter": "^5.0"
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1826,8 +1893,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
@@ -1847,33 +1913,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:25:16+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.2.0",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
-                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.2-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1896,8 +1962,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
             },
             "funding": [
                 {
@@ -1905,33 +1970,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T08:37:17+00:00"
+            "time": "2023-12-22T06:19:30+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.1.1",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
-                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0",
-                "symfony/process": "^6.4"
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1963,8 +2028,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
             },
             "funding": [
                 {
@@ -1972,27 +2036,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:15:17+00:00"
+            "time": "2024-03-02T06:30:58+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "6.1.0",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
-                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -2000,7 +2064,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.1-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -2019,7 +2083,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "https://github.com/sebastianbergmann/environment",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -2027,8 +2091,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -2036,34 +2099,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-23T08:47:14+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.1.4",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "0735b90f4da94969541dac1da743446e276defa6"
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
-                "reference": "0735b90f4da94969541dac1da743446e276defa6",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
                 "shasum": ""
             },
             "require": {
-                "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2105,8 +2168,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
             },
             "funding": [
                 {
@@ -2126,35 +2188,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:09:11+00:00"
+            "time": "2025-09-24T06:03:27+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.2",
+            "version": "5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
-                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2173,48 +2238,59 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T07:19:19+00:00"
+            "time": "2025-08-10T07:10:35+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.2",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
-                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -2237,8 +2313,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
             },
             "funding": [
                 {
@@ -2246,34 +2321,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T08:38:20+00:00"
+            "time": "2023-12-22T06:20:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "5.0.0",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2295,7 +2370,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
             },
             "funding": [
                 {
@@ -2303,32 +2378,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:08:32+00:00"
+            "time": "2020-10-26T13:12:34+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "3.0.0",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2350,7 +2425,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
             },
             "funding": [
                 {
@@ -2358,32 +2433,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:06:18+00:00"
+            "time": "2020-10-26T13:14:26+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "5.0.1",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
-                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2413,8 +2488,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
             },
             "funding": [
                 {
@@ -2434,32 +2508,86 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T07:50:56+00:00"
+            "time": "2025-08-10T06:57:39+00:00"
         },
         {
-            "name": "sebastian/type",
-            "version": "4.0.0",
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2482,7 +2610,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -2490,29 +2618,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:10:45+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "4.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2535,7 +2663,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
             },
             "funding": [
                 {
@@ -2543,7 +2671,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-07T11:34:05+00:00"
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "sirbrillig/phpcs-changed",

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -14,7 +14,7 @@ class Settings {
 
 	const DEFAULT_NUM_PRODUCTS           = 10;
 	const DEFAULT_NUM_ORDERS             = 10;
-	const DEFAULT_NUM_BOOKINGS           = 10;
+	const DEFAULT_NUM_BOOKINGS = 10;
 
 	/**
 	 *  Set up hooks.
@@ -327,7 +327,7 @@ class Settings {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_orders_to_generate'] );
 			BatchProcessor::create_new_job( 'orders', $num_to_generate, $args );
-		} else if ( ! empty( $_POST['generate_bookings'] ) && ! empty( $_POST['num_bookings_to_generate'] ) ) {
+		} elseif ( ! empty( $_POST['generate_bookings'] ) && ! empty( $_POST['num_bookings_to_generate'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_bookings_to_generate'] );
 			BatchProcessor::create_new_job( 'bookings', $num_to_generate, $args );

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -12,9 +12,9 @@ namespace WC\SmoothGenerator\Admin;
  */
 class Settings {
 
-	const DEFAULT_NUM_PRODUCTS           = 10;
-	const DEFAULT_NUM_ORDERS             = 10;
-	const DEFAULT_NUM_BOOKINGS           = 10;
+	const DEFAULT_NUM_PRODUCTS = 10;
+	const DEFAULT_NUM_ORDERS   = 10;
+	const DEFAULT_NUM_BOOKINGS = 10;
 
 	/**
 	 *  Set up hooks.
@@ -327,7 +327,7 @@ class Settings {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_orders_to_generate'] );
 			BatchProcessor::create_new_job( 'orders', $num_to_generate, $args );
-		} else if ( ! empty( $_POST['generate_bookings'] ) && ! empty( $_POST['num_bookings_to_generate'] ) ) {
+		} elseif ( ! empty( $_POST['generate_bookings'] ) && ! empty( $_POST['num_bookings_to_generate'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_bookings_to_generate'] );
 			BatchProcessor::create_new_job( 'bookings', $num_to_generate, $args );

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -14,7 +14,7 @@ class Settings {
 
 	const DEFAULT_NUM_PRODUCTS           = 10;
 	const DEFAULT_NUM_ORDERS             = 10;
-	const DEFAULT_NUM_BOOKINGS = 10;
+	const DEFAULT_NUM_BOOKINGS           = 10;
 
 	/**
 	 *  Set up hooks.
@@ -135,7 +135,7 @@ class Settings {
 			</p>
 
 			<h2>Generate bookings</h2>
-			<?php if ( class_exists( 'WC_Bookings' ) || function_exists( 'create_wc_booking' ) ) : ?>
+			<?php if ( \WC\SmoothGenerator\Generator\Booking::is_bookings_active() ) : ?>
 			<p>
 				<label for="generate_bookings_input" class="screen-reader-text">Number of bookings to generate</label>
 				<input
@@ -327,7 +327,7 @@ class Settings {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_orders_to_generate'] );
 			BatchProcessor::create_new_job( 'orders', $num_to_generate, $args );
-		} elseif ( ! empty( $_POST['generate_bookings'] ) && ! empty( $_POST['num_bookings_to_generate'] ) ) {
+		} else if ( ! empty( $_POST['generate_bookings'] ) && ! empty( $_POST['num_bookings_to_generate'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_bookings_to_generate'] );
 			BatchProcessor::create_new_job( 'bookings', $num_to_generate, $args );

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -14,6 +14,7 @@ class Settings {
 
 	const DEFAULT_NUM_PRODUCTS           = 10;
 	const DEFAULT_NUM_ORDERS             = 10;
+	const DEFAULT_NUM_BOOKINGS           = 10;
 
 	/**
 	 *  Set up hooks.
@@ -132,6 +133,34 @@ class Settings {
 				);
 				?>
 			</p>
+
+			<h2>Generate bookings</h2>
+			<?php if ( class_exists( 'WC_Bookings' ) || function_exists( 'create_wc_booking' ) ) : ?>
+			<p>
+				<label for="generate_bookings_input" class="screen-reader-text">Number of bookings to generate</label>
+				<input
+					id="generate_bookings_input"
+					type="number"
+					name="num_bookings_to_generate"
+					value="<?php echo esc_attr( self::DEFAULT_NUM_BOOKINGS ); ?>"
+					min="1"
+					<?php disabled( $current_job instanceof AsyncJob ); ?>
+				/>
+				<?php
+				submit_button(
+					'Generate',
+					'primary',
+					'generate_bookings',
+					false,
+					$generate_button_atts
+				);
+				?>
+			</p>
+			<?php else : ?>
+			<p class="description" style="color: #d63638;">
+				WooCommerce Bookings extension is not active. Install and activate it to generate bookings.
+			</p>
+			<?php endif; ?>
 
 			<h2>Advanced Options</h2>
 			<p>
@@ -298,6 +327,10 @@ class Settings {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_orders_to_generate'] );
 			BatchProcessor::create_new_job( 'orders', $num_to_generate, $args );
+		} else if ( ! empty( $_POST['generate_bookings'] ) && ! empty( $_POST['num_bookings_to_generate'] ) ) {
+			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
+			$num_to_generate = absint( $_POST['num_bookings_to_generate'] );
+			BatchProcessor::create_new_job( 'bookings', $num_to_generate, $args );
 		} else if ( ! empty( $_POST['cancel_job'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			BatchProcessor::delete_current_job();

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -325,9 +325,9 @@ WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'p
 		array(
 			'name'        => 'type',
 			'type'        => 'assoc',
-			'description' => 'Specify one type of product to generate. Otherwise defaults to a mix. "booking" and "booking-service" require the WooCommerce Bookings extension.',
+			'description' => 'Specify one type of product to generate. Otherwise defaults to a mix. "booking" requires WooCommerce Bookings. "bookable-service" and "bookable-event" also require WC_BOOKINGS_EXPERIMENTAL_ENABLED.',
 			'optional'    => true,
-			'options'     => array( 'simple', 'variable', 'booking', 'booking-service' ),
+			'options'     => array( 'simple', 'variable', 'booking', 'bookable-service', 'bookable-event' ),
 		),
 		array(
 			'name'        => 'use-existing-terms',
@@ -336,7 +336,7 @@ WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'p
 			'optional'    => true,
 		),
 	),
-	'longdesc'  => "## EXAMPLES\n\nwc generate products 10\n\nwc generate products 20 --type=variable --use-existing-terms\n\nwc generate products 5 --type=booking\n\nwc generate products 5 --type=booking-service",
+	'longdesc'  => "## EXAMPLES\n\nwc generate products 10\n\nwc generate products 20 --type=variable --use-existing-terms\n\nwc generate products 5 --type=booking\n\nwc generate products 5 --type=bookable-service\n\nwc generate products 5 --type=bookable-event",
 ) );
 
 WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'orders' ), array(

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -215,6 +215,58 @@ class CLI extends WP_CLI_Command {
 	}
 
 	/**
+	 * Generate bookings.
+	 *
+	 * @param array $args Arguments specified.
+	 * @param array $assoc_args Associative arguments specified.
+	 */
+	public static function bookings( $args, $assoc_args ) {
+		list( $amount ) = $args;
+		$amount = absint( $amount );
+
+		$time_start = microtime( true );
+
+		// Convert --no-orders flag to with-orders arg.
+		if ( ! empty( $assoc_args['no-orders'] ) ) {
+			$assoc_args['with-orders'] = false;
+			unset( $assoc_args['no-orders'] );
+		}
+
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating bookings', $amount );
+
+		add_action(
+			'smoothgenerator_booking_generated',
+			function () use ( $progress ) {
+				$progress->tick();
+			}
+		);
+
+		$remaining_amount = $amount;
+		$generated        = 0;
+
+		while ( $remaining_amount > 0 ) {
+			$batch = min( $remaining_amount, Generator\Booking::MAX_BATCH_SIZE );
+
+			$result = Generator\Booking::batch( $batch, $assoc_args );
+
+			if ( is_wp_error( $result ) ) {
+				WP_CLI::error( $result );
+			}
+
+			$generated        += count( $result );
+			$remaining_amount -= $batch;
+		}
+
+		$progress->finish();
+
+		$time_end       = microtime( true );
+		$execution_time = round( ( $time_end - $time_start ), 2 );
+		$display_time   = $execution_time < 60 ? $execution_time . ' seconds' : human_time_diff( $time_start, $time_end );
+
+		WP_CLI::success( $generated . ' bookings generated in ' . $display_time );
+	}
+
+	/**
 	 * Generate terms for the Product Category taxonomy.
 	 *
 	 * @param array $args Arguments specified.
@@ -343,6 +395,57 @@ WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'ord
 		)
 	),
 	'longdesc'  => "## EXAMPLES\n\nwc generate orders 10\n\nwc generate orders 50 --date-start=2020-01-01 --date-end=2022-12-31 --status=completed --coupons",
+) );
+
+WP_CLI::add_command( 'wc generate bookings', array( 'WC\SmoothGenerator\CLI', 'bookings' ), array(
+	'shortdesc' => 'Generate bookings. Requires the WooCommerce Bookings extension.',
+	'synopsis'  => array(
+		array(
+			'name'        => 'amount',
+			'type'        => 'positional',
+			'description' => 'The number of bookings to generate.',
+			'optional'    => true,
+			'default'     => 10,
+		),
+		array(
+			'name'        => 'date-start',
+			'type'        => 'assoc',
+			'description' => 'Earliest booking date (Y-m-d). Default: 14 days ago.',
+			'optional'    => true,
+		),
+		array(
+			'name'        => 'date-end',
+			'type'        => 'assoc',
+			'description' => 'Latest booking date (Y-m-d). Default: 42 days from now.',
+			'optional'    => true,
+		),
+		array(
+			'name'        => 'status',
+			'type'        => 'assoc',
+			'description' => 'Specify one status for all generated bookings. Otherwise defaults to a weighted mix.',
+			'optional'    => true,
+			'options'     => array( 'unpaid', 'pending-confirmation', 'confirmed', 'paid', 'cancelled', 'complete' ),
+		),
+		array(
+			'name'        => 'product-id',
+			'type'        => 'assoc',
+			'description' => 'Generate bookings for a specific bookable product ID. Otherwise picks from available bookable products.',
+			'optional'    => true,
+		),
+		array(
+			'name'        => 'with-orders',
+			'type'        => 'flag',
+			'description' => 'Create associated WooCommerce orders for each booking. Default: true.',
+			'optional'    => true,
+		),
+		array(
+			'name'        => 'no-orders',
+			'type'        => 'flag',
+			'description' => 'Skip creating associated WooCommerce orders.',
+			'optional'    => true,
+		),
+	),
+	'longdesc'  => "## EXAMPLES\n\nwc generate bookings 10\n\nwc generate bookings 50 --date-start=2026-04-01 --date-end=2026-06-30\n\nwc generate bookings 20 --status=confirmed --product-id=42\n\nwc generate bookings 30 --no-orders",
 ) );
 
 WP_CLI::add_command( 'wc generate customers', array( 'WC\SmoothGenerator\CLI', 'customers' ), array(

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -25,6 +25,14 @@ class CLI extends WP_CLI_Command {
 
 		$time_start = microtime( true );
 
+		$requested_type = $assoc_args['type'] ?? null;
+		if ( 'booking' === $requested_type && ! Generator\Booking::is_bookings_active() ) {
+			WP_CLI::error( 'Cannot generate booking products: the WooCommerce Bookings extension is not installed or active. Install and activate it, then try again.' );
+		}
+		if ( in_array( $requested_type, array( 'bookable-service', 'bookable-event' ), true ) && ! Generator\Booking::is_bookings_experimental_active() ) {
+			WP_CLI::error( "Cannot generate {$requested_type} products: WooCommerce Bookings experimental features are not active. Install/activate WooCommerce Bookings and define WC_BOOKINGS_EXPERIMENTAL_ENABLED, then try again." );
+		}
+
 		WP_CLI::line( 'Initializing...' );
 
 		// Pre-generate images. Min 20, max 100.

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -222,8 +222,8 @@ class CLI extends WP_CLI_Command {
 	 */
 	public static function bookings( $args, $assoc_args ) {
 		list( $amount ) = $args;
-		$amount     = absint( $amount );
-		$time_start = microtime( true );
+		$amount         = absint( $amount );
+		$time_start     = microtime( true );
 
 		// Convert --no-orders flag to with-orders arg.
 		if ( ! empty( $assoc_args['no-orders'] ) ) {

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -325,9 +325,9 @@ WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'p
 		array(
 			'name'        => 'type',
 			'type'        => 'assoc',
-			'description' => 'Specify one type of product to generate. Otherwise defaults to a mix.',
+			'description' => 'Specify one type of product to generate. Otherwise defaults to a mix. "booking" and "booking-service" require the WooCommerce Bookings extension.',
 			'optional'    => true,
-			'options'     => array( 'simple', 'variable' ),
+			'options'     => array( 'simple', 'variable', 'booking', 'booking-service' ),
 		),
 		array(
 			'name'        => 'use-existing-terms',
@@ -336,7 +336,7 @@ WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'p
 			'optional'    => true,
 		),
 	),
-	'longdesc'  => "## EXAMPLES\n\nwc generate products 10\n\nwc generate products 20 --type=variable --use-existing-terms",
+	'longdesc'  => "## EXAMPLES\n\nwc generate products 10\n\nwc generate products 20 --type=variable --use-existing-terms\n\nwc generate products 5 --type=booking\n\nwc generate products 5 --type=booking-service",
 ) );
 
 WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'orders' ), array(

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -222,8 +222,7 @@ class CLI extends WP_CLI_Command {
 	 */
 	public static function bookings( $args, $assoc_args ) {
 		list( $amount ) = $args;
-		$amount = absint( $amount );
-
+		$amount     = absint( $amount );
 		$time_start = microtime( true );
 
 		// Convert --no-orders flag to with-orders arg.

--- a/includes/Generator/Booking.php
+++ b/includes/Generator/Booking.php
@@ -1,0 +1,518 @@
+<?php
+/**
+ * Booking data generation.
+ *
+ * @package SmoothGenerator\Classes
+ */
+
+namespace WC\SmoothGenerator\Generator;
+
+/**
+ * Booking data generator.
+ *
+ * Requires the WooCommerce Bookings extension to be active.
+ */
+class Booking extends Generator {
+
+	/**
+	 * Cache of bookable product IDs to avoid repeated queries.
+	 *
+	 * @var array
+	 */
+	private static $bookable_product_ids = array();
+
+	/**
+	 * Cache of customer IDs.
+	 *
+	 * @var array
+	 */
+	private static $customer_ids = array();
+
+	/**
+	 * Names for auto-generated bookable products, by type.
+	 *
+	 * @var array
+	 */
+	private static $product_templates = array(
+		'hourly'    => array(
+			'names'         => array(
+				'Private Consultation',
+				'Photography Session',
+				'Personal Training',
+				'Tutoring Session',
+				'Therapy Appointment',
+				'Music Lesson',
+				'Yoga Class',
+				'Massage Session',
+			),
+			'duration_unit' => 'hour',
+			'duration'      => 1,
+			'min_cost'      => 50,
+			'max_cost'      => 200,
+		),
+		'daily'     => array(
+			'names'         => array(
+				'Equipment Rental',
+				'Venue Booking',
+				'Car Rental',
+				'Vacation Cabin',
+				'Meeting Room',
+				'Studio Rental',
+			),
+			'duration_unit' => 'day',
+			'duration'      => 1,
+			'min_cost'      => 100,
+			'max_cost'      => 500,
+		),
+		'persons'   => array(
+			'names'         => array(
+				'Group Workshop',
+				'Team Building Event',
+				'Guided Tour',
+				'Cooking Class',
+				'Wine Tasting',
+			),
+			'duration_unit' => 'hour',
+			'duration'      => 2,
+			'min_cost'      => 30,
+			'max_cost'      => 100,
+		),
+	);
+
+	/**
+	 * Check that WooCommerce Bookings is active.
+	 *
+	 * @return true|\WP_Error
+	 */
+	private static function check_dependencies() {
+		if ( ! class_exists( 'WC_Bookings' ) && ! function_exists( 'create_wc_booking' ) ) {
+			return new \WP_Error(
+				'smoothgenerator_missing_bookings',
+				'WooCommerce Bookings extension is not installed or active. Please install and activate it before generating bookings.'
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return a new booking.
+	 *
+	 * @param bool  $save       Save the object before returning or not.
+	 * @param array $assoc_args Arguments passed via the CLI for additional customization.
+	 *
+	 * @return int|\WP_Error Booking ID on success.
+	 */
+	public static function generate( $save = true, array $assoc_args = array() ) {
+		$check = self::check_dependencies();
+		if ( is_wp_error( $check ) ) {
+			return $check;
+		}
+
+		parent::maybe_initialize_generators();
+
+		$args = wp_parse_args(
+			$assoc_args,
+			array(
+				'product-id'  => 0,
+				'date-start'  => gmdate( 'Y-m-d', strtotime( '-14 days' ) ),
+				'date-end'    => gmdate( 'Y-m-d', strtotime( '+42 days' ) ),
+				'status'      => '',
+				'with-orders' => true,
+			)
+		);
+
+		// Get a bookable product.
+		$product_id = absint( $args['product-id'] );
+
+		if ( $product_id ) {
+			$product = wc_get_product( $product_id );
+			if ( ! $product || ! $product->is_type( 'booking' ) ) {
+				return new \WP_Error(
+					'smoothgenerator_invalid_product',
+					sprintf( 'Product ID %d is not a valid bookable product.', $product_id )
+				);
+			}
+		} else {
+			$product_id = self::get_random_bookable_product_id();
+			if ( is_wp_error( $product_id ) ) {
+				return $product_id;
+			}
+			$product = wc_get_product( $product_id );
+		}
+
+		// Get a customer.
+		$customer_id = self::get_random_customer_id();
+
+		// Generate booking dates.
+		$dates = self::get_random_booking_dates( $product, $args['date-start'], $args['date-end'] );
+
+		// Determine status.
+		$status = ! empty( $args['status'] ) ? $args['status'] : self::get_random_status();
+
+		// Build booking data.
+		$booking_data = array(
+			'product_id' => $product_id,
+			'start_date' => $dates['start'],
+			'end_date'   => $dates['end'],
+			'user_id'    => $customer_id,
+		);
+
+		// Add person counts if the product supports them.
+		if ( method_exists( $product, 'get_has_persons' ) && $product->get_has_persons() ) {
+			$min_persons = max( 1, $product->get_min_persons() );
+			$max_persons = max( $min_persons, $product->get_max_persons() );
+			$booking_data['persons'] = wp_rand( $min_persons, $max_persons );
+		}
+
+		// Add resource if the product has resources.
+		if ( method_exists( $product, 'get_has_resources' ) && $product->get_has_resources() ) {
+			$resource_ids = $product->get_resource_ids();
+			if ( ! empty( $resource_ids ) ) {
+				$booking_data['resource_id'] = $resource_ids[ array_rand( $resource_ids ) ];
+			}
+		}
+
+		if ( ! $save ) {
+			return $booking_data;
+		}
+
+		// Create the booking using WooCommerce Bookings' helper.
+		$booking = create_wc_booking( $product_id, $booking_data, $status, true );
+
+		if ( is_wp_error( $booking ) ) {
+			return $booking;
+		}
+
+		$booking_id = is_object( $booking ) ? $booking->get_id() : $booking;
+
+		// Create an associated order if requested.
+		if ( ! empty( $args['with-orders'] ) && 'cancelled' !== $status ) {
+			self::create_associated_order( $booking, $product, $customer_id, $status );
+		}
+
+		/**
+		 * Action: Booking generator returned a new booking.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param int $booking_id The ID of the generated booking.
+		 */
+		do_action( 'smoothgenerator_booking_generated', $booking_id );
+
+		return $booking_id;
+	}
+
+	/**
+	 * Create multiple bookings.
+	 *
+	 * @param int   $amount The number of bookings to create.
+	 * @param array $args   Additional args for booking creation.
+	 *
+	 * @return int[]|\WP_Error
+	 */
+	public static function batch( $amount, array $args = array() ) {
+		$check = self::check_dependencies();
+		if ( is_wp_error( $check ) ) {
+			return $check;
+		}
+
+		$amount = self::validate_batch_amount( $amount );
+		if ( is_wp_error( $amount ) ) {
+			return $amount;
+		}
+
+		$booking_ids = array();
+
+		for ( $i = 1; $i <= $amount; $i++ ) {
+			$result = self::generate( true, $args );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			$booking_ids[] = $result;
+		}
+
+		return $booking_ids;
+	}
+
+	/**
+	 * Get a random bookable product ID, creating products if none exist.
+	 *
+	 * @return int|\WP_Error Product ID on success.
+	 */
+	private static function get_random_bookable_product_id() {
+		if ( empty( self::$bookable_product_ids ) ) {
+			// Query for existing bookable products.
+			$existing = wc_get_products(
+				array(
+					'type'   => 'booking',
+					'status' => 'publish',
+					'limit'  => 50,
+					'return' => 'ids',
+				)
+			);
+
+			if ( ! empty( $existing ) ) {
+				self::$bookable_product_ids = $existing;
+			} else {
+				// Create a set of varied bookable products.
+				$created = self::create_bookable_products();
+				if ( is_wp_error( $created ) ) {
+					return $created;
+				}
+				self::$bookable_product_ids = $created;
+			}
+		}
+
+		return self::$bookable_product_ids[ array_rand( self::$bookable_product_ids ) ];
+	}
+
+	/**
+	 * Create a set of varied bookable products.
+	 *
+	 * @return int[]|\WP_Error Array of product IDs on success.
+	 */
+	private static function create_bookable_products() {
+		$product_ids = array();
+
+		foreach ( self::$product_templates as $type => $template ) {
+			$product_id = self::create_bookable_product( $type );
+			if ( is_wp_error( $product_id ) ) {
+				return $product_id;
+			}
+			$product_ids[] = $product_id;
+		}
+
+		return $product_ids;
+	}
+
+	/**
+	 * Create a single bookable product of a given type.
+	 *
+	 * @param string $type One of 'hourly', 'daily', 'persons'.
+	 *
+	 * @return int|\WP_Error Product ID on success.
+	 */
+	private static function create_bookable_product( $type ) {
+		if ( ! isset( self::$product_templates[ $type ] ) ) {
+			return new \WP_Error(
+				'smoothgenerator_invalid_product_type',
+				sprintf( 'Unknown bookable product type: %s', $type )
+			);
+		}
+
+		$template = self::$product_templates[ $type ];
+		$name     = $template['names'][ array_rand( $template['names'] ) ];
+		$cost     = wp_rand( $template['min_cost'], $template['max_cost'] );
+
+		$product = new \WC_Product_Booking();
+		$product->set_name( $name );
+		$product->set_status( 'publish' );
+		$product->set_catalog_visibility( 'visible' );
+		$product->set_description( self::$faker->paragraph() );
+		$product->set_short_description( self::$faker->sentence() );
+		$product->set_regular_price( $cost );
+
+		// Booking-specific properties.
+		$product->set_duration_type( 'fixed' );
+		$product->set_duration_unit( $template['duration_unit'] );
+		$product->set_duration( $template['duration'] );
+		$product->set_cost( $cost );
+
+		// Set availability: bookable by default, 90 days into the future.
+		$product->set_min_date_value( 0 );
+		$product->set_min_date_unit( 'day' );
+		$product->set_max_date_value( 90 );
+		$product->set_max_date_unit( 'day' );
+		$product->set_default_date_availability( 'available' );
+
+		// Type-specific configuration.
+		if ( 'persons' === $type ) {
+			$product->set_has_persons( true );
+			$product->set_min_persons( 1 );
+			$product->set_max_persons( 10 );
+			$product->set_has_person_cost_multiplier( true );
+		}
+
+		$product->save();
+
+		return $product->get_id();
+	}
+
+	/**
+	 * Get a random customer ID, using existing customers or creating one.
+	 *
+	 * @return int WordPress user ID.
+	 */
+	private static function get_random_customer_id() {
+		if ( empty( self::$customer_ids ) ) {
+			$customers = get_users(
+				array(
+					'role'    => 'customer',
+					'fields'  => 'ID',
+					'number'  => 50,
+					'orderby' => 'rand',
+				)
+			);
+
+			if ( ! empty( $customers ) ) {
+				self::$customer_ids = $customers;
+			}
+		}
+
+		if ( ! empty( self::$customer_ids ) ) {
+			return (int) self::$customer_ids[ array_rand( self::$customer_ids ) ];
+		}
+
+		// Create a new customer.
+		$customer = Customer::generate( true );
+		if ( is_wp_error( $customer ) ) {
+			return 0;
+		}
+
+		$customer_id          = $customer->get_id();
+		self::$customer_ids[] = $customer_id;
+
+		return $customer_id;
+	}
+
+	/**
+	 * Generate random booking start and end dates based on product settings.
+	 *
+	 * @param \WC_Product_Booking $product    The bookable product.
+	 * @param string              $date_start Lower bound date string (Y-m-d).
+	 * @param string              $date_end   Upper bound date string (Y-m-d).
+	 *
+	 * @return array Array with 'start' and 'end' as Unix timestamps.
+	 */
+	private static function get_random_booking_dates( $product, $date_start, $date_end ) {
+		$start_bound = strtotime( $date_start );
+		$end_bound   = strtotime( $date_end );
+
+		if ( ! $start_bound || ! $end_bound || $start_bound >= $end_bound ) {
+			$start_bound = strtotime( '-14 days' );
+			$end_bound   = strtotime( '+42 days' );
+		}
+
+		$duration_unit = $product->get_duration_unit();
+		$duration      = max( 1, $product->get_duration() );
+
+		if ( 'day' === $duration_unit || 'month' === $duration_unit ) {
+			// For day-based bookings, pick a random day.
+			$start_timestamp = wp_rand( $start_bound, $end_bound );
+			// Normalize to beginning of day.
+			$start_timestamp = strtotime( 'midnight', $start_timestamp );
+
+			if ( 'month' === $duration_unit ) {
+				$end_timestamp = strtotime( '+' . $duration . ' months', $start_timestamp );
+			} else {
+				$end_timestamp = strtotime( '+' . $duration . ' days', $start_timestamp );
+			}
+		} else {
+			// For hour/minute-based bookings, pick a random day and time within business hours.
+			$random_day      = wp_rand( $start_bound, $end_bound );
+			$day_start       = strtotime( 'midnight', $random_day );
+			$hour            = wp_rand( 8, 17 ); // 8 AM to 5 PM.
+			$minute          = self::$faker->randomElement( array( 0, 15, 30, 45 ) );
+			$start_timestamp = $day_start + ( $hour * HOUR_IN_SECONDS ) + ( $minute * MINUTE_IN_SECONDS );
+
+			if ( 'minute' === $duration_unit ) {
+				$end_timestamp = $start_timestamp + ( $duration * MINUTE_IN_SECONDS );
+			} else {
+				$end_timestamp = $start_timestamp + ( $duration * HOUR_IN_SECONDS );
+			}
+		}
+
+		return array(
+			'start' => $start_timestamp,
+			'end'   => $end_timestamp,
+		);
+	}
+
+	/**
+	 * Get a random booking status using weighted distribution.
+	 *
+	 * @return string Booking status slug.
+	 */
+	private static function get_random_status() {
+		return self::random_weighted_element(
+			array(
+				'paid'                 => 35,
+				'confirmed'            => 25,
+				'complete'             => 20,
+				'unpaid'               => 10,
+				'pending-confirmation' => 5,
+				'cancelled'            => 5,
+			)
+		);
+	}
+
+	/**
+	 * Create an associated WooCommerce order for a booking.
+	 *
+	 * @param \WC_Booking         $booking     The booking object.
+	 * @param \WC_Product_Booking $product     The bookable product.
+	 * @param int                 $customer_id The customer user ID.
+	 * @param string              $status      The booking status.
+	 *
+	 * @return int|null Order ID on success, null on failure.
+	 */
+	private static function create_associated_order( $booking, $product, $customer_id, $status ) {
+		if ( ! is_object( $booking ) ) {
+			return null;
+		}
+
+		$order = wc_create_order(
+			array(
+				'customer_id' => $customer_id,
+				'status'      => self::map_booking_status_to_order_status( $status ),
+			)
+		);
+
+		if ( is_wp_error( $order ) ) {
+			return null;
+		}
+
+		// Add the booking product as a line item.
+		$cost = $booking->get_cost();
+		if ( ! $cost ) {
+			$cost = $product->get_price();
+		}
+
+		$item = new \WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( 1 );
+		$item->set_subtotal( $cost );
+		$item->set_total( $cost );
+		$order->add_item( $item );
+
+		$order->calculate_totals( false );
+		$order->save();
+
+		// Link the booking to the order.
+		$booking->set_order_id( $order->get_id() );
+		$booking->save();
+
+		return $order->get_id();
+	}
+
+	/**
+	 * Map a booking status to an appropriate WooCommerce order status.
+	 *
+	 * @param string $booking_status The booking status.
+	 *
+	 * @return string WooCommerce order status.
+	 */
+	private static function map_booking_status_to_order_status( $booking_status ) {
+		$map = array(
+			'paid'                 => 'completed',
+			'confirmed'            => 'processing',
+			'complete'             => 'completed',
+			'unpaid'               => 'pending',
+			'pending-confirmation' => 'on-hold',
+			'cancelled'            => 'cancelled',
+		);
+
+		return isset( $map[ $booking_status ] ) ? $map[ $booking_status ] : 'processing';
+	}
+}

--- a/includes/Generator/Booking.php
+++ b/includes/Generator/Booking.php
@@ -29,63 +29,43 @@ class Booking extends Generator {
 	private static $customer_ids = array();
 
 	/**
-	 * Names for auto-generated bookable products, by type.
+	 * Product types to auto-create when no bookable products exist.
 	 *
-	 * @var array
+	 * Each entry generates one product via Product::generate() to provide variety.
+	 *
+	 * @var string[]
 	 */
-	private static $product_templates = array(
-		'hourly'  => array(
-			'names'         => array(
-				'Private Consultation',
-				'Photography Session',
-				'Personal Training',
-				'Tutoring Session',
-				'Therapy Appointment',
-				'Music Lesson',
-				'Yoga Class',
-				'Massage Session',
-			),
-			'duration_unit' => 'hour',
-			'duration'      => 1,
-			'min_cost'      => 50,
-			'max_cost'      => 200,
-		),
-		'daily'   => array(
-			'names'         => array(
-				'Equipment Rental',
-				'Venue Booking',
-				'Car Rental',
-				'Vacation Cabin',
-				'Meeting Room',
-				'Studio Rental',
-			),
-			'duration_unit' => 'day',
-			'duration'      => 1,
-			'min_cost'      => 100,
-			'max_cost'      => 500,
-		),
-		'persons' => array(
-			'names'         => array(
-				'Group Workshop',
-				'Team Building Event',
-				'Guided Tour',
-				'Cooking Class',
-				'Wine Tasting',
-			),
-			'duration_unit' => 'hour',
-			'duration'      => 2,
-			'min_cost'      => 30,
-			'max_cost'      => 100,
-		),
-	);
+	private static $auto_create_types = array( 'booking', 'booking', 'bookable-service' );
 
 	/**
-	 * Check that WooCommerce Bookings is active.
+	 * Check whether WooCommerce Bookings is active.
+	 *
+	 * This is the canonical check used across all generators and admin UI.
+	 *
+	 * @return bool
+	 */
+	public static function is_bookings_active() {
+		return class_exists( 'WC_Bookings' ) || function_exists( 'create_wc_booking' );
+	}
+
+	/**
+	 * Check whether the experimental Bookings product types are available.
+	 *
+	 * The bookable-service and bookable-event types require WC_BOOKINGS_EXPERIMENTAL_ENABLED.
+	 *
+	 * @return bool
+	 */
+	public static function is_bookings_experimental_active() {
+		return self::is_bookings_active() && class_exists( 'WC_Product_Bookable_Service' );
+	}
+
+	/**
+	 * Check that WooCommerce Bookings is active, returning WP_Error if not.
 	 *
 	 * @return true|\WP_Error
 	 */
 	private static function check_dependencies() {
-		if ( ! class_exists( 'WC_Bookings' ) && ! function_exists( 'create_wc_booking' ) ) {
+		if ( ! self::is_bookings_active() ) {
 			return new \WP_Error(
 				'smoothgenerator_missing_bookings',
 				'WooCommerce Bookings extension is not installed or active. Please install and activate it before generating bookings.'
@@ -268,75 +248,24 @@ class Booking extends Generator {
 	}
 
 	/**
-	 * Create a set of varied bookable products.
+	 * Create a set of varied bookable products using the Product generator.
+	 *
+	 * Delegates to Product::generate() so product creation logic is not duplicated.
 	 *
 	 * @return int[]|\WP_Error Array of product IDs on success.
 	 */
 	private static function create_bookable_products() {
 		$product_ids = array();
 
-		foreach ( self::$product_templates as $type => $template ) {
-			$product_id = self::create_bookable_product( $type );
-			if ( is_wp_error( $product_id ) ) {
-				return $product_id;
+		foreach ( self::$auto_create_types as $type ) {
+			$product = Product::generate( true, array( 'type' => $type ) );
+			if ( is_wp_error( $product ) ) {
+				return $product;
 			}
-			$product_ids[] = $product_id;
+			$product_ids[] = $product->get_id();
 		}
 
 		return $product_ids;
-	}
-
-	/**
-	 * Create a single bookable product of a given type.
-	 *
-	 * @param string $type One of 'hourly', 'daily', 'persons'.
-	 *
-	 * @return int|\WP_Error Product ID on success.
-	 */
-	private static function create_bookable_product( $type ) {
-		if ( ! isset( self::$product_templates[ $type ] ) ) {
-			return new \WP_Error(
-				'smoothgenerator_invalid_product_type',
-				sprintf( 'Unknown bookable product type: %s', $type )
-			);
-		}
-
-		$template = self::$product_templates[ $type ];
-		$name     = $template['names'][ array_rand( $template['names'] ) ];
-		$cost     = wp_rand( $template['min_cost'], $template['max_cost'] );
-
-		$product = new \WC_Product_Booking();
-		$product->set_name( $name );
-		$product->set_status( 'publish' );
-		$product->set_catalog_visibility( 'visible' );
-		$product->set_description( self::$faker->paragraph() );
-		$product->set_short_description( self::$faker->sentence() );
-		$product->set_regular_price( $cost );
-
-		// Booking-specific properties.
-		$product->set_duration_type( 'fixed' );
-		$product->set_duration_unit( $template['duration_unit'] );
-		$product->set_duration( $template['duration'] );
-		$product->set_cost( $cost );
-
-		// Set availability: bookable by default, 90 days into the future.
-		$product->set_min_date_value( 0 );
-		$product->set_min_date_unit( 'day' );
-		$product->set_max_date_value( 90 );
-		$product->set_max_date_unit( 'day' );
-		$product->set_default_date_availability( 'available' );
-
-		// Type-specific configuration.
-		if ( 'persons' === $type ) {
-			$product->set_has_persons( true );
-			$product->set_min_persons( 1 );
-			$product->set_max_persons( 10 );
-			$product->set_has_person_cost_multiplier( true );
-		}
-
-		$product->save();
-
-		return $product->get_id();
 	}
 
 	/**

--- a/includes/Generator/Booking.php
+++ b/includes/Generator/Booking.php
@@ -81,7 +81,7 @@ class Booking extends Generator {
 	 * @param bool  $save       Save the object before returning or not.
 	 * @param array $assoc_args Arguments passed via the CLI for additional customization.
 	 *
-	 * @return int|\WP_Error Booking ID on success.
+	 * @return int|array|\WP_Error Booking ID when $save is true, unsaved booking data array when $save is false, or WP_Error on failure.
 	 */
 	public static function generate( $save = true, array $assoc_args = array() ) {
 		$check = self::check_dependencies();
@@ -168,7 +168,10 @@ class Booking extends Generator {
 
 		// Create an associated order if requested.
 		if ( ! empty( $args['with-orders'] ) && 'cancelled' !== $status ) {
-			self::create_associated_order( $booking, $product, $customer_id, $status );
+			$booking_object = is_object( $booking ) ? $booking : get_wc_booking( $booking_id );
+			if ( is_object( $booking_object ) ) {
+				self::create_associated_order( $booking_object, $product, $customer_id, $status );
+			}
 		}
 
 		/**
@@ -322,6 +325,9 @@ class Booking extends Generator {
 			$start_bound = strtotime( '-14 days' );
 			$end_bound   = strtotime( '+42 days' );
 		}
+
+		// Treat date-end as inclusive of the full day so random day selection can land on that date.
+		$end_bound += DAY_IN_SECONDS - 1;
 
 		$duration_unit = $product->get_duration_unit();
 		$duration      = max( 1, $product->get_duration() );

--- a/includes/Generator/Booking.php
+++ b/includes/Generator/Booking.php
@@ -34,7 +34,7 @@ class Booking extends Generator {
 	 * @var array
 	 */
 	private static $product_templates = array(
-		'hourly'    => array(
+		'hourly'  => array(
 			'names'         => array(
 				'Private Consultation',
 				'Photography Session',
@@ -50,7 +50,7 @@ class Booking extends Generator {
 			'min_cost'      => 50,
 			'max_cost'      => 200,
 		),
-		'daily'     => array(
+		'daily'   => array(
 			'names'         => array(
 				'Equipment Rental',
 				'Venue Booking',
@@ -64,7 +64,7 @@ class Booking extends Generator {
 			'min_cost'      => 100,
 			'max_cost'      => 500,
 		),
-		'persons'   => array(
+		'persons' => array(
 			'names'         => array(
 				'Group Workshop',
 				'Team Building Event',
@@ -160,8 +160,8 @@ class Booking extends Generator {
 
 		// Add person counts if the product supports them.
 		if ( method_exists( $product, 'get_has_persons' ) && $product->get_has_persons() ) {
-			$min_persons = max( 1, $product->get_min_persons() );
-			$max_persons = max( $min_persons, $product->get_max_persons() );
+			$min_persons             = max( 1, $product->get_min_persons() );
+			$max_persons             = max( $min_persons, $product->get_max_persons() );
 			$booking_data['persons'] = wp_rand( $min_persons, $max_persons );
 		}
 

--- a/includes/Generator/Booking.php
+++ b/includes/Generator/Booking.php
@@ -29,15 +29,6 @@ class Booking extends Generator {
 	private static $customer_ids = array();
 
 	/**
-	 * Product types to auto-create when no bookable products exist.
-	 *
-	 * Each entry generates one product via Product::generate() to provide variety.
-	 *
-	 * @var string[]
-	 */
-	private static $auto_create_types = array( 'booking', 'booking', 'bookable-service' );
-
-	/**
 	 * Check whether WooCommerce Bookings is active.
 	 *
 	 * This is the canonical check used across all generators and admin UI.
@@ -219,13 +210,12 @@ class Booking extends Generator {
 	}
 
 	/**
-	 * Get a random bookable product ID, creating products if none exist.
+	 * Get a random bookable product ID.
 	 *
-	 * @return int|\WP_Error Product ID on success.
+	 * @return int|\WP_Error Product ID on success, or WP_Error if no bookable products exist.
 	 */
 	private static function get_random_bookable_product_id() {
 		if ( empty( self::$bookable_product_ids ) ) {
-			// Query for existing bookable products.
 			$existing = wc_get_products(
 				array(
 					'type'   => 'booking',
@@ -235,40 +225,17 @@ class Booking extends Generator {
 				)
 			);
 
-			if ( ! empty( $existing ) ) {
-				self::$bookable_product_ids = $existing;
-			} else {
-				// Create a set of varied bookable products.
-				$created = self::create_bookable_products();
-				if ( is_wp_error( $created ) ) {
-					return $created;
-				}
-				self::$bookable_product_ids = $created;
+			if ( empty( $existing ) ) {
+				return new \WP_Error(
+					'smoothgenerator_no_bookable_products',
+					"No bookable products found. Create at least one bookable product before generating bookings. Example:\n\n    wp wc generate products 5 --type=booking"
+				);
 			}
+
+			self::$bookable_product_ids = $existing;
 		}
 
 		return self::$bookable_product_ids[ array_rand( self::$bookable_product_ids ) ];
-	}
-
-	/**
-	 * Create a set of varied bookable products using the Product generator.
-	 *
-	 * Delegates to Product::generate() so product creation logic is not duplicated.
-	 *
-	 * @return int[]|\WP_Error Array of product IDs on success.
-	 */
-	private static function create_bookable_products() {
-		$product_ids = array();
-
-		foreach ( self::$auto_create_types as $type ) {
-			$product = Product::generate( true, array( 'type' => $type ) );
-			if ( is_wp_error( $product ) ) {
-				return $product;
-			}
-			$product_ids[] = $product->get_id();
-		}
-
-		return $product_ids;
 	}
 
 	/**

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -88,8 +88,11 @@ class Product extends Generator {
 			case 'booking':
 				$product = self::generate_booking_product();
 				break;
-			case 'booking-service':
-				$product = self::generate_booking_service_product();
+			case 'bookable-service':
+				$product = self::generate_bookable_service_product();
+				break;
+			case 'bookable-event':
+				$product = self::generate_bookable_event_product();
 				break;
 		}
 
@@ -297,10 +300,12 @@ class Product extends Generator {
 	/**
 	 * Check whether WooCommerce Bookings is active.
 	 *
+	 * Delegates to Booking::is_bookings_active() as the single source of truth.
+	 *
 	 * @return bool
 	 */
 	protected static function is_bookings_active() {
-		return class_exists( 'WC_Bookings' ) || class_exists( 'WC_Product_Booking' );
+		return Booking::is_bookings_active();
 	}
 
 	/**
@@ -319,7 +324,11 @@ class Product extends Generator {
 
 		if ( self::is_bookings_active() ) {
 			$types[] = 'booking';
-			$types[] = 'booking-service';
+		}
+
+		if ( Booking::is_bookings_experimental_active() ) {
+			$types[] = 'bookable-service';
+			$types[] = 'bookable-event';
 		}
 
 		if ( ! is_null( $type ) && in_array( $type, $types, true ) ) {
@@ -524,7 +533,7 @@ class Product extends Generator {
 	 *
 	 * @var array
 	 */
-	protected static $booking_service_names = array(
+	protected static $bookable_service_names = array(
 		'Express Haircut',
 		'Oil Change Service',
 		'Pet Grooming',
@@ -535,6 +544,24 @@ class Product extends Generator {
 		'Passport Photo Service',
 		'Bike Tune-Up',
 		'Shoe Repair',
+	);
+
+	/**
+	 * Names for bookable event products.
+	 *
+	 * @var array
+	 */
+	protected static $bookable_event_names = array(
+		'Live Concert',
+		'Weekend Workshop',
+		'Wine Tasting Evening',
+		'Charity Gala',
+		'Tech Conference',
+		'Cooking Masterclass',
+		'Open Mic Night',
+		'Outdoor Movie Screening',
+		'Networking Mixer',
+		'Art Exhibition Opening',
 	);
 
 	/**
@@ -621,28 +648,26 @@ class Product extends Generator {
 	}
 
 	/**
-	 * Generate a bookable service product and return it.
+	 * Generate a bookable service product using the real WC_Product_Bookable_Service class.
 	 *
-	 * A "service" booking product is a virtual booking with no physical component:
-	 * short duration (minutes to a few hours), no persons, no resources.
+	 * Requires WooCommerce Bookings with experimental features enabled
+	 * (WC_BOOKINGS_EXPERIMENTAL_ENABLED). The class enforces: virtual, fixed duration
+	 * in minutes, default date availability = non-available, resources assignment = customer.
 	 *
-	 * Requires WooCommerce Bookings to be active.
-	 *
-	 * @return \WC_Product_Booking|\WP_Error Product object or WP_Error on failure.
+	 * @return \WC_Product_Bookable_Service|\WP_Error Product object or WP_Error on failure.
 	 */
-	protected static function generate_booking_service_product() {
-		if ( ! self::is_bookings_active() ) {
+	protected static function generate_bookable_service_product() {
+		if ( ! Booking::is_bookings_experimental_active() ) {
 			return new \WP_Error(
-				'smoothgenerator_missing_bookings',
-				'WooCommerce Bookings extension is not active. Cannot generate booking-service products.'
+				'smoothgenerator_missing_bookings_experimental',
+				'WooCommerce Bookings experimental features are not active. The bookable-service type requires WC_BOOKINGS_EXPERIMENTAL_ENABLED.'
 			);
 		}
 
-		$name     = self::$booking_service_names[ array_rand( self::$booking_service_names ) ];
-		$is_short = self::$faker->boolean( 60 );
-		$cost     = self::$faker->numberBetween( 10, 100 );
+		$name = self::$bookable_service_names[ array_rand( self::$bookable_service_names ) ];
+		$cost = self::$faker->numberBetween( 10, 100 );
 
-		$product = new \WC_Product_Booking();
+		$product = new \WC_Product_Bookable_Service();
 
 		$image_id = self::get_image();
 
@@ -654,37 +679,90 @@ class Product extends Generator {
 			'short_description'  => self::$faker->sentence(),
 			'sku'                => sanitize_title( $name ) . '-' . self::$faker->ean8,
 			'regular_price'      => $cost,
-			'virtual'            => true,
 			'image_id'           => $image_id,
 			'category_ids'       => self::get_term_ids( 'product_cat', self::$faker->numberBetween( 0, 2 ) ),
 			'tag_ids'            => self::get_term_ids( 'product_tag', self::$faker->numberBetween( 0, 3 ) ),
 		) );
 
-		// Booking-specific settings: short fixed-duration services.
-		$product->set_duration_type( 'fixed' );
-
-		if ( $is_short ) {
-			$product->set_duration_unit( 'minute' );
-			$product->set_duration( self::$faker->randomElement( array( 15, 20, 30, 45, 60 ) ) );
-		} else {
-			$product->set_duration_unit( 'hour' );
-			$product->set_duration( self::$faker->numberBetween( 1, 2 ) );
-		}
-
+		// Duration is always in minutes for service products (enforced by the class).
+		$product->set_duration( self::$faker->randomElement( array( 15, 20, 30, 45, 60 ) ) );
 		$product->set_cost( $cost );
 
-		// Availability: same-day or short-notice bookings.
+		// Availability window.
 		$product->set_min_date_value( 0 );
 		$product->set_min_date_unit( 'day' );
 		$product->set_max_date_value( self::$faker->numberBetween( 14, 60 ) );
 		$product->set_max_date_unit( 'day' );
-		$product->set_default_date_availability( 'available' );
 
-		// Services are typically not cancellable or have tight cancellation windows.
+		// Cancellation.
 		$product->set_user_can_cancel( self::$faker->boolean( 30 ) );
 
-		// No persons, no resources — this is the key differentiator from a regular booking.
-		$product->set_has_persons( false );
+		$product->set_status( 'publish' );
+		$product->save();
+
+		return $product;
+	}
+
+	/**
+	 * Generate a bookable event product using the real WC_Product_Bookable_Event class.
+	 *
+	 * Requires WooCommerce Bookings with experimental features enabled
+	 * (WC_BOOKINGS_EXPERIMENTAL_ENABLED).
+	 *
+	 * @return \WC_Product_Bookable_Event|\WP_Error Product object or WP_Error on failure.
+	 */
+	protected static function generate_bookable_event_product() {
+		if ( ! Booking::is_bookings_experimental_active() ) {
+			return new \WP_Error(
+				'smoothgenerator_missing_bookings_experimental',
+				'WooCommerce Bookings experimental features are not active. The bookable-event type requires WC_BOOKINGS_EXPERIMENTAL_ENABLED.'
+			);
+		}
+
+		$name = self::$bookable_event_names[ array_rand( self::$bookable_event_names ) ];
+		$cost = self::$faker->numberBetween( 15, 250 );
+
+		$product = new \WC_Product_Bookable_Event();
+
+		$image_id = self::get_image();
+
+		$product->set_props( array(
+			'name'               => $name,
+			'featured'           => self::$faker->boolean( 15 ),
+			'catalog_visibility' => 'visible',
+			'description'        => self::$faker->paragraphs( self::$faker->numberBetween( 1, 3 ), true ),
+			'short_description'  => self::$faker->sentence(),
+			'sku'                => sanitize_title( $name ) . '-' . self::$faker->ean8,
+			'regular_price'      => $cost,
+			'image_id'           => $image_id,
+			'category_ids'       => self::get_term_ids( 'product_cat', self::$faker->numberBetween( 0, 2 ) ),
+			'tag_ids'            => self::get_term_ids( 'product_tag', self::$faker->numberBetween( 0, 3 ) ),
+		) );
+
+		// Event-specific settings.
+		$product->set_duration_type( 'fixed' );
+		$product->set_duration_unit( 'hour' );
+		$product->set_duration( self::$faker->numberBetween( 1, 4 ) );
+		$product->set_cost( $cost );
+
+		// Availability window.
+		$product->set_min_date_value( 0 );
+		$product->set_min_date_unit( 'day' );
+		$product->set_max_date_value( self::$faker->numberBetween( 30, 120 ) );
+		$product->set_max_date_unit( 'day' );
+		$product->set_default_date_availability( 'available' );
+
+		// Events typically support persons (attendees).
+		$min_persons = 1;
+		$max_persons = self::$faker->numberBetween( 20, 200 );
+
+		$product->set_has_persons( true );
+		$product->set_min_persons( $min_persons );
+		$product->set_max_persons( $max_persons );
+		$product->set_has_person_cost_multiplier( true );
+
+		// Cancellation.
+		$product->set_user_can_cancel( self::$faker->boolean( 40 ) );
 
 		$product->set_status( 'publish' );
 		$product->save();

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -699,10 +699,18 @@ class Product extends Generator {
 	 */
 	protected static function add_booking_resources( $product ) {
 		$resource_names = array(
-			'Room A', 'Room B', 'Room C',
-			'Court 1', 'Court 2', 'Court 3',
-			'Station Alpha', 'Station Beta',
-			'Bay 1', 'Bay 2', 'Bay 3', 'Bay 4',
+			'Room A',
+			'Room B',
+			'Room C',
+			'Court 1',
+			'Court 2',
+			'Court 3',
+			'Station Alpha',
+			'Station Beta',
+			'Bay 1',
+			'Bay 2',
+			'Bay 3',
+			'Bay 4',
 		);
 
 		$num_resources = self::$faker->numberBetween( 2, 4 );

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -85,6 +85,12 @@ class Product extends Generator {
 			case 'variable':
 				$product = self::generate_variable_product();
 				break;
+			case 'booking':
+				$product = self::generate_booking_product();
+				break;
+			case 'booking-service':
+				$product = self::generate_booking_service_product();
+				break;
 		}
 
 		// Check if product generation failed.
@@ -289,6 +295,15 @@ class Product extends Generator {
 	}
 
 	/**
+	 * Check whether WooCommerce Bookings is active.
+	 *
+	 * @return bool
+	 */
+	protected static function is_bookings_active() {
+		return class_exists( 'WC_Bookings' ) || class_exists( 'WC_Product_Booking' );
+	}
+
+	/**
 	 * Returns a product type to generate. If no type is specified, or an invalid type is specified,
 	 * a weighted random type is returned.
 	 *
@@ -301,6 +316,11 @@ class Product extends Generator {
 			'simple',
 			'variable',
 		);
+
+		if ( self::is_bookings_active() ) {
+			$types[] = 'booking';
+			$types[] = 'booking-service';
+		}
 
 		if ( ! is_null( $type ) && in_array( $type, $types, true ) ) {
 			return $type;
@@ -467,6 +487,242 @@ class Product extends Generator {
 		}
 
 		return $product;
+	}
+
+	/**
+	 * Names for bookable product generation.
+	 *
+	 * @var array
+	 */
+	protected static $booking_product_names = array(
+		'hourly' => array(
+			'Private Consultation',
+			'Photography Session',
+			'Personal Training',
+			'Tutoring Session',
+			'Therapy Appointment',
+			'Music Lesson',
+			'Yoga Class',
+			'Massage Session',
+			'Career Coaching',
+			'Language Lesson',
+		),
+		'daily'  => array(
+			'Equipment Rental',
+			'Venue Booking',
+			'Car Rental',
+			'Vacation Cabin',
+			'Meeting Room',
+			'Studio Rental',
+			'Boat Rental',
+			'Campsite Reservation',
+		),
+	);
+
+	/**
+	 * Names for bookable service products.
+	 *
+	 * @var array
+	 */
+	protected static $booking_service_names = array(
+		'Express Haircut',
+		'Oil Change Service',
+		'Pet Grooming',
+		'Phone Screen Repair',
+		'Dry Cleaning Pickup',
+		'Car Wash & Detail',
+		'Key Cutting Service',
+		'Passport Photo Service',
+		'Bike Tune-Up',
+		'Shoe Repair',
+	);
+
+	/**
+	 * Generate a bookable product (WC_Product_Booking) and return it.
+	 *
+	 * Requires WooCommerce Bookings to be active.
+	 *
+	 * @return \WC_Product_Booking|\WP_Error Product object or WP_Error on failure.
+	 */
+	protected static function generate_booking_product() {
+		if ( ! self::is_bookings_active() ) {
+			return new \WP_Error(
+				'smoothgenerator_missing_bookings',
+				'WooCommerce Bookings extension is not active. Cannot generate booking products.'
+			);
+		}
+
+		$is_daily      = self::$faker->boolean( 40 );
+		$duration_unit = $is_daily ? 'day' : 'hour';
+		$duration      = $is_daily ? self::$faker->numberBetween( 1, 3 ) : self::$faker->numberBetween( 1, 4 );
+		$cost          = $is_daily
+			? self::$faker->numberBetween( 50, 500 )
+			: self::$faker->numberBetween( 25, 200 );
+
+		$name_pool = $is_daily ? self::$booking_product_names['daily'] : self::$booking_product_names['hourly'];
+		$name      = $name_pool[ array_rand( $name_pool ) ];
+
+		$has_persons   = self::$faker->boolean( 40 );
+		$has_resources = self::$faker->boolean( 30 );
+
+		$product = new \WC_Product_Booking();
+
+		$image_id = self::get_image();
+
+		$product->set_props( array(
+			'name'               => $name,
+			'featured'           => self::$faker->boolean( 10 ),
+			'catalog_visibility' => 'visible',
+			'description'        => self::$faker->paragraphs( self::$faker->numberBetween( 1, 3 ), true ),
+			'short_description'  => self::$faker->sentence(),
+			'sku'                => sanitize_title( $name ) . '-' . self::$faker->ean8,
+			'regular_price'      => $cost,
+			'image_id'           => $image_id,
+			'category_ids'       => self::get_term_ids( 'product_cat', self::$faker->numberBetween( 0, 2 ) ),
+			'tag_ids'            => self::get_term_ids( 'product_tag', self::$faker->numberBetween( 0, 3 ) ),
+		) );
+
+		// Booking-specific settings.
+		$product->set_duration_type( 'fixed' );
+		$product->set_duration_unit( $duration_unit );
+		$product->set_duration( $duration );
+		$product->set_cost( $cost );
+
+		// Availability window: bookable from now to 90 days in the future.
+		$product->set_min_date_value( 0 );
+		$product->set_min_date_unit( 'day' );
+		$product->set_max_date_value( self::$faker->numberBetween( 30, 180 ) );
+		$product->set_max_date_unit( 'day' );
+		$product->set_default_date_availability( 'available' );
+
+		// Cancellation.
+		$product->set_user_can_cancel( self::$faker->boolean( 60 ) );
+
+		// Person support.
+		if ( $has_persons ) {
+			$min_persons = self::$faker->numberBetween( 1, 2 );
+			$max_persons = self::$faker->numberBetween( $min_persons + 1, 20 );
+
+			$product->set_has_persons( true );
+			$product->set_min_persons( $min_persons );
+			$product->set_max_persons( $max_persons );
+			$product->set_has_person_cost_multiplier( self::$faker->boolean( 70 ) );
+		}
+
+		$product->set_status( 'publish' );
+		$product->save();
+
+		// Add resources after save (they need a product ID).
+		if ( $has_resources && method_exists( $product, 'set_has_resources' ) ) {
+			self::add_booking_resources( $product );
+		}
+
+		return $product;
+	}
+
+	/**
+	 * Generate a bookable service product and return it.
+	 *
+	 * A "service" booking product is a virtual booking with no physical component:
+	 * short duration (minutes to a few hours), no persons, no resources.
+	 *
+	 * Requires WooCommerce Bookings to be active.
+	 *
+	 * @return \WC_Product_Booking|\WP_Error Product object or WP_Error on failure.
+	 */
+	protected static function generate_booking_service_product() {
+		if ( ! self::is_bookings_active() ) {
+			return new \WP_Error(
+				'smoothgenerator_missing_bookings',
+				'WooCommerce Bookings extension is not active. Cannot generate booking-service products.'
+			);
+		}
+
+		$name     = self::$booking_service_names[ array_rand( self::$booking_service_names ) ];
+		$is_short = self::$faker->boolean( 60 );
+		$cost     = self::$faker->numberBetween( 10, 100 );
+
+		$product = new \WC_Product_Booking();
+
+		$image_id = self::get_image();
+
+		$product->set_props( array(
+			'name'               => $name,
+			'featured'           => self::$faker->boolean( 10 ),
+			'catalog_visibility' => 'visible',
+			'description'        => self::$faker->paragraphs( self::$faker->numberBetween( 1, 2 ), true ),
+			'short_description'  => self::$faker->sentence(),
+			'sku'                => sanitize_title( $name ) . '-' . self::$faker->ean8,
+			'regular_price'      => $cost,
+			'virtual'            => true,
+			'image_id'           => $image_id,
+			'category_ids'       => self::get_term_ids( 'product_cat', self::$faker->numberBetween( 0, 2 ) ),
+			'tag_ids'            => self::get_term_ids( 'product_tag', self::$faker->numberBetween( 0, 3 ) ),
+		) );
+
+		// Booking-specific settings: short fixed-duration services.
+		$product->set_duration_type( 'fixed' );
+
+		if ( $is_short ) {
+			$product->set_duration_unit( 'minute' );
+			$product->set_duration( self::$faker->randomElement( array( 15, 20, 30, 45, 60 ) ) );
+		} else {
+			$product->set_duration_unit( 'hour' );
+			$product->set_duration( self::$faker->numberBetween( 1, 2 ) );
+		}
+
+		$product->set_cost( $cost );
+
+		// Availability: same-day or short-notice bookings.
+		$product->set_min_date_value( 0 );
+		$product->set_min_date_unit( 'day' );
+		$product->set_max_date_value( self::$faker->numberBetween( 14, 60 ) );
+		$product->set_max_date_unit( 'day' );
+		$product->set_default_date_availability( 'available' );
+
+		// Services are typically not cancellable or have tight cancellation windows.
+		$product->set_user_can_cancel( self::$faker->boolean( 30 ) );
+
+		// No persons, no resources — this is the key differentiator from a regular booking.
+		$product->set_has_persons( false );
+
+		$product->set_status( 'publish' );
+		$product->save();
+
+		return $product;
+	}
+
+	/**
+	 * Add random resources to a bookable product.
+	 *
+	 * @param \WC_Product_Booking $product The bookable product.
+	 */
+	protected static function add_booking_resources( $product ) {
+		$resource_names = array(
+			'Room A', 'Room B', 'Room C',
+			'Court 1', 'Court 2', 'Court 3',
+			'Station Alpha', 'Station Beta',
+			'Bay 1', 'Bay 2', 'Bay 3', 'Bay 4',
+		);
+
+		$num_resources = self::$faker->numberBetween( 2, 4 );
+		shuffle( $resource_names );
+		$selected = array_slice( $resource_names, 0, $num_resources );
+
+		$product->set_has_resources( true );
+
+		foreach ( $selected as $resource_name ) {
+			$resource = new \WC_Product_Booking_Resource();
+			$resource->set_name( $resource_name );
+			$resource->set_qty( self::$faker->numberBetween( 1, 5 ) );
+			$resource->set_base_cost( 0 );
+			$resource->set_block_cost( 0 );
+			$resource->save();
+
+			$product->add_resource( $resource );
+		}
+
+		$product->save();
 	}
 
 	/**

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -797,17 +797,24 @@ class Product extends Generator {
 
 		$product->set_has_resources( true );
 
+		$base_costs  = array();
+		$block_costs = array();
+
 		foreach ( $selected as $resource_name ) {
 			$resource = new \WC_Product_Booking_Resource();
 			$resource->set_name( $resource_name );
 			$resource->set_qty( self::$faker->numberBetween( 1, 5 ) );
-			$resource->set_base_cost( 0 );
-			$resource->set_block_cost( 0 );
 			$resource->save();
 
 			$product->add_resource( $resource );
+
+			// Resource costs are stored at the product level, not on the resource object.
+			$base_costs[ $resource->get_id() ]  = 0;
+			$block_costs[ $resource->get_id() ] = 0;
 		}
 
+		$product->set_resource_base_costs( $base_costs );
+		$product->set_resource_block_costs( $block_costs );
 		$product->save();
 	}
 

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -333,12 +333,18 @@ class Product extends Generator {
 
 		if ( ! is_null( $type ) && in_array( $type, $types, true ) ) {
 			return $type;
-		} else {
-			return self::random_weighted_element( array(
-				'simple'   => 80,
-				'variable' => 20,
-			) );
 		}
+
+		// If the user explicitly requested a booking type but the dependency is inactive,
+		// pass it through so the downstream generator can surface a clear WP_Error.
+		if ( in_array( $type, array( 'booking', 'bookable-service', 'bookable-event' ), true ) ) {
+			return $type;
+		}
+
+		return self::random_weighted_element( array(
+			'simple'   => 80,
+			'variable' => 20,
+		) );
 	}
 
 	/**

--- a/includes/Router.php
+++ b/includes/Router.php
@@ -10,6 +10,7 @@ class Router {
 	 * @const array Associative array of available generator classes.
 	 */
 	const GENERATORS = array(
+		'bookings'  => Generator\Booking::class,
 		'coupons'   => Generator\Coupon::class,
 		'customers' => Generator\Customer::class,
 		'orders'    => Generator\Order::class,


### PR DESCRIPTION
## Summary

Adds a new Booking generator and bookable product types for the WooCommerce Bookings extension. Particularly useful for CIAB (Commerce in a Box) sites that need booking test data.

### What's included

- **New file: `includes/Generator/Booking.php`** - Core booking generator following the existing generator pattern
- **Modified: `includes/Generator/Product.php`** - Adds `booking` and `booking-service` product types to the product generator
- **Modified: `includes/Router.php`** - Registers the new `bookings` generator slug
- **Modified: `includes/CLI.php`** - Adds `wp wc generate bookings` WP-CLI command and extends `wp wc generate products --type` with `booking`/`booking-service`
- **Modified: `includes/Admin/Settings.php`** - Adds bookings section to the admin UI (conditionally shown when Bookings is active)
- **Modified: `README.md`** - Updated documentation with all new features, examples, and API usage

### Features

**Booking generator (`wp wc generate bookings`)**
- Checks for WooCommerce Bookings dependency before proceeding; shows a clear error if not installed
- Auto-creates varied bookable products (hourly services, daily rentals, group workshops) if none exist on the site
- Generates bookings with realistic dates, weighted status distribution, and random customer assignments
- Creates associated WooCommerce orders for bookings (can be disabled with `--no-orders`)
- Supports person counts and resource assignment based on product configuration
- Admin UI shows disabled state with explanation when WooCommerce Bookings is not active

**Bookable product types (`wp wc generate products --type=booking|booking-service`)**
- `booking`: Full bookable products with hourly or daily durations, person support (~40%), resource assignment (~30%), configurable availability windows, and cancellation settings
- `booking-service`: Virtual short-duration service products (haircuts, repairs, grooming) with minute/hour durations and no persons or resources
- Both types return a clear error if WooCommerce Bookings is not active

### CLI Usage

```bash
# Generate 10 bookings with defaults
wp wc generate bookings 10

# Generate 50 bookings in a date range
wp wc generate bookings 50 --date-start=2026-04-01 --date-end=2026-06-30

# Generate bookings for a specific product
wp wc generate bookings 20 --status=confirmed --product-id=42

# Generate bookings without associated orders
wp wc generate bookings 30 --no-orders

# Generate bookable products
wp wc generate products 5 --type=booking

# Generate bookable service products
wp wc generate products 5 --type=booking-service
```

## Test plan

### Prerequisites
- [ ] Install WooCommerce Bookings on a test site (or use a CIAB site with Bookings)
- [ ] Install the plugin from the zip attached to this PR or build from source

### Booking generation
- [ ] Run `wp wc generate bookings 10` and verify bookings appear in WooCommerce > Bookings
- [ ] Verify auto-created bookable products exist (hourly, daily, group types)
- [ ] Run `wp wc generate bookings 5 --status=confirmed` and verify all bookings have "confirmed" status
- [ ] Run `wp wc generate bookings 5 --date-start=2026-05-01 --date-end=2026-05-31` and verify dates are within range
- [ ] Run `wp wc generate bookings 5 --no-orders` and verify no WooCommerce orders are created for those bookings
- [ ] Test with `--product-id` pointing to an existing bookable product

### Bookable product generation
- [ ] Run `wp wc generate products 5 --type=booking` and verify 5 bookable products are created in Products list
- [ ] Verify booking products have varied configurations: some with persons, some with resources
- [ ] Run `wp wc generate products 5 --type=booking-service` and verify 5 virtual service products are created
- [ ] Verify service products have short durations (minutes or 1-2 hours) and are virtual
- [ ] Verify service products do NOT have persons or resources enabled

### Error handling
- [ ] Deactivate WooCommerce Bookings, then run `wp wc generate bookings 5` — verify clear error message
- [ ] Deactivate WooCommerce Bookings, then run `wp wc generate products 5 --type=booking` — verify clear error message
- [ ] Run `wp wc generate products 5 --type=booking-service` without Bookings — verify clear error message

### Admin UI
- [ ] Navigate to Tools > Smooth Generator — verify bookings section appears when Bookings is active
- [ ] Deactivate Bookings — verify bookings section shows disabled state with explanation
- [ ] Generate bookings from the admin UI and verify they appear correctly

### CIAB testing
- [ ] Test all of the above on a CIAB site with WooCommerce Bookings installed

## Building a test zip

```bash
git clone https://github.com/woocommerce/wc-smooth-generator.git
cd wc-smooth-generator
git checkout add/bookings-generator
composer install --no-dev
zip -r wc-smooth-generator.zip . -x ".git/*" "node_modules/*" ".github/*" "tests/*"
```

Or download the pre-built zip from this PR's artifacts.