### PR TITLE
Improve order generation throughput for large datasets

### DIFF
--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -12,8 +12,8 @@ namespace WC\SmoothGenerator\Admin;
  */
 class Settings {
 
-	const DEFAULT_NUM_PRODUCTS           = 10;
-	const DEFAULT_NUM_ORDERS             = 10;
+	const DEFAULT_NUM_PRODUCTS = 10;
+	const DEFAULT_NUM_ORDERS   = 10;
 
 	/**
 	 *  Set up hooks.
@@ -65,12 +65,12 @@ class Settings {
 					if ( 'analytics-sync' === $current_job->generator_slug ) {
 						printf(
 							'Syncing analytics for %s orders&hellip;',
-							number_format_i18n( $current_job->amount )
+							esc_html( number_format_i18n( $current_job->amount ) )
 						);
 					} else {
 						printf(
 							'Generating %s %s&hellip;',
-							number_format_i18n( $current_job->amount ),
+							esc_html( number_format_i18n( $current_job->amount ) ),
 							esc_html( $current_job->generator_slug )
 						);
 					}
@@ -86,7 +86,7 @@ class Settings {
 					printf(
 						'%d out of %d',
 						esc_html( $current_job->processed ),
-						esc_html( $current_job->amount ),
+						esc_html( $current_job->amount )
 					);
 					?>
 				</progress>
@@ -234,11 +234,11 @@ class Settings {
 			<?php else : ?>
 				<p>
 					<?php if ( $unsynced_count > 0 ) : ?>
-						<strong><?php echo number_format_i18n( $unsynced_count ); ?></strong> of
-						<strong><?php echo number_format_i18n( $total_count ); ?></strong> orders
+						<strong><?php echo esc_html( number_format_i18n( $unsynced_count ) ); ?></strong> of
+						<strong><?php echo esc_html( number_format_i18n( $total_count ) ); ?></strong> orders
 						are not yet reflected in Analytics reports.
 					<?php else : ?>
-						All <?php echo number_format_i18n( $total_count ); ?> orders are reflected in Analytics reports.
+						All <?php echo esc_html( number_format_i18n( $total_count ) ); ?> orders are reflected in Analytics reports.
 					<?php endif; ?>
 				</p>
 				<p>
@@ -250,7 +250,7 @@ class Settings {
 						false,
 						array_merge(
 							$generate_button_atts,
-							$unsynced_count === 0 ? array( 'disabled' => true ) : array()
+							0 === $unsynced_count ? array( 'disabled' => true ) : array()
 						)
 					);
 					?>
@@ -263,7 +263,7 @@ class Settings {
 							name="confirm_resync_all"
 							<?php disabled( $current_job instanceof AsyncJob ); ?>
 						/>
-						Re-sync all <?php echo number_format_i18n( $total_count ); ?> orders (replaces existing Analytics data)
+						Re-sync all <?php echo esc_html( number_format_i18n( $total_count ) ); ?> orders (replaces existing Analytics data)
 					</label>
 				</p>
 				<p>
@@ -275,7 +275,10 @@ class Settings {
 						false,
 						array_merge(
 							$generate_button_atts,
-							array( 'disabled' => true, 'id' => 'sync_analytics_all_btn' )
+							array(
+								'disabled' => true,
+								'id'       => 'sync_analytics_all_btn',
+							)
 						)
 					);
 					?>
@@ -374,7 +377,7 @@ class Settings {
 				} );
 			} )( jQuery );
 		</script>
-	<?php
+		<?php
 	}
 
 	/**
@@ -410,15 +413,15 @@ class Settings {
 		$args = array();
 
 		if ( ! empty( $_POST['use_date_range'] ) ) {
-			$args['date-start'] = sanitize_text_field( $_POST['start_date'] );
-			$args['date-end']   = sanitize_text_field( $_POST['end_date'] );
+			$args['date-start'] = sanitize_text_field( wp_unslash( $_POST['start_date'] ?? '' ) );
+			$args['date-end']   = sanitize_text_field( wp_unslash( $_POST['end_date'] ?? '' ) );
 		}
 
 		if ( ! empty( $_POST['generate_products'] ) && ! empty( $_POST['num_products_to_generate'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_products_to_generate'] );
 			BatchProcessor::create_new_job( 'products', $num_to_generate, $args );
-		} else if ( ! empty( $_POST['generate_orders'] ) && ! empty( $_POST['num_orders_to_generate'] ) ) {
+		} elseif ( ! empty( $_POST['generate_orders'] ) && ! empty( $_POST['num_orders_to_generate'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_orders_to_generate'] );
 			if ( ! empty( $_POST['use_bulk_insert'] ) && \WC\SmoothGenerator\Generator\OrderBulkInserter::is_hpos_enabled() ) {
@@ -434,7 +437,7 @@ class Settings {
 				}
 			}
 			BatchProcessor::create_new_job( 'orders', $num_to_generate, $args );
-		} else if ( ! empty( $_POST['sync_analytics_unsynced'] ) ) {
+		} elseif ( ! empty( $_POST['sync_analytics_unsynced'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			if ( \WC\SmoothGenerator\Generator\OrderAnalyticsSync::is_hpos_available() ) {
 				$unsynced = \WC\SmoothGenerator\Generator\OrderAnalyticsSync::get_unsynced_count();
@@ -442,7 +445,7 @@ class Settings {
 					BatchProcessor::create_new_job( 'analytics-sync', $unsynced, array() );
 				}
 			}
-		} else if ( ! empty( $_POST['sync_analytics_all'] ) && ! empty( $_POST['confirm_resync_all'] ) ) {
+		} elseif ( ! empty( $_POST['sync_analytics_all'] ) && ! empty( $_POST['confirm_resync_all'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			if ( \WC\SmoothGenerator\Generator\OrderAnalyticsSync::is_hpos_available() ) {
 				$total = \WC\SmoothGenerator\Generator\OrderAnalyticsSync::get_total_order_count();
@@ -451,7 +454,7 @@ class Settings {
 					BatchProcessor::create_new_job( 'analytics-sync', $total, array( 'all' => true ) );
 				}
 			}
-		} else if ( ! empty( $_POST['cancel_job'] ) ) {
+		} elseif ( ! empty( $_POST['cancel_job'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			BatchProcessor::delete_current_job();
 		}
@@ -490,7 +493,7 @@ class Settings {
 					$next_wait = 0;
 				}
 				$embed = $videos[ $next_wait ];
-				$next_wait ++;
+				++$next_wait;
 				setcookie(
 					'smoothgenerator_next_wait',
 					$next_wait,

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -42,7 +42,8 @@ class Settings {
 	 * Render the admin page.
 	 */
 	public static function render_admin_page() {
-		$current_job = self::get_current_job();
+		$current_job  = self::get_current_job();
+		$hpos_enabled = \WC\SmoothGenerator\Generator\OrderBulkInserter::is_hpos_enabled();
 
 		$generate_button_atts = $current_job instanceof AsyncJob ? array( 'disabled' => true ) : array();
 		$cancel_button_atts   = ! $current_job instanceof AsyncJob ? array( 'disabled' => true ) : array();
@@ -145,6 +146,20 @@ class Settings {
 					Specify date range for generation
 				</label>
 			</p>
+			<p>
+				<label>
+					<input
+						type="checkbox"
+						id="use_bulk_insert"
+						name="use_bulk_insert"
+						<?php disabled( $current_job instanceof AsyncJob || ! $hpos_enabled ); ?>
+					/>
+					Use bulk insert for orders (HPOS required)
+				</label>
+				<?php if ( ! $hpos_enabled ) : ?>
+					<span class="description"> &mdash; HPOS is not enabled. <a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=advanced&section=features' ) ); ?>">Enable it here</a>.</span>
+				<?php endif; ?>
+			</p>
 			<div id="date_range_inputs" style="display: none;">
 				<p>
 					<label for="generate_start_date_input">Start date</label>
@@ -210,7 +225,7 @@ class Settings {
 			( function( $ ) {
 				const $document = $( document );
 				const $progress = $( '#smoothgenerator-progress-bar' );
-				const $controls = $( '[id^="generate_"], #use_date_range, #date_range_inputs input' );
+				const $controls = $( '[id^="generate_"], #use_date_range, #use_bulk_insert, #date_range_inputs input' );
 				const $cancel   = $( '#cancel_job' );
 
 				$document.on( 'ready', function () {
@@ -284,10 +299,10 @@ class Settings {
 	 */
 	public static function process_page_submit() {
 		$args = array();
-		
+
 		if ( ! empty( $_POST['use_date_range'] ) ) {
 			$args['date-start'] = sanitize_text_field( $_POST['start_date'] );
-			$args['date-end'] = sanitize_text_field( $_POST['end_date'] );
+			$args['date-end']   = sanitize_text_field( $_POST['end_date'] );
 		}
 
 		if ( ! empty( $_POST['generate_products'] ) && ! empty( $_POST['num_products_to_generate'] ) ) {
@@ -297,6 +312,9 @@ class Settings {
 		} else if ( ! empty( $_POST['generate_orders'] ) && ! empty( $_POST['num_orders_to_generate'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_orders_to_generate'] );
+			if ( ! empty( $_POST['use_bulk_insert'] ) && \WC\SmoothGenerator\Generator\OrderBulkInserter::is_hpos_enabled() ) {
+				$args['bulk-insert'] = true;
+			}
 			BatchProcessor::create_new_job( 'orders', $num_to_generate, $args );
 		} else if ( ! empty( $_POST['cancel_job'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -163,12 +163,47 @@ class Settings {
 						name="use_bulk_insert"
 						<?php disabled( $current_job instanceof AsyncJob || ! $hpos_enabled ); ?>
 					/>
-					Use bulk insert for orders (HPOS required)
+					Use bulk insert for orders (HPOS required) <span class="description">&mdash; experimental</span>
 				</label>
 				<?php if ( ! $hpos_enabled ) : ?>
 					<span class="description"> &mdash; HPOS is not enabled. <a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=advanced&section=features' ) ); ?>">Enable it here</a>.</span>
 				<?php endif; ?>
 			</p>
+			<div id="bulk_insert_options" style="display: none; margin-left: 1.5em;">
+				<p>
+					<label>
+						<input
+							type="checkbox"
+							id="use_bulk_coupons"
+							name="use_bulk_coupons"
+							<?php disabled( $current_job instanceof AsyncJob || ! $hpos_enabled ); ?>
+						/>
+						Apply a random coupon to each order (uses existing coupons; creates 6 if none exist)
+					</label>
+				</p>
+				<p>
+					<label>
+						<input
+							type="checkbox"
+							id="use_bulk_shipping"
+							name="use_bulk_shipping"
+							<?php disabled( $current_job instanceof AsyncJob || ! $hpos_enabled ); ?>
+						/>
+						Add a shipping line using a random enabled shipping zone method
+					</label>
+				</p>
+				<p>
+					<label>
+						<input
+							type="checkbox"
+							id="use_bulk_taxes"
+							name="use_bulk_taxes"
+							<?php disabled( $current_job instanceof AsyncJob || ! $hpos_enabled ); ?>
+						/>
+						Add a tax line using a random defined tax rate
+					</label>
+				</p>
+			</div>
 			<div id="date_range_inputs" style="display: none;">
 				<p>
 					<label for="generate_start_date_input">Start date</label>
@@ -190,7 +225,7 @@ class Settings {
 				</p>
 			</div>
 
-			<h2>Sync Analytics</h2>
+			<h2>Sync Analytics <span class="description" style="font-size: 0.8em; font-weight: normal;">&mdash; experimental</span></h2>
 			<?php if ( ! $hpos_enabled ) : ?>
 				<p class="description">
 					Analytics sync requires HPOS to be enabled.
@@ -276,6 +311,10 @@ class Settings {
 					$( '#date_range_inputs' ).toggle( this.checked );
 				} );
 
+				$( '#use_bulk_insert' ).on( 'change', function() {
+					$( '#bulk_insert_options' ).toggle( this.checked );
+				} );
+
 				$( '#confirm_resync_all' ).on( 'change', function() {
 					$( '#sync_analytics_all_btn' ).prop( 'disabled', ! this.checked );
 				} );
@@ -295,7 +334,7 @@ class Settings {
 			( function( $ ) {
 				const $document = $( document );
 				const $progress = $( '#smoothgenerator-progress-bar' );
-				const $controls = $( '[id^="generate_"], #use_date_range, #use_bulk_insert, #confirm_resync_all, #date_range_inputs input, [name="sync_analytics_unsynced"]' );
+				const $controls = $( '[id^="generate_"], #use_date_range, #use_bulk_insert, #use_bulk_coupons, #use_bulk_shipping, #use_bulk_taxes, #confirm_resync_all, #date_range_inputs input, [name="sync_analytics_unsynced"]' );
 				const $cancel   = $( '#cancel_job' );
 
 				$document.on( 'ready', function () {
@@ -384,6 +423,15 @@ class Settings {
 			$num_to_generate = absint( $_POST['num_orders_to_generate'] );
 			if ( ! empty( $_POST['use_bulk_insert'] ) && \WC\SmoothGenerator\Generator\OrderBulkInserter::is_hpos_enabled() ) {
 				$args['bulk-insert'] = true;
+				if ( ! empty( $_POST['use_bulk_coupons'] ) ) {
+					$args['coupons'] = true;
+				}
+				if ( ! empty( $_POST['use_bulk_shipping'] ) ) {
+					$args['shipping'] = true;
+				}
+				if ( ! empty( $_POST['use_bulk_taxes'] ) ) {
+					$args['taxes'] = true;
+				}
 			}
 			BatchProcessor::create_new_job( 'orders', $num_to_generate, $args );
 		} else if ( ! empty( $_POST['sync_analytics_unsynced'] ) ) {

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -42,8 +42,10 @@ class Settings {
 	 * Render the admin page.
 	 */
 	public static function render_admin_page() {
-		$current_job  = self::get_current_job();
-		$hpos_enabled = \WC\SmoothGenerator\Generator\OrderBulkInserter::is_hpos_enabled();
+		$current_job    = self::get_current_job();
+		$hpos_enabled   = \WC\SmoothGenerator\Generator\OrderBulkInserter::is_hpos_enabled();
+		$unsynced_count = $hpos_enabled ? \WC\SmoothGenerator\Generator\OrderAnalyticsSync::get_unsynced_count() : 0;
+		$total_count    = $hpos_enabled ? \WC\SmoothGenerator\Generator\OrderAnalyticsSync::get_total_order_count() : 0;
 
 		$generate_button_atts = $current_job instanceof AsyncJob ? array( 'disabled' => true ) : array();
 		$cancel_button_atts   = ! $current_job instanceof AsyncJob ? array( 'disabled' => true ) : array();
@@ -60,11 +62,18 @@ class Settings {
 			<div id="smoothgenerator-progress">
 				<label for="smoothgenerator-progress-bar" style="display: block;">
 					<?php
-					printf(
-						'Generating %s %s&hellip;',
-						number_format_i18n( $current_job->amount ),
-						esc_html( $current_job->generator_slug )
-					);
+					if ( 'analytics-sync' === $current_job->generator_slug ) {
+						printf(
+							'Syncing analytics for %s orders&hellip;',
+							number_format_i18n( $current_job->amount )
+						);
+					} else {
+						printf(
+							'Generating %s %s&hellip;',
+							number_format_i18n( $current_job->amount ),
+							esc_html( $current_job->generator_slug )
+						);
+					}
 					?>
 				</label>
 				<progress
@@ -181,6 +190,63 @@ class Settings {
 				</p>
 			</div>
 
+			<h2>Sync Analytics</h2>
+			<?php if ( ! $hpos_enabled ) : ?>
+				<p class="description">
+					Analytics sync requires HPOS to be enabled.
+					<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=advanced&section=features' ) ); ?>">Enable it here</a>.
+				</p>
+			<?php else : ?>
+				<p>
+					<?php if ( $unsynced_count > 0 ) : ?>
+						<strong><?php echo number_format_i18n( $unsynced_count ); ?></strong> of
+						<strong><?php echo number_format_i18n( $total_count ); ?></strong> orders
+						are not yet reflected in Analytics reports.
+					<?php else : ?>
+						All <?php echo number_format_i18n( $total_count ); ?> orders are reflected in Analytics reports.
+					<?php endif; ?>
+				</p>
+				<p>
+					<?php
+					submit_button(
+						'Sync unsynced orders',
+						'secondary',
+						'sync_analytics_unsynced',
+						false,
+						array_merge(
+							$generate_button_atts,
+							$unsynced_count === 0 ? array( 'disabled' => true ) : array()
+						)
+					);
+					?>
+				</p>
+				<p>
+					<label>
+						<input
+							type="checkbox"
+							id="confirm_resync_all"
+							name="confirm_resync_all"
+							<?php disabled( $current_job instanceof AsyncJob ); ?>
+						/>
+						Re-sync all <?php echo number_format_i18n( $total_count ); ?> orders (replaces existing Analytics data)
+					</label>
+				</p>
+				<p>
+					<?php
+					submit_button(
+						'Re-sync all orders',
+						'secondary',
+						'sync_analytics_all',
+						false,
+						array_merge(
+							$generate_button_atts,
+							array( 'disabled' => true, 'id' => 'sync_analytics_all_btn' )
+						)
+					);
+					?>
+				</p>
+			<?php endif; ?>
+
 			<?php
 			submit_button(
 				'Cancel current job',
@@ -209,6 +275,10 @@ class Settings {
 				$( '#use_date_range' ).on( 'change', function() {
 					$( '#date_range_inputs' ).toggle( this.checked );
 				} );
+
+				$( '#confirm_resync_all' ).on( 'change', function() {
+					$( '#sync_analytics_all_btn' ).prop( 'disabled', ! this.checked );
+				} );
 			} )( jQuery );
 		</script>
 		<?php
@@ -225,7 +295,7 @@ class Settings {
 			( function( $ ) {
 				const $document = $( document );
 				const $progress = $( '#smoothgenerator-progress-bar' );
-				const $controls = $( '[id^="generate_"], #use_date_range, #use_bulk_insert, #date_range_inputs input' );
+				const $controls = $( '[id^="generate_"], #use_date_range, #use_bulk_insert, #confirm_resync_all, #date_range_inputs input, [name="sync_analytics_unsynced"]' );
 				const $cancel   = $( '#cancel_job' );
 
 				$document.on( 'ready', function () {
@@ -316,6 +386,23 @@ class Settings {
 				$args['bulk-insert'] = true;
 			}
 			BatchProcessor::create_new_job( 'orders', $num_to_generate, $args );
+		} else if ( ! empty( $_POST['sync_analytics_unsynced'] ) ) {
+			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
+			if ( \WC\SmoothGenerator\Generator\OrderAnalyticsSync::is_hpos_available() ) {
+				$unsynced = \WC\SmoothGenerator\Generator\OrderAnalyticsSync::get_unsynced_count();
+				if ( $unsynced > 0 ) {
+					BatchProcessor::create_new_job( 'analytics-sync', $unsynced, array() );
+				}
+			}
+		} else if ( ! empty( $_POST['sync_analytics_all'] ) && ! empty( $_POST['confirm_resync_all'] ) ) {
+			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
+			if ( \WC\SmoothGenerator\Generator\OrderAnalyticsSync::is_hpos_available() ) {
+				$total = \WC\SmoothGenerator\Generator\OrderAnalyticsSync::get_total_order_count();
+				if ( $total > 0 ) {
+					delete_option( \WC\SmoothGenerator\Generator\OrderAnalyticsSync::CURSOR_OPTION );
+					BatchProcessor::create_new_job( 'analytics-sync', $total, array( 'all' => true ) );
+				}
+			}
 		} else if ( ! empty( $_POST['cancel_job'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			BatchProcessor::delete_current_job();

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -94,7 +94,7 @@ class CLI extends WP_CLI_Command {
 				return;
 			}
 			WP_CLI::log( 'Bulk-insert mode: writing directly into HPOS tables (no ORM, no tax calculation, no coupons/refunds).' );
-			WP_CLI::log( 'Analytics tables (wc_order_stats, wc_order_product_lookup) are populated inline.' );
+			WP_CLI::log( 'Run `wp wc sync analytics` after generation to populate Analytics report data.' );
 		}
 
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating orders', $amount );
@@ -284,7 +284,83 @@ class CLI extends WP_CLI_Command {
 
 		WP_CLI::success( $generated . ' terms generated in ' . $display_time );
 	}
+
+	/**
+	 * Sync orders into WooCommerce Analytics tables.
+	 *
+	 * @param array $args Arguments specified.
+	 * @param array $assoc_args Associative arguments specified.
+	 */
+	public static function sync_analytics( $args, $assoc_args ) {
+		if ( ! Generator\OrderAnalyticsSync::is_hpos_available() ) {
+			WP_CLI::error(
+				'Analytics sync requires WooCommerce HPOS (High-Performance Order Storage) to be enabled. '
+				. 'Enable it under WooCommerce > Settings > Advanced > Features.'
+			);
+			return;
+		}
+
+		$all        = ! empty( $assoc_args['all'] );
+		$time_start = microtime( true );
+
+		if ( $all ) {
+			$total = Generator\OrderAnalyticsSync::get_total_order_count();
+			WP_CLI::log( "Re-syncing all $total orders into Analytics tables." );
+			delete_option( Generator\OrderAnalyticsSync::CURSOR_OPTION );
+		} else {
+			$total = Generator\OrderAnalyticsSync::get_unsynced_count();
+			if ( $total === 0 ) {
+				WP_CLI::success( 'All orders are already reflected in the Analytics tables.' );
+				return;
+			}
+			WP_CLI::log( "Syncing $total unsynced orders into Analytics tables." );
+		}
+
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Syncing analytics', $total );
+		$synced   = 0;
+
+		while ( true ) {
+			$batch_size = min( Generator\OrderAnalyticsSync::MAX_BATCH_SIZE, $total - $synced );
+			if ( $batch_size <= 0 ) {
+				break;
+			}
+
+			$result = Generator\OrderAnalyticsSync::batch( $batch_size, $assoc_args );
+
+			if ( empty( $result ) ) {
+				break; // No more orders to process.
+			}
+
+			$synced += count( $result );
+			$progress->tick( count( $result ) );
+		}
+
+		$progress->finish();
+
+		if ( $all ) {
+			delete_option( Generator\OrderAnalyticsSync::CURSOR_OPTION );
+		}
+
+		$time_end       = microtime( true );
+		$execution_time = round( ( $time_end - $time_start ), 2 );
+		$display_time   = $execution_time < 60 ? $execution_time . ' seconds' : human_time_diff( $time_start, $time_end );
+
+		WP_CLI::success( "$synced orders synced into Analytics tables in $display_time." );
+	}
 }
+
+WP_CLI::add_command( 'wc sync analytics', array( 'WC\SmoothGenerator\CLI', 'sync_analytics' ), array(
+	'shortdesc' => 'Sync orders into WooCommerce Analytics tables.',
+	'synopsis'  => array(
+		array(
+			'name'        => 'all',
+			'type'        => 'flag',
+			'description' => 'Re-sync every order, including those already in the Analytics tables. Useful after bulk imports. Without this flag only orders missing from the Analytics tables are processed.',
+			'optional'    => true,
+		),
+	),
+	'longdesc'  => "## EXAMPLES\n\nwc sync analytics\n\nwc sync analytics --all",
+) );
 
 WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'products' ), array(
 	'shortdesc' => 'Generate products.',
@@ -369,7 +445,7 @@ WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'ord
 		array(
 			'name'        => 'bulk-insert',
 			'type'        => 'flag',
-			'description' => 'Write orders directly into HPOS tables via raw SQL, bypassing the WC_Order ORM. Requires HPOS to be enabled. Much faster for large volumes but skips tax calculation, coupons, and refunds. Analytics tables (wc_order_stats, wc_order_product_lookup) are populated inline.',
+			'description' => 'Write orders directly into HPOS tables via raw SQL, bypassing the WC_Order ORM. Requires HPOS to be enabled. Much faster for large volumes but skips tax calculation, coupons, and refunds. Run `wp wc sync analytics` after to populate Analytics report data.',
 			'optional'    => true,
 		),
 	),

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -74,7 +74,8 @@ class CLI extends WP_CLI_Command {
 		list( $amount ) = $args;
 		$amount = absint( $amount );
 
-		$time_start = microtime( true );
+		$time_start  = microtime( true );
+		$bulk_insert = ! empty( $assoc_args['bulk-insert'] );
 
 		if ( ! empty( $assoc_args['status'] ) ) {
 			$status = $assoc_args['status'];
@@ -82,6 +83,18 @@ class CLI extends WP_CLI_Command {
 				WP_CLI::error( "The argument \"$status\" is not a valid order status." );
 				return;
 			}
+		}
+
+		if ( $bulk_insert ) {
+			if ( ! Generator\OrderBulkInserter::is_hpos_enabled() ) {
+				WP_CLI::error(
+					'--bulk-insert requires WooCommerce HPOS (High-Performance Order Storage) to be enabled. '
+					. 'Enable it under WooCommerce > Settings > Advanced > Features.'
+				);
+				return;
+			}
+			WP_CLI::log( 'Bulk-insert mode: writing directly into HPOS tables (no ORM, no tax calculation, no coupons/refunds).' );
+			WP_CLI::log( 'Run `wp wc analytics sync` after generation to rebuild Analytics report data.' );
 		}
 
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating orders', $amount );
@@ -93,20 +106,32 @@ class CLI extends WP_CLI_Command {
 			}
 		);
 
-		$remaining_amount = $amount;
-		$generated        = 0;
+		$generated = 0;
 
-		while ( $remaining_amount > 0 ) {
-			$batch = min( $remaining_amount, Generator\Order::MAX_BATCH_SIZE );
-
-			$result = Generator\Order::batch( $batch, $assoc_args );
+		if ( $bulk_insert ) {
+			$result = Generator\Order::bulk_insert( $amount, $assoc_args );
 
 			if ( is_wp_error( $result ) ) {
-				WP_CLI::error( $result );
+				WP_CLI::error( $result->get_error_message() );
+				return;
 			}
 
-			$generated        += count( $result );
-			$remaining_amount -= $batch;
+			$generated = count( $result );
+		} else {
+			$remaining_amount = $amount;
+
+			while ( $remaining_amount > 0 ) {
+				$batch = min( $remaining_amount, Generator\Order::MAX_BATCH_SIZE );
+
+				$result = Generator\Order::batch( $batch, $assoc_args );
+
+				if ( is_wp_error( $result ) ) {
+					WP_CLI::error( $result );
+				}
+
+				$generated        += count( $result );
+				$remaining_amount -= $batch;
+			}
 		}
 
 		$progress->finish();
@@ -340,9 +365,15 @@ WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'ord
 			'type'        => 'flag',
 			'description' => 'Skip adding order attribution meta to the generated orders.',
 			'optional'    => true,
-		)
+		),
+		array(
+			'name'        => 'bulk-insert',
+			'type'        => 'flag',
+			'description' => 'Write orders directly into HPOS tables via raw SQL, bypassing the WC_Order ORM. Requires HPOS to be enabled. Much faster for large volumes but skips tax calculation, coupons, and refunds. Run `wp wc analytics sync` after to rebuild report data.',
+			'optional'    => true,
+		),
 	),
-	'longdesc'  => "## EXAMPLES\n\nwc generate orders 10\n\nwc generate orders 50 --date-start=2020-01-01 --date-end=2022-12-31 --status=completed --coupons",
+	'longdesc'  => "## EXAMPLES\n\nwc generate orders 10\n\nwc generate orders 50 --date-start=2020-01-01 --date-end=2022-12-31 --status=completed --coupons\n\nwc generate orders 1000000 --bulk-insert --status=completed --date-start=2020-01-01 --date-end=2024-12-31",
 ) );
 
 WP_CLI::add_command( 'wc generate customers', array( 'WC\SmoothGenerator\CLI', 'customers' ), array(

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -21,7 +21,7 @@ class CLI extends WP_CLI_Command {
 	 */
 	public static function products( $args, $assoc_args ) {
 		list( $amount ) = $args;
-		$amount = absint( $amount );
+		$amount         = absint( $amount );
 
 		$time_start = microtime( true );
 
@@ -72,7 +72,7 @@ class CLI extends WP_CLI_Command {
 	 */
 	public static function orders( $args, $assoc_args ) {
 		list( $amount ) = $args;
-		$amount = absint( $amount );
+		$amount         = absint( $amount );
 
 		$time_start  = microtime( true );
 		$bulk_insert = ! empty( $assoc_args['bulk-insert'] );
@@ -140,7 +140,7 @@ class CLI extends WP_CLI_Command {
 		$execution_time = round( ( $time_end - $time_start ), 2 );
 		$display_time   = $execution_time < 60 ? $execution_time . ' seconds' : human_time_diff( $time_start, $time_end );
 
-		if ( $generated === 0 && $amount > 0 ) {
+		if ( 0 === $generated && $amount > 0 ) {
 			WP_CLI::error( 'No orders were generated. Make sure there are published products in your store.' );
 		}
 
@@ -155,7 +155,7 @@ class CLI extends WP_CLI_Command {
 	 */
 	public static function customers( $args, $assoc_args ) {
 		list( $amount ) = $args;
-		$amount = absint( $amount );
+		$amount         = absint( $amount );
 
 		$time_start = microtime( true );
 
@@ -201,7 +201,7 @@ class CLI extends WP_CLI_Command {
 	 */
 	public static function coupons( $args, $assoc_args ) {
 		list( $amount ) = $args;
-		$amount = absint( $amount );
+		$amount         = absint( $amount );
 
 		$time_start = microtime( true );
 
@@ -247,7 +247,7 @@ class CLI extends WP_CLI_Command {
 	 */
 	public static function terms( $args, $assoc_args ) {
 		list( $taxonomy, $amount ) = $args;
-		$amount = absint( $amount );
+		$amount                    = absint( $amount );
 
 		$time_start = microtime( true );
 
@@ -309,7 +309,7 @@ class CLI extends WP_CLI_Command {
 			delete_option( Generator\OrderAnalyticsSync::CURSOR_OPTION );
 		} else {
 			$total = Generator\OrderAnalyticsSync::get_unsynced_count();
-			if ( $total === 0 ) {
+			if ( 0 === $total ) {
 				WP_CLI::success( 'All orders are already reflected in the Analytics tables.' );
 				return;
 			}
@@ -559,5 +559,5 @@ WP_CLI::add_command( 'wc generate terms', array( 'WC\SmoothGenerator\CLI', 'term
 			'default'     => 0,
 		),
 	),
-	'longdesc' => "## EXAMPLES\n\nwc generate terms product_tag 10\n\nwc generate terms product_cat 50 --max-depth=3",
+	'longdesc'  => "## EXAMPLES\n\nwc generate terms product_tag 10\n\nwc generate terms product_cat 50 --max-depth=3",
 ) );

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -93,7 +93,7 @@ class CLI extends WP_CLI_Command {
 				);
 				return;
 			}
-			WP_CLI::log( 'Bulk-insert mode: writing directly into HPOS tables (no ORM, no tax calculation, no coupons/refunds).' );
+			WP_CLI::log( 'Bulk-insert mode: writing directly into HPOS tables (no ORM, no refunds).' );
 			WP_CLI::log( 'Run `wp wc sync analytics` after generation to populate Analytics report data.' );
 		}
 
@@ -445,11 +445,23 @@ WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'ord
 		array(
 			'name'        => 'bulk-insert',
 			'type'        => 'flag',
-			'description' => 'Write orders directly into HPOS tables via raw SQL, bypassing the WC_Order ORM. Requires HPOS to be enabled. Much faster for large volumes but skips tax calculation, coupons, and refunds. Run `wp wc sync analytics` after to populate Analytics report data.',
+			'description' => 'Write orders directly into HPOS tables via raw SQL, bypassing the WC_Order ORM. Requires HPOS to be enabled. Much faster for large volumes but skips refunds. Combine with --coupons, --shipping, --taxes for those features. Run `wp wc sync analytics` after to populate Analytics report data.',
+			'optional'    => true,
+		),
+		array(
+			'name'        => 'shipping',
+			'type'        => 'flag',
+			'description' => 'Bulk-insert only: add a shipping line item to each order using a random enabled shipping zone method. If no shipping zones are defined, shipping is skipped.',
+			'optional'    => true,
+		),
+		array(
+			'name'        => 'taxes',
+			'type'        => 'flag',
+			'description' => 'Bulk-insert only: add a tax line item to each order using a random defined tax rate. If no tax rates are defined, taxes are skipped.',
 			'optional'    => true,
 		),
 	),
-	'longdesc'  => "## EXAMPLES\n\nwc generate orders 10\n\nwc generate orders 50 --date-start=2020-01-01 --date-end=2022-12-31 --status=completed --coupons\n\nwc generate orders 1000000 --bulk-insert --status=completed --date-start=2020-01-01 --date-end=2024-12-31",
+	'longdesc'  => "## EXAMPLES\n\nwc generate orders 10\n\nwc generate orders 50 --date-start=2020-01-01 --date-end=2022-12-31 --status=completed --coupons\n\nwc generate orders 1000000 --bulk-insert --status=completed --date-start=2020-01-01 --date-end=2024-12-31\n\nwc generate orders 1000000 --bulk-insert --coupons --shipping --taxes --date-start=2020-01-01 --date-end=2024-12-31",
 ) );
 
 WP_CLI::add_command( 'wc generate customers', array( 'WC\SmoothGenerator\CLI', 'customers' ), array(

--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -94,7 +94,7 @@ class CLI extends WP_CLI_Command {
 				return;
 			}
 			WP_CLI::log( 'Bulk-insert mode: writing directly into HPOS tables (no ORM, no tax calculation, no coupons/refunds).' );
-			WP_CLI::log( 'Run `wp wc analytics sync` after generation to rebuild Analytics report data.' );
+			WP_CLI::log( 'Analytics tables (wc_order_stats, wc_order_product_lookup) are populated inline.' );
 		}
 
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating orders', $amount );
@@ -369,7 +369,7 @@ WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'ord
 		array(
 			'name'        => 'bulk-insert',
 			'type'        => 'flag',
-			'description' => 'Write orders directly into HPOS tables via raw SQL, bypassing the WC_Order ORM. Requires HPOS to be enabled. Much faster for large volumes but skips tax calculation, coupons, and refunds. Run `wp wc analytics sync` after to rebuild report data.',
+			'description' => 'Write orders directly into HPOS tables via raw SQL, bypassing the WC_Order ORM. Requires HPOS to be enabled. Much faster for large volumes but skips tax calculation, coupons, and refunds. Analytics tables (wc_order_stats, wc_order_product_lookup) are populated inline.',
 			'optional'    => true,
 		),
 	),

--- a/includes/Generator/Coupon.php
+++ b/includes/Generator/Coupon.php
@@ -13,6 +13,14 @@ use WC_Data_Store;
  * Customer data generator.
  */
 class Coupon extends Generator {
+
+	/**
+	 * Cached coupon IDs for fast random selection without repeated DB queries.
+	 *
+	 * @var int[]|null Null means not yet loaded.
+	 */
+	private static $cached_coupon_ids = null;
+
 	/**
 	 * Create a new coupon.
 	 *
@@ -148,28 +156,43 @@ class Coupon extends Generator {
 	/**
 	 * Get a random existing coupon.
 	 *
+	 * Coupon IDs are fetched once per process lifetime and cached in memory,
+	 * eliminating the repeated full-table scan that occurred on every order.
+	 *
 	 * @return \WC_Coupon|false Coupon object or false if none available.
 	 */
 	public static function get_random() {
-		// Note: Using posts_per_page=-1 loads all coupon IDs into memory for random selection.
-		// For stores with thousands of coupons, consider using direct SQL with RAND() for better performance.
-		// This approach was chosen for consistency with WordPress APIs and to avoid raw SQL queries.
-		$coupon_ids = get_posts(
-			array(
-				'post_type'      => 'shop_coupon',
-				'post_status'    => 'publish',
-				'posts_per_page' => -1,
-				'fields'         => 'ids',
-			)
-		);
+		global $wpdb;
 
-		if ( empty( $coupon_ids ) ) {
+		if ( null === self::$cached_coupon_ids ) {
+			self::$cached_coupon_ids = array_map(
+				'intval',
+				$wpdb->get_col(
+					"SELECT ID FROM {$wpdb->posts}
+					WHERE post_type = 'shop_coupon'
+					AND post_status = 'publish'"
+				)
+			);
+		}
+
+		if ( empty( self::$cached_coupon_ids ) ) {
 			return false;
 		}
 
-		$random_coupon_id = $coupon_ids[ array_rand( $coupon_ids ) ];
+		$random_coupon_id = self::$cached_coupon_ids[ array_rand( self::$cached_coupon_ids ) ];
 
 		return new \WC_Coupon( $random_coupon_id );
+	}
+
+	/**
+	 * Invalidate the coupon ID cache so the next call to get_random() re-fetches from the DB.
+	 *
+	 * Call this after creating new coupons during a generation run.
+	 *
+	 * @return void
+	 */
+	public static function invalidate_cache() {
+		self::$cached_coupon_ids = null;
 	}
 }
 

--- a/includes/Generator/Generator.php
+++ b/includes/Generator/Generator.php
@@ -14,7 +14,7 @@ abstract class Generator {
 	/**
 	 * Maximum number of objects that can be generated in one batch.
 	 */
-	const MAX_BATCH_SIZE = 100;
+	const MAX_BATCH_SIZE = 1000;
 
 	/**
 	 * Dimension, in pixels, of generated images.

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -595,6 +595,21 @@ class Order extends Generator {
 	}
 
 	/**
+	 * Invalidate the in-memory product and customer caches.
+	 *
+	 * Forces the next call to get_customer() and get_random_products() to
+	 * re-query the database. Primarily useful in test environments where the
+	 * DB is rolled back between tests, making cached IDs stale.
+	 *
+	 * @return void
+	 */
+	public static function invalidate_caches(): void {
+		self::$cached_user_ids       = null;
+		self::$cached_product_ids    = null;
+		self::$cached_product_objects = array();
+	}
+
+	/**
 	 * Get a random existing coupon or create coupons if none exist.
 	 * If no coupons exist, creates 6 coupons: 3 fixed value and 3 percentage.
 	 *

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -286,6 +286,21 @@ class Order extends Generator {
 	}
 
 	/**
+	 * Create multiple orders using raw SQL bulk inserts (HPOS only).
+	 *
+	 * Delegates to OrderBulkInserter which writes directly into the HPOS tables,
+	 * bypassing the WC_Order ORM for maximum throughput. See OrderBulkInserter
+	 * for a full description of what is and isn't supported in this mode.
+	 *
+	 * @param int   $amount Number of orders to create.
+	 * @param array $args   Additional args for order creation.
+	 * @return int[]|\WP_Error IDs of inserted orders, or a WP_Error on failure.
+	 */
+	public static function bulk_insert( int $amount, array $args = array() ) {
+		return OrderBulkInserter::run( $amount, $args );
+	}
+
+	/**
 	 * Create multiple orders.
 	 *
 	 * @param int    $amount   The number of orders to create.

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -52,6 +52,28 @@ class Order extends Generator {
 	const REFUND_DISTRIBUTION_PARTIAL_RATIO = 0.25;
 
 	/**
+	 * Cached user IDs for fast random customer selection without repeated COUNT + ORDER BY RAND() queries.
+	 *
+	 * @var int[]|null Null means not yet loaded.
+	 */
+	private static $cached_user_ids = null;
+
+	/**
+	 * Cached published product IDs for fast random product selection without repeated queries.
+	 *
+	 * @var int[]|null Null means not yet loaded.
+	 */
+	private static $cached_product_ids = null;
+
+	/**
+	 * Cached WC_Product objects keyed by product ID.
+	 * Avoids repeated wc_get_product() calls for the same product across orders.
+	 *
+	 * @var array<int, \WC_Product>
+	 */
+	private static $cached_product_objects = array();
+
+	/**
 	 * Return a new order.
 	 *
 	 * @param bool        $save Save the object before returning or not.
@@ -385,6 +407,10 @@ class Order extends Generator {
 	/**
 	 * Return a new customer.
 	 *
+	 * User IDs are fetched once per process lifetime and cached in memory,
+	 * eliminating the COUNT + ORDER BY RAND() full table scan that ran on every order.
+	 * Newly created guest customers are appended to the cache to keep it warm.
+	 *
 	 * @return \WC_Customer Customer object with data populated.
 	 */
 	public static function get_customer() {
@@ -394,16 +420,29 @@ class Order extends Generator {
 		$existing = (bool) wp_rand( 0, 1 );
 
 		if ( $existing ) {
-			$total_users = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->users}" );
-			$offset      = wp_rand( 0, $total_users );
-			$user_id     = (int) $wpdb->get_var( "SELECT ID FROM {$wpdb->users} ORDER BY rand() LIMIT $offset, 1" ); // phpcs:ignore
-			return new \WC_Customer( $user_id );
+			if ( null === self::$cached_user_ids ) {
+				self::$cached_user_ids = array_map(
+					'intval',
+					$wpdb->get_col( "SELECT ID FROM {$wpdb->users}" )
+				);
+			}
+
+			if ( ! empty( self::$cached_user_ids ) ) {
+				$user_id = self::$cached_user_ids[ array_rand( self::$cached_user_ids ) ];
+				return new \WC_Customer( $user_id );
+			}
 		}
 
 		$customer = Customer::generate( ! $guest );
 
 		if ( ! $customer instanceof \WC_Customer ) {
 			error_log( 'Customer generation failed: Customer::generate() returned invalid result' );
+			return $customer;
+		}
+
+		// Keep the cache warm so subsequent "existing" picks can use this customer.
+		if ( null !== self::$cached_user_ids && $customer->get_id() ) {
+			self::$cached_user_ids[] = $customer->get_id();
 		}
 
 		return $customer;
@@ -466,7 +505,11 @@ class Order extends Generator {
 	}
 
 	/**
-	 *  Get random products selected from existing products.
+	 * Get random products selected from existing products.
+	 *
+	 * Product IDs are fetched once per process lifetime and cached in memory,
+	 * replacing the per-order COUNT + WC_Product_Query with ORDER BY RAND().
+	 * Product objects are also cached to avoid repeated wc_get_product() calls.
 	 *
 	 * @param int $min_amount Minimum amount of products to get.
 	 * @param int $max_amount Maximum amount of products to get.
@@ -475,53 +518,48 @@ class Order extends Generator {
 	protected static function get_random_products( int $min_amount = 1, int $max_amount = 4 ) {
 		global $wpdb;
 
-		$products = array();
+		if ( null === self::$cached_product_ids ) {
+			self::$cached_product_ids = array_map(
+				'intval',
+				$wpdb->get_col(
+					"SELECT ID FROM {$wpdb->posts}
+					WHERE post_type = 'product'
+					AND post_status = 'publish'"
+				)
+			);
+		}
 
-		$num_existing_products = (int) $wpdb->get_var(
-			"SELECT COUNT( DISTINCT ID )
-			FROM {$wpdb->posts}
-			WHERE 1=1
-			AND post_type='product'
-			AND post_status='publish'"
-		);
-
-		if ( $num_existing_products === 0 ) {
+		if ( empty( self::$cached_product_ids ) ) {
 			error_log( 'No published products found in database' );
 			return array();
 		}
 
-		$num_products_to_get = wp_rand( $min_amount, $max_amount );
+		$pool_size           = count( self::$cached_product_ids );
+		$num_products_to_get = wp_rand( $min_amount, min( $max_amount, $pool_size ) );
 
-		if ( $num_products_to_get > $num_existing_products ) {
-			$num_products_to_get = $num_existing_products;
-		}
+		// Pick unique random indices from the pool.
+		$keys        = (array) array_rand( self::$cached_product_ids, min( $num_products_to_get, $pool_size ) );
+		$product_ids = array_map( fn( $k ) => self::$cached_product_ids[ $k ], $keys );
 
-		$query = new \WC_Product_Query( array(
-			'limit'   => $num_products_to_get,
-			'return'  => 'ids',
-			'orderby' => 'rand',
-		) );
-
-		$product_ids = $query->get_products();
-		if ( empty( $product_ids ) ) {
-			error_log( 'WC_Product_Query returned no product IDs' );
-			return array();
-		}
-
+		$products = array();
 		foreach ( $product_ids as $product_id ) {
-			$product = wc_get_product( $product_id );
-
-			if ( ! $product ) {
-				error_log( "Failed to retrieve product with ID: {$product_id}" );
-				continue;
+			if ( ! isset( self::$cached_product_objects[ $product_id ] ) ) {
+				$product = wc_get_product( $product_id );
+				if ( ! $product ) {
+					error_log( "Failed to retrieve product with ID: {$product_id}" );
+					continue;
+				}
+				self::$cached_product_objects[ $product_id ] = $product;
 			}
+
+			$product = self::$cached_product_objects[ $product_id ];
 
 			if ( $product->is_type( 'variable' ) ) {
 				$available_variations = $product->get_available_variations();
 				if ( empty( $available_variations ) ) {
 					continue;
 				}
-				$index      = self::$faker->numberBetween( 0, count( $available_variations ) - 1 );
+				$index     = self::$faker->numberBetween( 0, count( $available_variations ) - 1 );
 				$variation = new \WC_Product_Variation( $available_variations[ $index ]['variation_id'] );
 				if ( $variation && $variation->exists() ) {
 					$products[] = $variation;
@@ -555,6 +593,9 @@ class Order extends Generator {
 
 			// Create 3 percentage coupons (5%-25%)
 			$percent_result = Coupon::batch( 3, array( 'min' => 5, 'max' => 25, 'discount_type' => 'percent' ) );
+
+			// Invalidate the coupon ID cache so the newly created coupons are included.
+			Coupon::invalidate_cache();
 
 		// If coupon creation failed, return false
 		if ( is_wp_error( $fixed_result ) || is_wp_error( $percent_result ) ) {

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -303,12 +303,19 @@ class Order extends Generator {
 	/**
 	 * Create multiple orders.
 	 *
+	 * When $args['bulk-insert'] is set, delegates to OrderBulkInserter::run() which
+	 * writes directly into HPOS tables via raw SQL instead of using the WC_Order ORM.
+	 *
 	 * @param int    $amount   The number of orders to create.
 	 * @param array  $args     Additional args for order creation.
 	 *
 	 * @return int[]|\WP_Error
 	 */
 	public static function batch( $amount, array $args = array() ) {
+		if ( ! empty( $args['bulk-insert'] ) ) {
+			return OrderBulkInserter::run( (int) $amount, $args );
+		}
+
 		$amount = self::validate_batch_amount( $amount );
 		if ( is_wp_error( $amount ) ) {
 			error_log( 'Batch generation failed: ' . $amount->get_error_message() );

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -604,8 +604,8 @@ class Order extends Generator {
 	 * @return void
 	 */
 	public static function invalidate_caches(): void {
-		self::$cached_user_ids       = null;
-		self::$cached_product_ids    = null;
+		self::$cached_user_ids        = null;
+		self::$cached_product_ids     = null;
 		self::$cached_product_objects = array();
 	}
 

--- a/includes/Generator/OrderAnalyticsSync.php
+++ b/includes/Generator/OrderAnalyticsSync.php
@@ -146,7 +146,7 @@ class OrderAnalyticsSync {
 		}
 
 		if ( ! empty( $order_ids ) ) {
-			self::sync_order_ids( $order_ids, $all );
+			self::sync_order_ids( $order_ids, $all ); // throws \RuntimeException on DB failure
 		}
 
 		return $order_ids;
@@ -184,188 +184,211 @@ class OrderAnalyticsSync {
 		$in     = implode( ',', array_fill( 0, count( $order_ids ), '%d' ) );
 		$insert = $replace ? 'REPLACE INTO' : 'INSERT IGNORE INTO';
 
+		$check = static function ( $result, string $table ) use ( $wpdb ): void {
+			if ( false === $result ) {
+				$msg = "SmoothGenerator analytics sync: failed to write to $table — " . $wpdb->last_error;
+				error_log( $msg );
+				throw new \RuntimeException( $msg );
+			}
+		};
+
 		// ------------------------------------------------------------------
 		// 1. wc_customer_lookup
 		//    Always INSERT IGNORE — replacing would generate a new customer_id
 		//    (AUTO_INCREMENT) and orphan any existing wc_order_stats rows.
 		// ------------------------------------------------------------------
-		$wpdb->query(
-			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"INSERT IGNORE INTO {$wpdb->prefix}wc_customer_lookup
-				     (user_id, username, first_name, last_name, email,
-				      date_last_active, date_registered, country, postcode, city, state)
-				 SELECT
-				     o.customer_id,
-				     MIN( COALESCE( u.user_login, '' ) ),
-				     MIN( COALESCE( a.first_name, '' ) ),
-				     MIN( COALESCE( a.last_name, '' ) ),
-				     MIN( a.email ),
-				     MAX( o.date_created_gmt ),
-				     MIN( u.user_registered ),
-				     MIN( COALESCE( a.country, '' ) ),
-				     MIN( COALESCE( a.postcode, '' ) ),
-				     MIN( COALESCE( a.city, '' ) ),
-				     MIN( COALESCE( a.state, '' ) )
-				 FROM {$wpdb->prefix}wc_orders o
-				 LEFT JOIN {$wpdb->users} u ON u.ID = o.customer_id
-				 LEFT JOIN {$wpdb->prefix}wc_order_addresses a
-				        ON a.order_id = o.id AND a.address_type = 'billing'
-				 WHERE o.id IN ( $in )
-				 GROUP BY o.customer_id",
-				...$order_ids
-			)
+		$check(
+			$wpdb->query(
+				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					"INSERT IGNORE INTO {$wpdb->prefix}wc_customer_lookup
+					     (user_id, username, first_name, last_name, email,
+					      date_last_active, date_registered, country, postcode, city, state)
+					 SELECT
+					     o.customer_id,
+					     MIN( COALESCE( u.user_login, '' ) ),
+					     MIN( COALESCE( a.first_name, '' ) ),
+					     MIN( COALESCE( a.last_name, '' ) ),
+					     MIN( a.email ),
+					     MAX( o.date_created_gmt ),
+					     MIN( u.user_registered ),
+					     MIN( COALESCE( a.country, '' ) ),
+					     MIN( COALESCE( a.postcode, '' ) ),
+					     MIN( COALESCE( a.city, '' ) ),
+					     MIN( COALESCE( a.state, '' ) )
+					 FROM {$wpdb->prefix}wc_orders o
+					 LEFT JOIN {$wpdb->users} u ON u.ID = o.customer_id
+					 LEFT JOIN {$wpdb->prefix}wc_order_addresses a
+					        ON a.order_id = o.id AND a.address_type = 'billing'
+					 WHERE o.id IN ( $in )
+					 GROUP BY o.customer_id",
+					...$order_ids
+				)
+			),
+			'wc_customer_lookup'
 		);
 
 		// ------------------------------------------------------------------
 		// 2. wc_order_stats
-		//    shipping_total is read from wc_order_operational_data (NULL for
-		//    bulk-inserted orders that have no shipping, treated as 0).
+		//    shipping_total_amount is the actual column name in wc_order_operational_data
+		//    (NULL for bulk-inserted orders that have no shipping, treated as 0).
 		//    returning_customer is left NULL — computing it correctly requires
 		//    cross-order analysis that would negate bulk-sync throughput.
 		// ------------------------------------------------------------------
-		$wpdb->query(
-			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"$insert {$wpdb->prefix}wc_order_stats
-				     (order_id, parent_id, date_created, date_created_gmt,
-				      date_paid, date_completed, num_items_sold,
-				      total_sales, tax_total, shipping_total, net_total,
-				      returning_customer, status, customer_id)
-				 SELECT
-				     o.id,
-				     COALESCE( o.parent_order_id, 0 ),
-				     o.date_created_gmt,
-				     o.date_created_gmt,
-				     od.date_paid_gmt,
-				     od.date_completed_gmt,
-				     COALESCE( ic.num_items, 0 ),
-				     o.total_amount,
-				     o.tax_amount,
-				     COALESCE( od.shipping_total, 0 ),
-				     o.total_amount - o.tax_amount - COALESCE( od.shipping_total, 0 ),
-				     NULL,
-				     IF( o.status LIKE 'wc-%%', SUBSTR( o.status, 4 ), o.status ),
-				     COALESCE( cl.customer_id, 0 )
-				 FROM {$wpdb->prefix}wc_orders o
-				 LEFT JOIN {$wpdb->prefix}wc_order_operational_data od ON od.order_id = o.id
-				 LEFT JOIN {$wpdb->prefix}wc_customer_lookup cl ON cl.user_id = o.customer_id
-				 LEFT JOIN (
-				     SELECT oi.order_id,
-				            SUM( CAST( oim.meta_value AS UNSIGNED ) ) AS num_items
-				     FROM {$wpdb->prefix}woocommerce_order_items oi
-				     JOIN {$wpdb->prefix}woocommerce_order_itemmeta oim
-				          ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_qty'
-				     WHERE oi.order_item_type = 'line_item'
-				       AND oi.order_id IN ( $in )
-				     GROUP BY oi.order_id
-				 ) ic ON ic.order_id = o.id
-				 WHERE o.id IN ( $in )",
-				...$order_ids,
-				...$order_ids
-			)
+		$check(
+			$wpdb->query(
+				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					"$insert {$wpdb->prefix}wc_order_stats
+					     (order_id, parent_id, date_created, date_created_gmt,
+					      date_paid, date_completed, num_items_sold,
+					      total_sales, tax_total, shipping_total, net_total,
+					      returning_customer, status, customer_id)
+					 SELECT
+					     o.id,
+					     COALESCE( o.parent_order_id, 0 ),
+					     o.date_created_gmt,
+					     o.date_created_gmt,
+					     od.date_paid_gmt,
+					     od.date_completed_gmt,
+					     COALESCE( ic.num_items, 0 ),
+					     o.total_amount,
+					     o.tax_amount,
+					     COALESCE( od.shipping_total_amount, 0 ),
+					     o.total_amount - o.tax_amount - COALESCE( od.shipping_total_amount, 0 ),
+					     NULL,
+					     IF( o.status LIKE 'wc-%%', SUBSTR( o.status, 4 ), o.status ),
+					     COALESCE( cl.customer_id, 0 )
+					 FROM {$wpdb->prefix}wc_orders o
+					 LEFT JOIN {$wpdb->prefix}wc_order_operational_data od ON od.order_id = o.id
+					 LEFT JOIN {$wpdb->prefix}wc_customer_lookup cl ON cl.user_id = o.customer_id
+					 LEFT JOIN (
+					     SELECT oi.order_id,
+					            SUM( CAST( oim.meta_value AS UNSIGNED ) ) AS num_items
+					     FROM {$wpdb->prefix}woocommerce_order_items oi
+					     JOIN {$wpdb->prefix}woocommerce_order_itemmeta oim
+					          ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_qty'
+					     WHERE oi.order_item_type = 'line_item'
+					       AND oi.order_id IN ( $in )
+					     GROUP BY oi.order_id
+					 ) ic ON ic.order_id = o.id
+					 WHERE o.id IN ( $in )",
+					...$order_ids,
+					...$order_ids
+				)
+			),
+			'wc_order_stats'
 		);
 
 		// ------------------------------------------------------------------
 		// 3. wc_order_product_lookup — one row per line item.
 		// ------------------------------------------------------------------
-		$wpdb->query(
-			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"$insert {$wpdb->prefix}wc_order_product_lookup
-				     (order_item_id, order_id, product_id, variation_id, customer_id,
-				      date_created, product_qty, product_net_revenue,
-				      product_gross_revenue, coupon_amount, tax_amount,
-				      shipping_amount, shipping_tax_amount)
-				 SELECT
-				     oi.order_item_id,
-				     oi.order_id,
-				     COALESCE( CAST( pid.meta_value AS UNSIGNED ), 0 ),
-				     COALESCE( CAST( vid.meta_value AS UNSIGNED ), 0 ),
-				     COALESCE( cl.customer_id, 0 ),
-				     o.date_created_gmt,
-				     COALESCE( CAST( qty.meta_value AS UNSIGNED ), 0 ),
-				     COALESCE( CAST( tot.meta_value AS DECIMAL(20,6) ), 0 ),
-				     COALESCE( CAST( tot.meta_value AS DECIMAL(20,6) ), 0 )
-				         + COALESCE( CAST( tax.meta_value AS DECIMAL(20,6) ), 0 ),
-				     0,
-				     COALESCE( CAST( tax.meta_value AS DECIMAL(20,6) ), 0 ),
-				     0,
-				     0
-				 FROM {$wpdb->prefix}woocommerce_order_items oi
-				 JOIN {$wpdb->prefix}wc_orders o ON o.id = oi.order_id
-				 LEFT JOIN {$wpdb->prefix}wc_customer_lookup cl ON cl.user_id = o.customer_id
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta pid
-				        ON pid.order_item_id = oi.order_item_id AND pid.meta_key = '_product_id'
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta vid
-				        ON vid.order_item_id = oi.order_item_id AND vid.meta_key = '_variation_id'
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta qty
-				        ON qty.order_item_id = oi.order_item_id AND qty.meta_key = '_qty'
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta tot
-				        ON tot.order_item_id = oi.order_item_id AND tot.meta_key = '_line_total'
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta tax
-				        ON tax.order_item_id = oi.order_item_id AND tax.meta_key = '_line_tax'
-				 WHERE oi.order_item_type = 'line_item'
-				   AND oi.order_id IN ( $in )",
-				...$order_ids
-			)
+		$check(
+			$wpdb->query(
+				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					"$insert {$wpdb->prefix}wc_order_product_lookup
+					     (order_item_id, order_id, product_id, variation_id, customer_id,
+					      date_created, product_qty, product_net_revenue,
+					      product_gross_revenue, coupon_amount, tax_amount,
+					      shipping_amount, shipping_tax_amount)
+					 SELECT
+					     oi.order_item_id,
+					     oi.order_id,
+					     COALESCE( CAST( pid.meta_value AS UNSIGNED ), 0 ),
+					     COALESCE( CAST( vid.meta_value AS UNSIGNED ), 0 ),
+					     COALESCE( cl.customer_id, 0 ),
+					     o.date_created_gmt,
+					     COALESCE( CAST( qty.meta_value AS UNSIGNED ), 0 ),
+					     COALESCE( CAST( tot.meta_value AS DECIMAL(20,6) ), 0 ),
+					     COALESCE( CAST( tot.meta_value AS DECIMAL(20,6) ), 0 )
+					         + COALESCE( CAST( tax.meta_value AS DECIMAL(20,6) ), 0 ),
+					     0,
+					     COALESCE( CAST( tax.meta_value AS DECIMAL(20,6) ), 0 ),
+					     0,
+					     0
+					 FROM {$wpdb->prefix}woocommerce_order_items oi
+					 JOIN {$wpdb->prefix}wc_orders o ON o.id = oi.order_id
+					 LEFT JOIN {$wpdb->prefix}wc_customer_lookup cl ON cl.user_id = o.customer_id
+					 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta pid
+					        ON pid.order_item_id = oi.order_item_id AND pid.meta_key = '_product_id'
+					 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta vid
+					        ON vid.order_item_id = oi.order_item_id AND vid.meta_key = '_variation_id'
+					 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta qty
+					        ON qty.order_item_id = oi.order_item_id AND qty.meta_key = '_qty'
+					 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta tot
+					        ON tot.order_item_id = oi.order_item_id AND tot.meta_key = '_line_total'
+					 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta tax
+					        ON tax.order_item_id = oi.order_item_id AND tax.meta_key = '_line_tax'
+					 WHERE oi.order_item_type = 'line_item'
+					   AND oi.order_id IN ( $in )",
+					...$order_ids
+				)
+			),
+			'wc_order_product_lookup'
 		);
 
 		// ------------------------------------------------------------------
 		// 4. wc_order_coupon_lookup — only produces rows for orders that have
 		//    coupon line items (bulk-inserted orders do not; ORM orders may).
 		// ------------------------------------------------------------------
-		$wpdb->query(
-			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"$insert {$wpdb->prefix}wc_order_coupon_lookup
-				     (order_id, coupon_id, date_created, discount_amount)
-				 SELECT
-				     oi.order_id,
-				     COALESCE( CAST( cp_id.meta_value AS UNSIGNED ), 0 ),
-				     o.date_created_gmt,
-				     COALESCE( CAST( cp_disc.meta_value AS DECIMAL(20,6) ), 0 )
-				 FROM {$wpdb->prefix}woocommerce_order_items oi
-				 JOIN {$wpdb->prefix}wc_orders o ON o.id = oi.order_id
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta cp_id
-				        ON cp_id.order_item_id = oi.order_item_id AND cp_id.meta_key = 'coupon_id'
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta cp_disc
-				        ON cp_disc.order_item_id = oi.order_item_id AND cp_disc.meta_key = 'discount_amount'
-				 WHERE oi.order_item_type = 'coupon'
-				   AND oi.order_id IN ( $in )",
-				...$order_ids
-			)
+		$check(
+			$wpdb->query(
+				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					"$insert {$wpdb->prefix}wc_order_coupon_lookup
+					     (order_id, coupon_id, date_created, discount_amount)
+					 SELECT
+					     oi.order_id,
+					     COALESCE( CAST( cp_id.meta_value AS UNSIGNED ), 0 ),
+					     o.date_created_gmt,
+					     COALESCE( CAST( cp_disc.meta_value AS DECIMAL(20,6) ), 0 )
+					 FROM {$wpdb->prefix}woocommerce_order_items oi
+					 JOIN {$wpdb->prefix}wc_orders o ON o.id = oi.order_id
+					 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta cp_id
+					        ON cp_id.order_item_id = oi.order_item_id AND cp_id.meta_key = 'coupon_id'
+					 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta cp_disc
+					        ON cp_disc.order_item_id = oi.order_item_id AND cp_disc.meta_key = 'discount_amount'
+					 WHERE oi.order_item_type = 'coupon'
+					   AND oi.order_id IN ( $in )",
+					...$order_ids
+				)
+			),
+			'wc_order_coupon_lookup'
 		);
 
 		// ------------------------------------------------------------------
 		// 5. wc_order_tax_lookup — only produces rows for orders that have
 		//    tax line items (bulk-inserted orders do not; ORM orders may).
 		// ------------------------------------------------------------------
-		$wpdb->query(
-			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"$insert {$wpdb->prefix}wc_order_tax_lookup
-				     (order_id, tax_rate_id, date_created, shipping_tax, order_tax, total_tax)
-				 SELECT
-				     oi.order_id,
-				     COALESCE( CAST( rate_id.meta_value AS UNSIGNED ), 0 ),
-				     o.date_created_gmt,
-				     COALESCE( CAST( ship_tax.meta_value AS DECIMAL(20,6) ), 0 ),
-				     COALESCE( CAST( ord_tax.meta_value AS DECIMAL(20,6) ), 0 ),
-				     COALESCE( CAST( ship_tax.meta_value AS DECIMAL(20,6) ), 0 )
-				         + COALESCE( CAST( ord_tax.meta_value AS DECIMAL(20,6) ), 0 )
-				 FROM {$wpdb->prefix}woocommerce_order_items oi
-				 JOIN {$wpdb->prefix}wc_orders o ON o.id = oi.order_id
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta rate_id
-				        ON rate_id.order_item_id = oi.order_item_id AND rate_id.meta_key = 'rate_id'
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta ship_tax
-				        ON ship_tax.order_item_id = oi.order_item_id AND ship_tax.meta_key = 'shipping_tax_amount'
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta ord_tax
-				        ON ord_tax.order_item_id = oi.order_item_id AND ord_tax.meta_key = 'tax_amount'
-				 WHERE oi.order_item_type = 'tax'
-				   AND oi.order_id IN ( $in )",
-				...$order_ids
-			)
+		$check(
+			$wpdb->query(
+				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					"$insert {$wpdb->prefix}wc_order_tax_lookup
+					     (order_id, tax_rate_id, date_created, shipping_tax, order_tax, total_tax)
+					 SELECT
+					     oi.order_id,
+					     COALESCE( CAST( rate_id.meta_value AS UNSIGNED ), 0 ),
+					     o.date_created_gmt,
+					     COALESCE( CAST( ship_tax.meta_value AS DECIMAL(20,6) ), 0 ),
+					     COALESCE( CAST( ord_tax.meta_value AS DECIMAL(20,6) ), 0 ),
+					     COALESCE( CAST( ship_tax.meta_value AS DECIMAL(20,6) ), 0 )
+					         + COALESCE( CAST( ord_tax.meta_value AS DECIMAL(20,6) ), 0 )
+					 FROM {$wpdb->prefix}woocommerce_order_items oi
+					 JOIN {$wpdb->prefix}wc_orders o ON o.id = oi.order_id
+					 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta rate_id
+					        ON rate_id.order_item_id = oi.order_item_id AND rate_id.meta_key = 'rate_id'
+					 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta ship_tax
+					        ON ship_tax.order_item_id = oi.order_item_id AND ship_tax.meta_key = 'shipping_tax_amount'
+					 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta ord_tax
+					        ON ord_tax.order_item_id = oi.order_item_id AND ord_tax.meta_key = 'tax_amount'
+					 WHERE oi.order_item_type = 'tax'
+					   AND oi.order_id IN ( $in )",
+					...$order_ids
+				)
+			),
+			'wc_order_tax_lookup'
 		);
 	}
 

--- a/includes/Generator/OrderAnalyticsSync.php
+++ b/includes/Generator/OrderAnalyticsSync.php
@@ -147,6 +147,7 @@ class OrderAnalyticsSync {
 
 		if ( ! empty( $order_ids ) ) {
 			self::sync_order_ids( $order_ids, $all ); // throws \RuntimeException on DB failure
+			\Automattic\WooCommerce\Admin\API\Reports\Cache::invalidate();
 		}
 
 		return $order_ids;

--- a/includes/Generator/OrderAnalyticsSync.php
+++ b/includes/Generator/OrderAnalyticsSync.php
@@ -1,0 +1,385 @@
+<?php
+/**
+ * Analytics sync for orders not yet reflected in WooCommerce Analytics tables.
+ *
+ * @package SmoothGenerator\Classes
+ */
+
+namespace WC\SmoothGenerator\Generator;
+
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
+/**
+ * Populates WooCommerce Analytics lookup tables for HPOS orders that are not
+ * yet reflected in the analytics tables — whether they were bulk-inserted via
+ * this plugin or created via the normal WooCommerce ORM without a sync step.
+ *
+ * Implements the same static batch() interface as the Generator classes so it
+ * integrates with BatchProcessor / Router for the background-job UI path.
+ *
+ * Tables populated:
+ *   wc_customer_lookup       (INSERT IGNORE — preserves existing customer_id)
+ *   wc_order_stats           (INSERT IGNORE or REPLACE INTO for --all re-sync)
+ *   wc_order_product_lookup  (INSERT IGNORE or REPLACE INTO for --all re-sync)
+ *   wc_order_coupon_lookup   (INSERT IGNORE or REPLACE INTO, only for coupon items)
+ *   wc_order_tax_lookup      (INSERT IGNORE or REPLACE INTO, only for tax items)
+ *
+ * Tables not handled here (require per-order WC_Order loading):
+ *   returning_customer in wc_order_stats  (cross-order analysis, left NULL)
+ */
+class OrderAnalyticsSync {
+
+	/**
+	 * Orders synced per batch call.
+	 *
+	 * @var int
+	 */
+	const MAX_BATCH_SIZE = 500;
+
+	/**
+	 * wp_options key used to persist the order-ID cursor for --all re-sync jobs.
+	 *
+	 * @var string
+	 */
+	const CURSOR_OPTION = 'smoothgenerator_analytics_sync_cursor';
+
+	// -------------------------------------------------------------------------
+	// Status helpers (used by the Settings UI)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Count HPOS shop_orders that are not yet in wc_order_stats.
+	 *
+	 * @return int
+	 */
+	public static function get_unsynced_count(): int {
+		global $wpdb;
+
+		if ( ! self::is_hpos_available() ) {
+			return 0;
+		}
+
+		return (int) $wpdb->get_var(
+			"SELECT COUNT(*)
+			 FROM {$wpdb->prefix}wc_orders o
+			 LEFT JOIN {$wpdb->prefix}wc_order_stats s ON s.order_id = o.id
+			 WHERE o.type = 'shop_order'
+			   AND s.order_id IS NULL"
+		);
+	}
+
+	/**
+	 * Count all HPOS shop_orders.
+	 *
+	 * @return int
+	 */
+	public static function get_total_order_count(): int {
+		global $wpdb;
+
+		if ( ! self::is_hpos_available() ) {
+			return 0;
+		}
+
+		return (int) $wpdb->get_var(
+			"SELECT COUNT(*) FROM {$wpdb->prefix}wc_orders WHERE type = 'shop_order'"
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Batch interface (called by BatchProcessor via Router)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Sync a batch of orders into the analytics tables.
+	 *
+	 * Called by BatchProcessor with the same interface as Generator::batch().
+	 *
+	 * @param int   $amount     Maximum number of orders to process this call.
+	 * @param array $args       Optional args:
+	 *                            'all' => true — cursor-based re-sync of every order
+	 *                                            (uses REPLACE INTO; default is INSERT IGNORE
+	 *                                             which only syncs unsynced orders).
+	 * @return int[] Order IDs that were synced.
+	 */
+	public static function batch( int $amount, array $args = array() ): array {
+		global $wpdb;
+
+		$amount = min( $amount, self::MAX_BATCH_SIZE );
+		$all    = ! empty( $args['all'] );
+
+		if ( $all ) {
+			// Cursor-based scan so every order is processed exactly once.
+			$cursor    = (int) get_option( self::CURSOR_OPTION, 0 );
+			$order_ids = array_map(
+				'intval',
+				$wpdb->get_col(
+					$wpdb->prepare(
+						"SELECT id FROM {$wpdb->prefix}wc_orders
+						 WHERE type = 'shop_order' AND id > %d
+						 ORDER BY id ASC LIMIT %d",
+						$cursor,
+						$amount
+					)
+				)
+			);
+
+			if ( ! empty( $order_ids ) ) {
+				update_option( self::CURSOR_OPTION, max( $order_ids ), false );
+			}
+		} else {
+			// Only pick orders that do not yet have a wc_order_stats row.
+			// The LEFT JOIN is self-correcting: each batch consumes the oldest
+			// unsynced orders and the next call automatically finds the next ones.
+			$order_ids = array_map(
+				'intval',
+				$wpdb->get_col(
+					$wpdb->prepare(
+						"SELECT o.id
+						 FROM {$wpdb->prefix}wc_orders o
+						 LEFT JOIN {$wpdb->prefix}wc_order_stats s ON s.order_id = o.id
+						 WHERE o.type = 'shop_order' AND s.order_id IS NULL
+						 ORDER BY o.id ASC LIMIT %d",
+						$amount
+					)
+				)
+			);
+		}
+
+		if ( ! empty( $order_ids ) ) {
+			self::sync_order_ids( $order_ids, $all );
+		}
+
+		return $order_ids;
+	}
+
+	// -------------------------------------------------------------------------
+	// Core sync logic
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Write analytics rows for a given list of order IDs.
+	 *
+	 * Uses five INSERT…SELECT statements to populate all five analytics tables
+	 * from the raw HPOS and order-item tables, without loading WC_Order objects.
+	 * Coupon/tax lookup queries produce zero rows for orders that have no
+	 * coupon or tax line items (e.g. bulk-inserted orders).
+	 *
+	 * @param int[] $order_ids Order IDs to sync.
+	 * @param bool  $replace   When true, use REPLACE INTO for wc_order_stats,
+	 *                         wc_order_product_lookup, wc_order_coupon_lookup, and
+	 *                         wc_order_tax_lookup so that existing rows are updated
+	 *                         (used for the re-sync-all path). When false (default),
+	 *                         uses INSERT IGNORE to only add missing rows.
+	 *                         wc_customer_lookup always uses INSERT IGNORE to avoid
+	 *                         changing AUTO_INCREMENT customer_id values.
+	 * @return void
+	 */
+	public static function sync_order_ids( array $order_ids, bool $replace = false ): void {
+		global $wpdb;
+
+		if ( empty( $order_ids ) ) {
+			return;
+		}
+
+		$in     = implode( ',', array_fill( 0, count( $order_ids ), '%d' ) );
+		$insert = $replace ? 'REPLACE INTO' : 'INSERT IGNORE INTO';
+
+		// ------------------------------------------------------------------
+		// 1. wc_customer_lookup
+		//    Always INSERT IGNORE — replacing would generate a new customer_id
+		//    (AUTO_INCREMENT) and orphan any existing wc_order_stats rows.
+		// ------------------------------------------------------------------
+		$wpdb->query(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"INSERT IGNORE INTO {$wpdb->prefix}wc_customer_lookup
+				     (user_id, username, first_name, last_name, email,
+				      date_last_active, date_registered, country, postcode, city, state)
+				 SELECT
+				     o.customer_id,
+				     MIN( COALESCE( u.user_login, '' ) ),
+				     MIN( COALESCE( a.first_name, '' ) ),
+				     MIN( COALESCE( a.last_name, '' ) ),
+				     MIN( a.email ),
+				     MAX( o.date_created_gmt ),
+				     MIN( u.user_registered ),
+				     MIN( COALESCE( a.country, '' ) ),
+				     MIN( COALESCE( a.postcode, '' ) ),
+				     MIN( COALESCE( a.city, '' ) ),
+				     MIN( COALESCE( a.state, '' ) )
+				 FROM {$wpdb->prefix}wc_orders o
+				 LEFT JOIN {$wpdb->users} u ON u.ID = o.customer_id
+				 LEFT JOIN {$wpdb->prefix}wc_order_addresses a
+				        ON a.order_id = o.id AND a.address_type = 'billing'
+				 WHERE o.id IN ( $in )
+				 GROUP BY o.customer_id",
+				...$order_ids
+			)
+		);
+
+		// ------------------------------------------------------------------
+		// 2. wc_order_stats
+		//    shipping_total is read from wc_order_operational_data (NULL for
+		//    bulk-inserted orders that have no shipping, treated as 0).
+		//    returning_customer is left NULL — computing it correctly requires
+		//    cross-order analysis that would negate bulk-sync throughput.
+		// ------------------------------------------------------------------
+		$wpdb->query(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"$insert {$wpdb->prefix}wc_order_stats
+				     (order_id, parent_id, date_created, date_created_gmt,
+				      date_paid, date_completed, num_items_sold,
+				      total_sales, tax_total, shipping_total, net_total,
+				      returning_customer, status, customer_id)
+				 SELECT
+				     o.id,
+				     COALESCE( o.parent_order_id, 0 ),
+				     o.date_created_gmt,
+				     o.date_created_gmt,
+				     od.date_paid_gmt,
+				     od.date_completed_gmt,
+				     COALESCE( ic.num_items, 0 ),
+				     o.total_amount,
+				     o.tax_amount,
+				     COALESCE( od.shipping_total, 0 ),
+				     o.total_amount - o.tax_amount - COALESCE( od.shipping_total, 0 ),
+				     NULL,
+				     IF( o.status LIKE 'wc-%%', SUBSTR( o.status, 4 ), o.status ),
+				     COALESCE( cl.customer_id, 0 )
+				 FROM {$wpdb->prefix}wc_orders o
+				 LEFT JOIN {$wpdb->prefix}wc_order_operational_data od ON od.order_id = o.id
+				 LEFT JOIN {$wpdb->prefix}wc_customer_lookup cl ON cl.user_id = o.customer_id
+				 LEFT JOIN (
+				     SELECT oi.order_id,
+				            SUM( CAST( oim.meta_value AS UNSIGNED ) ) AS num_items
+				     FROM {$wpdb->prefix}woocommerce_order_items oi
+				     JOIN {$wpdb->prefix}woocommerce_order_itemmeta oim
+				          ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_qty'
+				     WHERE oi.order_item_type = 'line_item'
+				       AND oi.order_id IN ( $in )
+				     GROUP BY oi.order_id
+				 ) ic ON ic.order_id = o.id
+				 WHERE o.id IN ( $in )",
+				...$order_ids,
+				...$order_ids
+			)
+		);
+
+		// ------------------------------------------------------------------
+		// 3. wc_order_product_lookup — one row per line item.
+		// ------------------------------------------------------------------
+		$wpdb->query(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"$insert {$wpdb->prefix}wc_order_product_lookup
+				     (order_item_id, order_id, product_id, variation_id, customer_id,
+				      date_created, product_qty, product_net_revenue,
+				      product_gross_revenue, coupon_amount, tax_amount,
+				      shipping_amount, shipping_tax_amount)
+				 SELECT
+				     oi.order_item_id,
+				     oi.order_id,
+				     COALESCE( CAST( pid.meta_value AS UNSIGNED ), 0 ),
+				     COALESCE( CAST( vid.meta_value AS UNSIGNED ), 0 ),
+				     COALESCE( cl.customer_id, 0 ),
+				     o.date_created_gmt,
+				     COALESCE( CAST( qty.meta_value AS UNSIGNED ), 0 ),
+				     COALESCE( CAST( tot.meta_value AS DECIMAL(20,6) ), 0 ),
+				     COALESCE( CAST( tot.meta_value AS DECIMAL(20,6) ), 0 )
+				         + COALESCE( CAST( tax.meta_value AS DECIMAL(20,6) ), 0 ),
+				     0,
+				     COALESCE( CAST( tax.meta_value AS DECIMAL(20,6) ), 0 ),
+				     0,
+				     0
+				 FROM {$wpdb->prefix}woocommerce_order_items oi
+				 JOIN {$wpdb->prefix}wc_orders o ON o.id = oi.order_id
+				 LEFT JOIN {$wpdb->prefix}wc_customer_lookup cl ON cl.user_id = o.customer_id
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta pid
+				        ON pid.order_item_id = oi.order_item_id AND pid.meta_key = '_product_id'
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta vid
+				        ON vid.order_item_id = oi.order_item_id AND vid.meta_key = '_variation_id'
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta qty
+				        ON qty.order_item_id = oi.order_item_id AND qty.meta_key = '_qty'
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta tot
+				        ON tot.order_item_id = oi.order_item_id AND tot.meta_key = '_line_total'
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta tax
+				        ON tax.order_item_id = oi.order_item_id AND tax.meta_key = '_line_tax'
+				 WHERE oi.order_item_type = 'line_item'
+				   AND oi.order_id IN ( $in )",
+				...$order_ids
+			)
+		);
+
+		// ------------------------------------------------------------------
+		// 4. wc_order_coupon_lookup — only produces rows for orders that have
+		//    coupon line items (bulk-inserted orders do not; ORM orders may).
+		// ------------------------------------------------------------------
+		$wpdb->query(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"$insert {$wpdb->prefix}wc_order_coupon_lookup
+				     (order_id, coupon_id, date_created, discount_amount)
+				 SELECT
+				     oi.order_id,
+				     COALESCE( CAST( cp_id.meta_value AS UNSIGNED ), 0 ),
+				     o.date_created_gmt,
+				     COALESCE( CAST( cp_disc.meta_value AS DECIMAL(20,6) ), 0 )
+				 FROM {$wpdb->prefix}woocommerce_order_items oi
+				 JOIN {$wpdb->prefix}wc_orders o ON o.id = oi.order_id
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta cp_id
+				        ON cp_id.order_item_id = oi.order_item_id AND cp_id.meta_key = 'coupon_id'
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta cp_disc
+				        ON cp_disc.order_item_id = oi.order_item_id AND cp_disc.meta_key = 'discount_amount'
+				 WHERE oi.order_item_type = 'coupon'
+				   AND oi.order_id IN ( $in )",
+				...$order_ids
+			)
+		);
+
+		// ------------------------------------------------------------------
+		// 5. wc_order_tax_lookup — only produces rows for orders that have
+		//    tax line items (bulk-inserted orders do not; ORM orders may).
+		// ------------------------------------------------------------------
+		$wpdb->query(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"$insert {$wpdb->prefix}wc_order_tax_lookup
+				     (order_id, tax_rate_id, date_created, shipping_tax, order_tax, total_tax)
+				 SELECT
+				     oi.order_id,
+				     COALESCE( CAST( rate_id.meta_value AS UNSIGNED ), 0 ),
+				     o.date_created_gmt,
+				     COALESCE( CAST( ship_tax.meta_value AS DECIMAL(20,6) ), 0 ),
+				     COALESCE( CAST( ord_tax.meta_value AS DECIMAL(20,6) ), 0 ),
+				     COALESCE( CAST( ship_tax.meta_value AS DECIMAL(20,6) ), 0 )
+				         + COALESCE( CAST( ord_tax.meta_value AS DECIMAL(20,6) ), 0 )
+				 FROM {$wpdb->prefix}woocommerce_order_items oi
+				 JOIN {$wpdb->prefix}wc_orders o ON o.id = oi.order_id
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta rate_id
+				        ON rate_id.order_item_id = oi.order_item_id AND rate_id.meta_key = 'rate_id'
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta ship_tax
+				        ON ship_tax.order_item_id = oi.order_item_id AND ship_tax.meta_key = 'shipping_tax_amount'
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta ord_tax
+				        ON ord_tax.order_item_id = oi.order_item_id AND ord_tax.meta_key = 'tax_amount'
+				 WHERE oi.order_item_type = 'tax'
+				   AND oi.order_id IN ( $in )",
+				...$order_ids
+			)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Helper
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Return true when WooCommerce HPOS is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_hpos_available(): bool {
+		return class_exists( OrderUtil::class )
+			&& OrderUtil::custom_orders_table_usage_is_enabled();
+	}
+}

--- a/includes/Generator/OrderAnalyticsSync.php
+++ b/includes/Generator/OrderAnalyticsSync.php
@@ -37,7 +37,7 @@ class OrderAnalyticsSync {
 	const MAX_BATCH_SIZE = 500;
 
 	/**
-	 * wp_options key used to persist the order-ID cursor for --all re-sync jobs.
+	 * Options key used to persist the order-ID cursor for --all re-sync jobs.
 	 *
 	 * @var string
 	 */
@@ -146,7 +146,7 @@ class OrderAnalyticsSync {
 		}
 
 		if ( ! empty( $order_ids ) ) {
-			self::sync_order_ids( $order_ids, $all ); // throws \RuntimeException on DB failure
+			self::sync_order_ids( $order_ids, $all ); // throws \RuntimeException on DB failure.
 			\Automattic\WooCommerce\Admin\API\Reports\Cache::invalidate();
 		}
 
@@ -188,20 +188,20 @@ class OrderAnalyticsSync {
 		$check = static function ( $result, string $table ) use ( $wpdb ): void {
 			if ( false === $result ) {
 				$msg = "SmoothGenerator analytics sync: failed to write to $table — " . $wpdb->last_error;
-				error_log( $msg );
-				throw new \RuntimeException( $msg );
+				error_log( $msg ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				throw new \RuntimeException( $msg ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			}
 		};
 
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 		// ------------------------------------------------------------------
 		// 1. wc_customer_lookup
-		//    Always INSERT IGNORE — replacing would generate a new customer_id
-		//    (AUTO_INCREMENT) and orphan any existing wc_order_stats rows.
+		// Always INSERT IGNORE — replacing would generate a new customer_id
+		// (AUTO_INCREMENT) and orphan any existing wc_order_stats rows.
 		// ------------------------------------------------------------------
 		$check(
 			$wpdb->query(
 				$wpdb->prepare(
-					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					"INSERT IGNORE INTO {$wpdb->prefix}wc_customer_lookup
 					     (user_id, username, first_name, last_name, email,
 					      date_last_active, date_registered, country, postcode, city, state)
@@ -231,15 +231,14 @@ class OrderAnalyticsSync {
 
 		// ------------------------------------------------------------------
 		// 2. wc_order_stats
-		//    shipping_total_amount is the actual column name in wc_order_operational_data
-		//    (NULL for bulk-inserted orders that have no shipping, treated as 0).
-		//    returning_customer is left NULL — computing it correctly requires
-		//    cross-order analysis that would negate bulk-sync throughput.
+		// shipping_total_amount is the actual column name in wc_order_operational_data
+		// (NULL for bulk-inserted orders that have no shipping, treated as 0).
+		// returning_customer is left NULL — computing it correctly requires
+		// cross-order analysis that would negate bulk-sync throughput.
 		// ------------------------------------------------------------------
 		$check(
 			$wpdb->query(
 				$wpdb->prepare(
-					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					"$insert {$wpdb->prefix}wc_order_stats
 					     (order_id, parent_id, date_created, date_created_gmt,
 					      date_paid, date_completed, num_items_sold,
@@ -258,7 +257,7 @@ class OrderAnalyticsSync {
 					     COALESCE( od.shipping_total_amount, 0 ),
 					     o.total_amount - o.tax_amount - COALESCE( od.shipping_total_amount, 0 ),
 					     NULL,
-					     IF( o.status LIKE 'wc-%%', SUBSTR( o.status, 4 ), o.status ),
+					     o.status,
 					     COALESCE( cl.customer_id, 0 )
 					 FROM {$wpdb->prefix}wc_orders o
 					 LEFT JOIN {$wpdb->prefix}wc_order_operational_data od ON od.order_id = o.id
@@ -287,7 +286,6 @@ class OrderAnalyticsSync {
 		$check(
 			$wpdb->query(
 				$wpdb->prepare(
-					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					"$insert {$wpdb->prefix}wc_order_product_lookup
 					     (order_item_id, order_id, product_id, variation_id, customer_id,
 					      date_created, product_qty, product_net_revenue,
@@ -331,12 +329,11 @@ class OrderAnalyticsSync {
 
 		// ------------------------------------------------------------------
 		// 4. wc_order_coupon_lookup — only produces rows for orders that have
-		//    coupon line items (bulk-inserted orders do not; ORM orders may).
+		// coupon line items (bulk-inserted orders do not; ORM orders may).
 		// ------------------------------------------------------------------
 		$check(
 			$wpdb->query(
 				$wpdb->prepare(
-					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					"$insert {$wpdb->prefix}wc_order_coupon_lookup
 					     (order_id, coupon_id, date_created, discount_amount)
 					 SELECT
@@ -360,12 +357,11 @@ class OrderAnalyticsSync {
 
 		// ------------------------------------------------------------------
 		// 5. wc_order_tax_lookup — only produces rows for orders that have
-		//    tax line items (bulk-inserted orders do not; ORM orders may).
+		// tax line items (bulk-inserted orders do not; ORM orders may).
 		// ------------------------------------------------------------------
 		$check(
 			$wpdb->query(
 				$wpdb->prepare(
-					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					"$insert {$wpdb->prefix}wc_order_tax_lookup
 					     (order_id, tax_rate_id, date_created, shipping_tax, order_tax, total_tax)
 					 SELECT
@@ -391,6 +387,7 @@ class OrderAnalyticsSync {
 			),
 			'wc_order_tax_lookup'
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 	}
 
 	// -------------------------------------------------------------------------

--- a/includes/Generator/OrderAttribution.php
+++ b/includes/Generator/OrderAttribution.php
@@ -30,52 +30,69 @@ class OrderAttribution {
 		}
 
 		$order_products = $order->get_items();
+		$product_url    = empty( $order_products ) ? '' : get_permalink( $order_products[ array_rand( $order_products ) ]->get_id() );
+		$date_gmt       = $order->get_date_created() ? $order->get_date_created()->date( 'Y-m-d H:i:s' ) : gmdate( 'Y-m-d H:i:s' );
 
-		$device_type = self::get_random_device_type();
-		$source      = 'woocommerce.com';
-		$source_type = self::get_source_type();
-		$origin      = self::get_origin( $source_type, $source );
-		$product_url = empty( $order_products ) ? '' : get_permalink( $order_products[ array_rand( $order_products ) ]->get_id() );
-		$utm_content = array( '/', 'campaign_a', 'campaign_b' );
-		$utm_content = $utm_content[ array_rand( $utm_content ) ];
-
-		$meta = array();
-
-		// For these source types, we only need to set the source type.
-		if ( in_array( $source_type, array( 'admin', 'mobile_app', 'unknown' ), true ) ) {
-			$meta = array(
-				'_wc_order_attribution_source_type' => $source_type,
-			);
-		} else {
-			$meta = array(
-				'_wc_order_attribution_origin'             => $origin,
-				'_wc_order_attribution_device_type'        => $device_type,
-				'_wc_order_attribution_user_agent'         => self::get_random_user_agent_for_device( $device_type ),
-				'_wc_order_attribution_session_count'      => wp_rand( 1, 10 ),
-				'_wc_order_attribution_session_pages'      => wp_rand( 1, 10 ),
-				'_wc_order_attribution_session_start_time' => self::get_random_session_start_time( $order ),
-				'_wc_order_attribution_session_entry'      => $product_url,
-				'_wc_order_attribution_utm_content'        => $utm_content,
-				'_wc_order_attribution_utm_source'         => self::get_source( $source_type ),
-				'_wc_order_attribution_referrer'           => self::get_referrer( $source_type ),
-				'_wc_order_attribution_source_type'        => $source_type,
-			);
-
-			// Add campaign data only for a percentage of orders.
-			if ( wp_rand( 1, 100 ) <= self::CAMPAIGN_PROBABILITY ) {
-				$campaign_data = self::get_campaign_data();
-				$meta          = array_merge( $meta, $campaign_data );
-			}
-		}
-
-		// If the source type is not typein ( Direct ), set a random utm medium.
-		if ( ! in_array( $source_type, array( 'typein', 'admin', 'mobile_app', 'unknown' ), true ) ) {
-			$meta['_wc_order_attribution_utm_medium'] = self::get_random_utm_medium();
-		}
+		$meta = self::generate_meta_array( $date_gmt, $product_url );
 
 		foreach ( $meta as $key => $value ) {
 			$order->add_meta_data( $key, $value );
 		}
+	}
+
+	/**
+	 * Generate an attribution meta array without requiring a WC_Order object.
+	 *
+	 * This is the canonical data-generation logic. Both the ORM path
+	 * (add_order_attribution_meta) and the bulk-insert path call this method.
+	 *
+	 * @param string $date_gmt    Order creation date in GMT (Y-m-d H:i:s).
+	 * @param string $product_url Optional permalink for a product on the order.
+	 * @return array<string, string|int> Meta key => value pairs.
+	 */
+	public static function generate_meta_array( string $date_gmt, string $product_url = '' ): array {
+		$device_type = self::get_random_device_type();
+		$source      = 'woocommerce.com';
+		$source_type = self::get_source_type();
+		$origin      = self::get_origin( $source_type, $source );
+		$utm_content = array( '/', 'campaign_a', 'campaign_b' );
+		$utm_content = $utm_content[ array_rand( $utm_content ) ];
+
+		// Calculate session start time from the date string (mirrors get_random_session_start_time).
+		$session_start = gmdate(
+			'Y-m-d H:i:s',
+			strtotime( $date_gmt ) - wp_rand( 10, 360 ) * MINUTE_IN_SECONDS
+		);
+
+		if ( in_array( $source_type, array( 'admin', 'mobile_app', 'unknown' ), true ) ) {
+			return array(
+				'_wc_order_attribution_source_type' => $source_type,
+			);
+		}
+
+		$meta = array(
+			'_wc_order_attribution_origin'             => $origin,
+			'_wc_order_attribution_device_type'        => $device_type,
+			'_wc_order_attribution_user_agent'         => self::get_random_user_agent_for_device( $device_type ),
+			'_wc_order_attribution_session_count'      => wp_rand( 1, 10 ),
+			'_wc_order_attribution_session_pages'      => wp_rand( 1, 10 ),
+			'_wc_order_attribution_session_start_time' => $session_start,
+			'_wc_order_attribution_session_entry'      => $product_url,
+			'_wc_order_attribution_utm_content'        => $utm_content,
+			'_wc_order_attribution_utm_source'         => self::get_source( $source_type ),
+			'_wc_order_attribution_referrer'           => self::get_referrer( $source_type ),
+			'_wc_order_attribution_source_type'        => $source_type,
+		);
+
+		if ( wp_rand( 1, 100 ) <= self::CAMPAIGN_PROBABILITY ) {
+			$meta = array_merge( $meta, self::get_campaign_data() );
+		}
+
+		if ( ! in_array( $source_type, array( 'typein', 'admin', 'mobile_app', 'unknown' ), true ) ) {
+			$meta['_wc_order_attribution_utm_medium'] = self::get_random_utm_medium();
+		}
+
+		return $meta;
 	}
 
 	/**
@@ -337,7 +354,7 @@ class OrderAttribution {
 	 *
 	 * @return array Campaign attribution data.
 	 */
-	private static function get_campaign_data() {
+	public static function get_campaign_data() {
 		$campaign_type = self::get_campaign_type();
 
 		switch ( $campaign_type ) {
@@ -357,7 +374,7 @@ class OrderAttribution {
 	 *
 	 * @return string Campaign type.
 	 */
-	private static function get_campaign_type() {
+	public static function get_campaign_type() {
 		$random = wp_rand( 1, 100 );
 
 		if ( $random <= 40 ) {

--- a/includes/Generator/OrderBulkInserter.php
+++ b/includes/Generator/OrderBulkInserter.php
@@ -18,8 +18,6 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
  * - Tax calculation  (all tax amounts stored as zero)
  * - Coupon application
  * - Refund creation
- * - WooCommerce Analytics lookup tables (wc_order_stats etc.) — run
- *   `wp wc analytics sync` afterwards if you need analytics to reflect the data
  * - Billing/shipping addresses are freshly generated fake data rather than
  *   being loaded from existing WC_Customer records
  *
@@ -27,6 +25,8 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
  * - All six HPOS tables (wp_posts, wc_orders, wc_order_addresses,
  *   wc_order_operational_data, wc_orders_meta, woocommerce_order_items +
  *   woocommerce_order_itemmeta)
+ * - Analytics lookup tables (wc_customer_lookup, wc_order_stats,
+ *   wc_order_product_lookup) populated inline via INSERT…SELECT
  * - Full order attribution meta (same data as the ORM path)
  * - Realistic billing + shipping addresses (Faker-generated)
  * - Weighted random order statuses (or a fixed status via --status)
@@ -219,6 +219,7 @@ class OrderBulkInserter {
 		self::insert_operational_data( $order_ids, $data );
 		self::insert_meta( $order_ids, $data );
 		self::insert_order_items( $order_ids, $data );
+		self::sync_analytics_tables( $order_ids );
 
 		return $order_ids;
 	}
@@ -623,6 +624,165 @@ class OrderBulkInserter {
 				. implode( ',', $meta_rows )
 			);
 		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Analytics sync
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Populate WooCommerce Analytics lookup tables for a completed sub-batch.
+	 *
+	 * Three INSERT…SELECT statements replace per-order ORM calls:
+	 *   1. wc_customer_lookup  — one row per unique WP user seen in the batch.
+	 *   2. wc_order_stats      — one row per order; references customer_id from (1).
+	 *   3. wc_order_product_lookup — one row per line item; also references customer_id.
+	 *
+	 * wc_order_coupon_lookup and wc_order_tax_lookup are intentionally skipped:
+	 * the bulk path does not create coupon or tax line items.
+	 *
+	 * @param int[] $order_ids IDs of the orders that were just inserted.
+	 * @return void
+	 */
+	private static function sync_analytics_tables( array $order_ids ): void {
+		global $wpdb;
+
+		if ( empty( $order_ids ) ) {
+			return;
+		}
+
+		$in = implode( ',', array_fill( 0, count( $order_ids ), '%d' ) );
+
+		// ------------------------------------------------------------------
+		// 1. wc_customer_lookup
+		//    Insert one row per unique WP user. INSERT IGNORE skips users who
+		//    already have a customer record. MIN() aggregates satisfy
+		//    ONLY_FULL_GROUP_BY without distorting the data for test purposes.
+		// ------------------------------------------------------------------
+		$wpdb->query(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"INSERT IGNORE INTO {$wpdb->prefix}wc_customer_lookup
+				     (user_id, username, first_name, last_name, email,
+				      date_last_active, date_registered, country, postcode, city, state)
+				 SELECT
+				     o.customer_id,
+				     MIN( COALESCE( u.user_login, '' ) ),
+				     MIN( COALESCE( a.first_name, '' ) ),
+				     MIN( COALESCE( a.last_name, '' ) ),
+				     MIN( a.email ),
+				     MAX( o.date_created_gmt ),
+				     MIN( u.user_registered ),
+				     MIN( COALESCE( a.country, '' ) ),
+				     MIN( COALESCE( a.postcode, '' ) ),
+				     MIN( COALESCE( a.city, '' ) ),
+				     MIN( COALESCE( a.state, '' ) )
+				 FROM {$wpdb->prefix}wc_orders o
+				 LEFT JOIN {$wpdb->users} u ON u.ID = o.customer_id
+				 LEFT JOIN {$wpdb->prefix}wc_order_addresses a
+				        ON a.order_id = o.id AND a.address_type = 'billing'
+				 WHERE o.id IN ( $in )
+				 GROUP BY o.customer_id",
+				...$order_ids
+			)
+		);
+
+		// ------------------------------------------------------------------
+		// 2. wc_order_stats
+		//    date_paid / date_completed come from wc_order_operational_data.
+		//    num_items_sold is summed from order item meta (_qty).
+		//    status strips the 'wc-' prefix stored in wc_orders.status.
+		//    returning_customer is left NULL (requires cross-order analysis
+		//    that would negate the throughput benefit of bulk insert).
+		// ------------------------------------------------------------------
+		$wpdb->query(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"INSERT IGNORE INTO {$wpdb->prefix}wc_order_stats
+				     (order_id, parent_id, date_created, date_created_gmt,
+				      date_paid, date_completed, num_items_sold,
+				      total_sales, tax_total, shipping_total, net_total,
+				      returning_customer, status, customer_id)
+				 SELECT
+				     o.id,
+				     COALESCE( o.parent_order_id, 0 ),
+				     o.date_created_gmt,
+				     o.date_created_gmt,
+				     od.date_paid_gmt,
+				     od.date_completed_gmt,
+				     COALESCE( ic.num_items, 0 ),
+				     o.total_amount,
+				     o.tax_amount,
+				     0,
+				     o.total_amount - o.tax_amount,
+				     NULL,
+				     IF( o.status LIKE 'wc-%%', SUBSTR( o.status, 4 ), o.status ),
+				     COALESCE( cl.customer_id, 0 )
+				 FROM {$wpdb->prefix}wc_orders o
+				 LEFT JOIN {$wpdb->prefix}wc_order_operational_data od ON od.order_id = o.id
+				 LEFT JOIN {$wpdb->prefix}wc_customer_lookup cl ON cl.user_id = o.customer_id
+				 LEFT JOIN (
+				     SELECT oi.order_id,
+				            SUM( CAST( oim.meta_value AS UNSIGNED ) ) AS num_items
+				     FROM {$wpdb->prefix}woocommerce_order_items oi
+				     JOIN {$wpdb->prefix}woocommerce_order_itemmeta oim
+				          ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_qty'
+				     WHERE oi.order_item_type = 'line_item'
+				       AND oi.order_id IN ( $in )
+				     GROUP BY oi.order_id
+				 ) ic ON ic.order_id = o.id
+				 WHERE o.id IN ( $in )",
+				...$order_ids,
+				...$order_ids
+			)
+		);
+
+		// ------------------------------------------------------------------
+		// 3. wc_order_product_lookup
+		//    One row per line item. Shipping and coupon amounts are zero
+		//    because the bulk path does not generate those line item types.
+		// ------------------------------------------------------------------
+		$wpdb->query(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"INSERT IGNORE INTO {$wpdb->prefix}wc_order_product_lookup
+				     (order_item_id, order_id, product_id, variation_id, customer_id,
+				      date_created, product_qty, product_net_revenue,
+				      product_gross_revenue, coupon_amount, tax_amount,
+				      shipping_amount, shipping_tax_amount)
+				 SELECT
+				     oi.order_item_id,
+				     oi.order_id,
+				     COALESCE( CAST( pid.meta_value AS UNSIGNED ), 0 ),
+				     COALESCE( CAST( vid.meta_value AS UNSIGNED ), 0 ),
+				     COALESCE( cl.customer_id, 0 ),
+				     o.date_created_gmt,
+				     COALESCE( CAST( qty.meta_value AS UNSIGNED ), 0 ),
+				     COALESCE( CAST( tot.meta_value AS DECIMAL(20,6) ), 0 ),
+				     COALESCE( CAST( tot.meta_value AS DECIMAL(20,6) ), 0 )
+				         + COALESCE( CAST( tax.meta_value AS DECIMAL(20,6) ), 0 ),
+				     0,
+				     COALESCE( CAST( tax.meta_value AS DECIMAL(20,6) ), 0 ),
+				     0,
+				     0
+				 FROM {$wpdb->prefix}woocommerce_order_items oi
+				 JOIN {$wpdb->prefix}wc_orders o ON o.id = oi.order_id
+				 LEFT JOIN {$wpdb->prefix}wc_customer_lookup cl ON cl.user_id = o.customer_id
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta pid
+				        ON pid.order_item_id = oi.order_item_id AND pid.meta_key = '_product_id'
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta vid
+				        ON vid.order_item_id = oi.order_item_id AND vid.meta_key = '_variation_id'
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta qty
+				        ON qty.order_item_id = oi.order_item_id AND qty.meta_key = '_qty'
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta tot
+				        ON tot.order_item_id = oi.order_item_id AND tot.meta_key = '_line_total'
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta tax
+				        ON tax.order_item_id = oi.order_item_id AND tax.meta_key = '_line_tax'
+				 WHERE oi.order_item_type = 'line_item'
+				   AND oi.order_id IN ( $in )",
+				...$order_ids
+			)
+		);
 	}
 
 	// -------------------------------------------------------------------------

--- a/includes/Generator/OrderBulkInserter.php
+++ b/includes/Generator/OrderBulkInserter.php
@@ -1,0 +1,738 @@
+<?php
+/**
+ * Bulk order insertion via raw SQL for HPOS-enabled stores.
+ *
+ * @package SmoothGenerator\Classes
+ */
+
+namespace WC\SmoothGenerator\Generator;
+
+use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
+/**
+ * Generates orders by writing directly into HPOS tables, bypassing the
+ * WC_Order ORM entirely for maximum throughput.
+ *
+ * What this path skips vs the ORM path:
+ * - Tax calculation  (all tax amounts stored as zero)
+ * - Coupon application
+ * - Refund creation
+ * - WooCommerce Analytics lookup tables (wc_order_stats etc.) — run
+ *   `wp wc analytics sync` afterwards if you need analytics to reflect the data
+ * - Billing/shipping addresses are freshly generated fake data rather than
+ *   being loaded from existing WC_Customer records
+ *
+ * What it includes:
+ * - All six HPOS tables (wp_posts, wc_orders, wc_order_addresses,
+ *   wc_order_operational_data, wc_orders_meta, woocommerce_order_items +
+ *   woocommerce_order_itemmeta)
+ * - Full order attribution meta (same data as the ORM path)
+ * - Realistic billing + shipping addresses (Faker-generated)
+ * - Weighted random order statuses (or a fixed status via --status)
+ * - Date ranges via --date-start / --date-end
+ */
+class OrderBulkInserter {
+
+	/**
+	 * Orders inserted per DB round-trip. Large enough for efficiency,
+	 * small enough to avoid hitting PHP memory or MySQL max_allowed_packet limits.
+	 */
+	const SUB_BATCH_SIZE = 500;
+
+	/**
+	 * Faker instance shared across the full generation run.
+	 *
+	 * @var \Faker\Generator|null
+	 */
+	private static $faker = null;
+
+	/**
+	 * Pre-fetched product pool (stdObjects with id, name, price).
+	 *
+	 * @var object[]|null
+	 */
+	private static $product_pool = null;
+
+	/**
+	 * Pre-fetched user IDs for customer association.
+	 *
+	 * @var int[]|null
+	 */
+	private static $user_ids = null;
+
+	/**
+	 * Post type written to wp_posts. Determined by the data-sync setting:
+	 * 'shop_order' when sync is on, DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE when off.
+	 *
+	 * @var string|null
+	 */
+	private static $post_type = null;
+
+	/**
+	 * Monotonically increasing counter used to generate unique customer emails.
+	 *
+	 * @var int
+	 */
+	private static $email_counter = 0;
+
+	// -------------------------------------------------------------------------
+	// Public API
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Return true if HPOS is active on this site.
+	 *
+	 * @return bool
+	 */
+	public static function is_hpos_enabled(): bool {
+		if ( ! class_exists( OrderUtil::class ) ) {
+			return false;
+		}
+		return OrderUtil::custom_orders_table_usage_is_enabled();
+	}
+
+	/**
+	 * Insert $amount orders using raw SQL.
+	 *
+	 * @param int   $amount Number of orders to generate.
+	 * @param array $args   CLI args (same keys as the ORM path).
+	 * @return int[]|\WP_Error IDs of inserted orders, or a WP_Error on failure.
+	 */
+	public static function run( int $amount, array $args = array() ) {
+		if ( ! self::is_hpos_enabled() ) {
+			return new \WP_Error(
+				'hpos_required',
+				'--bulk-insert requires WooCommerce HPOS (High-Performance Order Storage) to be enabled. '
+				. 'Enable it under WooCommerce > Settings > Advanced > Features.'
+			);
+		}
+
+		self::init();
+
+		if ( empty( self::$product_pool ) ) {
+			return new \WP_Error(
+				'no_products',
+				'--bulk-insert requires at least one published product with a price greater than zero.'
+			);
+		}
+
+		$all_ids   = array();
+		$remaining = $amount;
+
+		while ( $remaining > 0 ) {
+			$batch_size = min( $remaining, self::SUB_BATCH_SIZE );
+			$ids        = self::insert_batch( $batch_size, $args );
+
+			if ( is_wp_error( $ids ) ) {
+				return $ids;
+			}
+
+			$all_ids   = array_merge( $all_ids, $ids );
+			$remaining -= $batch_size;
+
+			// Fire the progress action once per inserted order.
+			// Note: the order parameter is null in bulk mode — the action is used
+			// solely for progress tracking (ticking the CLI progress bar).
+			foreach ( $ids as $unused ) {
+				do_action( 'smoothgenerator_order_generated', null );
+			}
+		}
+
+		return $all_ids;
+	}
+
+	// -------------------------------------------------------------------------
+	// Initialisation
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Load shared data that stays constant for the full generation run.
+	 *
+	 * @return void
+	 */
+	private static function init(): void {
+		global $wpdb;
+
+		// Disable WC email sending and ensure SERVER_NAME is set
+		// (mirrors Generator::maybe_initialize_generators()).
+		Generator::disable_emails();
+		if ( ! isset( $_SERVER['SERVER_NAME'] ) ) {
+			$_SERVER['SERVER_NAME'] = 'localhost'; // phpcs:ignore WordPress.VIP.SuperGlobalInputUsage
+		}
+
+		if ( null === self::$faker ) {
+			self::$faker = \Faker\Factory::create( 'en_US' );
+		}
+
+		if ( null === self::$product_pool ) {
+			self::$product_pool = $wpdb->get_results(
+				"SELECT p.ID AS id,
+				        p.post_title AS name,
+				        CAST( COALESCE( pm.meta_value, '0' ) AS DECIMAL(10,2) ) AS price
+				 FROM {$wpdb->posts} p
+				 INNER JOIN {$wpdb->postmeta} pm
+				         ON p.ID = pm.post_id AND pm.meta_key = '_price'
+				 WHERE p.post_type   = 'product'
+				   AND p.post_status = 'publish'
+				   AND CAST( pm.meta_value AS DECIMAL(10,2) ) > 0
+				 LIMIT 500"
+			);
+		}
+
+		if ( null === self::$user_ids ) {
+			self::$user_ids = array_map(
+				'intval',
+				$wpdb->get_col( "SELECT ID FROM {$wpdb->users}" )
+			);
+		}
+
+		if ( null === self::$post_type ) {
+			$sync            = wc_get_container()->get( DataSynchronizer::class );
+			self::$post_type = $sync->data_sync_is_enabled()
+				? 'shop_order'
+				: DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Batch orchestration
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Insert one sub-batch of orders across all required HPOS tables.
+	 *
+	 * @param int   $count Number of orders in this sub-batch.
+	 * @param array $args  CLI args.
+	 * @return int[]|\WP_Error
+	 */
+	private static function insert_batch( int $count, array $args ) {
+		$data = self::prepare_batch_data( $count, $args );
+
+		$order_ids = self::insert_posts( $data );
+		if ( is_wp_error( $order_ids ) ) {
+			return $order_ids;
+		}
+
+		self::insert_wc_orders( $order_ids, $data );
+		self::insert_addresses( $order_ids, $data );
+		self::insert_operational_data( $order_ids, $data );
+		self::insert_meta( $order_ids, $data );
+		self::insert_order_items( $order_ids, $data );
+
+		return $order_ids;
+	}
+
+	// -------------------------------------------------------------------------
+	// PHP-side data generation (no DB access)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Generate all in-memory order data for a sub-batch.
+	 *
+	 * @param int   $count Number of orders.
+	 * @param array $args  CLI args.
+	 * @return array[]
+	 */
+	private static function prepare_batch_data( int $count, array $args ): array {
+		$skip_attribution = isset( $args['skip-order-attribution'] );
+
+		$dates = ! empty( $args['date-start'] ) ? self::generate_dates( $count, $args ) : null;
+
+		$data = array();
+		for ( $i = 0; $i < $count; $i++ ) {
+			$status         = ! empty( $args['status'] ) ? $args['status'] : self::random_status();
+			$date_gmt       = $dates ? $dates[ $i ] : gmdate( 'Y-m-d H:i:s' );
+			$date_paid_gmt  = null;
+			$date_compl_gmt = null;
+
+			if ( in_array( $status, array( 'completed', 'processing' ), true ) ) {
+				$date_paid_gmt = gmdate(
+					'Y-m-d H:i:s',
+					strtotime( $date_gmt ) + wp_rand( 0, 36 ) * HOUR_IN_SECONDS
+				);
+				if ( 'completed' === $status ) {
+					$date_compl_gmt = gmdate(
+						'Y-m-d H:i:s',
+						strtotime( $date_paid_gmt ) + wp_rand( 0, 36 ) * HOUR_IN_SECONDS
+					);
+				}
+			}
+
+			$items       = self::pick_products();
+			$total       = (float) array_sum( array_map( fn( $item ) => $item['line_total'], $items ) );
+			$billing     = self::generate_address_data();
+			$shipping    = wp_rand( 0, 1 ) ? self::generate_address_data() : $billing;
+			$customer_id = ! empty( self::$user_ids ) ? self::$user_ids[ array_rand( self::$user_ids ) ] : 0;
+			$order_key   = 'wc_' . wp_generate_password( 13, false );
+
+			$attribution = array();
+			if ( ! $skip_attribution && strtotime( $date_gmt ) >= strtotime( '2024-01-09' ) ) {
+				$attribution = OrderAttribution::generate_meta_array( $date_gmt );
+			}
+
+			$data[] = compact(
+				'status', 'date_gmt', 'date_paid_gmt', 'date_compl_gmt',
+				'total', 'items', 'billing', 'shipping',
+				'customer_id', 'order_key', 'attribution'
+			);
+		}
+
+		return $data;
+	}
+
+	// -------------------------------------------------------------------------
+	// SQL insert helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Bulk-insert rows into wp_posts and return the assigned IDs.
+	 *
+	 * wp_posts provides the canonical IDs that all other HPOS tables reference.
+	 * After the INSERT we read the IDs back to handle MySQL 8.0's non-consecutive
+	 * auto-increment behaviour (innodb_autoinc_lock_mode=2).
+	 *
+	 * @param array[] $data Batch data.
+	 * @return int[]|\WP_Error
+	 */
+	private static function insert_posts( array $data ) {
+		global $wpdb;
+
+		$post_type = self::$post_type;
+		$rows      = array();
+
+		foreach ( $data as $row ) {
+			$post_status = ( 'shop_order' === $post_type )
+				? 'wc-' . $row['status']
+				: 'draft';
+
+			$rows[] = $wpdb->prepare(
+				'(%d, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %d, %s, %d, %s, %s, %d)',
+				$row['customer_id'],   // post_author
+				$row['date_gmt'],      // post_date
+				$row['date_gmt'],      // post_date_gmt
+				'',                    // post_content
+				'',                    // post_title
+				'',                    // post_excerpt
+				$post_status,          // post_status
+				'open',                // comment_status
+				'closed',              // ping_status
+				'',                    // post_name
+				'',                    // to_ping
+				'',                    // pinged
+				$row['date_gmt'],      // post_modified
+				$row['date_gmt'],      // post_modified_gmt
+				'',                    // post_content_filtered
+				0,                     // post_parent
+				'',                    // guid
+				0,                     // menu_order
+				$post_type,            // post_type
+				'',                    // post_mime_type
+				0                      // comment_count
+			);
+		}
+
+		$cols = '(post_author, post_date, post_date_gmt, post_content, post_title,
+		          post_excerpt, post_status, comment_status, ping_status, post_name,
+		          to_ping, pinged, post_modified, post_modified_gmt,
+		          post_content_filtered, post_parent, guid, menu_order,
+		          post_type, post_mime_type, comment_count)';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- rows are individually prepared above
+		$result = $wpdb->query( "INSERT INTO {$wpdb->posts} {$cols} VALUES " . implode( ',', $rows ) );
+
+		if ( false === $result ) {
+			return new \WP_Error(
+				'db_insert_failed',
+				'Failed to insert placeholder posts: ' . $wpdb->last_error
+			);
+		}
+
+		$first_id = (int) $wpdb->insert_id;
+		$count    = count( $data );
+
+		// Read back the actual IDs. This handles MySQL 8.0's non-consecutive mode
+		// and protects against concurrent inserts from other wp-cli processes.
+		$order_ids = array_map(
+			'intval',
+			$wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT ID FROM {$wpdb->posts}
+					 WHERE ID >= %d AND post_type = %s
+					 ORDER BY ID ASC LIMIT %d",
+					$first_id,
+					$post_type,
+					$count
+				)
+			)
+		);
+
+		if ( count( $order_ids ) !== $count ) {
+			return new \WP_Error(
+				'id_mismatch',
+				sprintf(
+					'Expected %d post IDs after bulk insert, got %d. '
+					. 'This can happen under heavy concurrent load — retry the operation.',
+					$count,
+					count( $order_ids )
+				)
+			);
+		}
+
+		return $order_ids;
+	}
+
+	/**
+	 * Bulk-insert rows into wp_wc_orders.
+	 *
+	 * @param int[]   $order_ids Ordered list of order IDs.
+	 * @param array[] $data      Batch data aligned with $order_ids.
+	 */
+	private static function insert_wc_orders( array $order_ids, array $data ): void {
+		global $wpdb;
+
+		$rows  = array();
+		$table = $wpdb->prefix . 'wc_orders';
+		$cols  = '(id, status, currency, type, tax_amount, total_amount,
+		           customer_id, billing_email, date_created_gmt, date_updated_gmt)';
+
+		foreach ( $data as $i => $row ) {
+			$rows[] = $wpdb->prepare(
+				'(%d, %s, %s, %s, %f, %f, %d, %s, %s, %s)',
+				$order_ids[ $i ],
+				'wc-' . $row['status'],
+				get_woocommerce_currency(),
+				'shop_order',
+				0.0,
+				$row['total'],
+				$row['customer_id'],
+				$row['billing']['email'],
+				$row['date_gmt'],
+				$row['date_gmt']
+			);
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( "INSERT INTO {$table} {$cols} VALUES " . implode( ',', $rows ) );
+	}
+
+	/**
+	 * Bulk-insert billing and shipping rows into wp_wc_order_addresses.
+	 *
+	 * @param int[]   $order_ids Ordered list of order IDs.
+	 * @param array[] $data      Batch data aligned with $order_ids.
+	 */
+	private static function insert_addresses( array $order_ids, array $data ): void {
+		global $wpdb;
+
+		$rows  = array();
+		$table = $wpdb->prefix . 'wc_order_addresses';
+		$cols  = '(order_id, address_type, first_name, last_name, company,
+		           address_1, address_2, city, state, postcode, country, email, phone)';
+
+		foreach ( $data as $i => $row ) {
+			foreach ( array( 'billing', 'shipping' ) as $type ) {
+				$addr   = $row[ $type ];
+				$rows[] = $wpdb->prepare(
+					'(%d, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)',
+					$order_ids[ $i ],
+					$type,
+					$addr['first_name'],
+					$addr['last_name'],
+					$addr['company'],
+					$addr['address_1'],
+					$addr['address_2'],
+					$addr['city'],
+					$addr['state'],
+					$addr['postcode'],
+					$addr['country'],
+					'billing' === $type ? $addr['email'] : '',
+					'billing' === $type ? $addr['phone'] : ''
+				);
+			}
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( "INSERT INTO {$table} {$cols} VALUES " . implode( ',', $rows ) );
+	}
+
+	/**
+	 * Bulk-insert rows into wp_wc_order_operational_data.
+	 *
+	 * @param int[]   $order_ids Ordered list of order IDs.
+	 * @param array[] $data      Batch data aligned with $order_ids.
+	 */
+	private static function insert_operational_data( array $order_ids, array $data ): void {
+		global $wpdb;
+
+		$wc_version = defined( 'WC_VERSION' ) ? WC_VERSION : '';
+		$rows       = array();
+		$table      = $wpdb->prefix . 'wc_order_operational_data';
+		$cols       = '(order_id, created_via, woocommerce_version, prices_include_tax,
+		                coupon_usages_are_counted, download_permission_granted,
+		                new_order_email_sent, order_key, order_stock_reduced,
+		                date_paid_gmt, date_completed_gmt)';
+
+		foreach ( $data as $i => $row ) {
+			$date_paid  = self::nullable_datetime( $row['date_paid_gmt'] );
+			$date_compl = self::nullable_datetime( $row['date_compl_gmt'] );
+
+			$base   = $wpdb->prepare(
+				'(%d, %s, %s, %d, %d, %d, %d, %s, %d',
+				$order_ids[ $i ],
+				'smooth-generator',
+				$wc_version,
+				0,   // prices_include_tax
+				1,   // coupon_usages_are_counted
+				0,   // download_permission_granted
+				0,   // new_order_email_sent
+				$row['order_key'],
+				0    // order_stock_reduced
+			);
+			$rows[] = $base . ', ' . $date_paid . ', ' . $date_compl . ')';
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( "INSERT INTO {$table} {$cols} VALUES " . implode( ',', $rows ) );
+	}
+
+	/**
+	 * Bulk-insert order attribution meta into wp_wc_orders_meta.
+	 *
+	 * @param int[]   $order_ids Ordered list of order IDs.
+	 * @param array[] $data      Batch data aligned with $order_ids.
+	 */
+	private static function insert_meta( array $order_ids, array $data ): void {
+		global $wpdb;
+
+		$rows  = array();
+		$table = $wpdb->prefix . 'wc_orders_meta';
+
+		foreach ( $data as $i => $row ) {
+			if ( empty( $row['attribution'] ) ) {
+				continue;
+			}
+			foreach ( $row['attribution'] as $meta_key => $meta_value ) {
+				$rows[] = $wpdb->prepare(
+					'(%d, %s, %s)',
+					$order_ids[ $i ],
+					$meta_key,
+					(string) $meta_value
+				);
+			}
+		}
+
+		if ( empty( $rows ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( "INSERT INTO {$table} (order_id, meta_key, meta_value) VALUES " . implode( ',', $rows ) );
+	}
+
+	/**
+	 * Bulk-insert order line items and their meta.
+	 *
+	 * woocommerce_order_items has AUTO_INCREMENT, so we do the same
+	 * read-back trick as insert_posts to get the real item IDs.
+	 *
+	 * @param int[]   $order_ids Ordered list of order IDs.
+	 * @param array[] $data      Batch data aligned with $order_ids.
+	 */
+	private static function insert_order_items( array $order_ids, array $data ): void {
+		global $wpdb;
+
+		$item_rows   = array();
+		$items_table = $wpdb->prefix . 'woocommerce_order_items';
+
+		foreach ( $data as $i => $row ) {
+			foreach ( $row['items'] as $item ) {
+				$item_rows[] = $wpdb->prepare(
+					'(%s, %s, %d)',
+					$item['name'],
+					'line_item',
+					$order_ids[ $i ]
+				);
+			}
+		}
+
+		if ( empty( $item_rows ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query(
+			"INSERT INTO {$items_table} (order_item_name, order_item_type, order_id) VALUES "
+			. implode( ',', $item_rows )
+		);
+
+		$first_item_id = (int) $wpdb->insert_id;
+		$total_items   = count( $item_rows );
+
+		$item_ids = array_map(
+			'intval',
+			$wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT order_item_id FROM {$items_table}
+					 WHERE order_item_id >= %d
+					 ORDER BY order_item_id ASC LIMIT %d",
+					$first_item_id,
+					$total_items
+				)
+			)
+		);
+
+		$meta_rows  = array();
+		$meta_table = $wpdb->prefix . 'woocommerce_order_itemmeta';
+		$meta_idx   = 0;
+
+		$line_tax_data = serialize( array( 'total' => array(), 'subtotal' => array() ) );
+
+		foreach ( $data as $row ) {
+			foreach ( $row['items'] as $item ) {
+				$item_id = $item_ids[ $meta_idx ] ?? null;
+				if ( null === $item_id ) {
+					$meta_idx++;
+					continue;
+				}
+
+				foreach (
+					array(
+						'_product_id'        => $item['product_id'],
+						'_variation_id'      => 0,
+						'_qty'               => $item['qty'],
+						'_tax_class'         => '',
+						'_line_subtotal'     => $item['line_total'],
+						'_line_subtotal_tax' => 0,
+						'_line_total'        => $item['line_total'],
+						'_line_tax'          => 0,
+						'_line_tax_data'     => $line_tax_data,
+					) as $meta_key => $meta_val
+				) {
+					$meta_rows[] = $wpdb->prepare( '(%d, %s, %s)', $item_id, $meta_key, $meta_val );
+				}
+
+				$meta_idx++;
+			}
+		}
+
+		if ( ! empty( $meta_rows ) ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query(
+				"INSERT INTO {$meta_table} (order_item_id, meta_key, meta_value) VALUES "
+				. implode( ',', $meta_rows )
+			);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Data generation helpers (pure PHP, no DB)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Randomly pick 1–5 products from the pre-fetched pool.
+	 *
+	 * @return array[]
+	 */
+	private static function pick_products(): array {
+		$pool  = self::$product_pool;
+		$count = count( $pool );
+		$num   = wp_rand( 1, min( 5, $count ) );
+		$keys  = (array) array_rand( (array) $pool, min( $num, $count ) );
+		$items = array();
+
+		foreach ( $keys as $key ) {
+			$product = $pool[ $key ];
+			$qty     = wp_rand( 1, 5 );
+			$price   = (float) $product->price;
+			$items[] = array(
+				'product_id' => (int) $product->id,
+				'name'       => $product->name,
+				'qty'        => $qty,
+				'line_total' => round( $price * $qty, 2 ),
+			);
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Generate a fake customer address.
+	 * Uses a single shared Faker instance to avoid the overhead of
+	 * creating a new locale-specific Faker per order (as CustomerInfo does).
+	 *
+	 * @return array
+	 */
+	private static function generate_address_data(): array {
+		$f          = self::$faker;
+		$is_company = $f->boolean( 30 );
+
+		return array(
+			'first_name' => $is_company ? '' : $f->firstName(),
+			'last_name'  => $is_company ? '' : $f->lastName(),
+			'company'    => $is_company ? $f->company() : '',
+			'address_1'  => $f->streetAddress(),
+			'address_2'  => '',
+			'city'       => $f->city(),
+			'state'      => $f->stateAbbr(),
+			'postcode'   => $f->postcode(),
+			'country'    => 'US',
+			'email'      => sprintf( 'order-%d@example.com', ++self::$email_counter ),
+			'phone'      => $f->phoneNumber(),
+		);
+	}
+
+	/**
+	 * Return a random order status using the same weighted distribution as the ORM path.
+	 *
+	 * @return string
+	 */
+	private static function random_status(): string {
+		$rand = wp_rand( 1, 100 );
+		if ( $rand <= 70 ) {
+			return 'completed';
+		}
+		if ( $rand <= 85 ) {
+			return 'processing';
+		}
+		if ( $rand <= 90 ) {
+			return 'on-hold';
+		}
+		return 'failed';
+	}
+
+	/**
+	 * Pre-generate a sorted array of GMT datetime strings for a batch.
+	 * Chronological sort ensures lower order IDs get earlier dates.
+	 *
+	 * @param int   $count Number of dates.
+	 * @param array $args  CLI args with date-start / date-end.
+	 * @return string[]
+	 */
+	private static function generate_dates( int $count, array $args ): array {
+		$start    = $args['date-start'];
+		$end      = ! empty( $args['date-end'] ) ? $args['date-end'] : gmdate( 'Y-m-d' );
+		$start_ts = strtotime( $start );
+		$end_ts   = strtotime( $end );
+		$range    = max( 1, $end_ts - $start_ts );
+
+		$dates = array();
+		for ( $i = 0; $i < $count; $i++ ) {
+			$ts      = $start_ts + wp_rand( 0, $range );
+			$dates[] = gmdate( 'Y-m-d ', $ts ) . wp_rand( 0, 23 ) . ':00:00';
+		}
+
+		sort( $dates );
+		return $dates;
+	}
+
+	/**
+	 * Return a SQL-safe datetime literal or the string 'NULL' for nullable columns.
+	 *
+	 * @param string|null $dt Datetime string or null.
+	 * @return string
+	 */
+	private static function nullable_datetime( ?string $dt ): string {
+		return $dt ? "'" . esc_sql( $dt ) . "'" : 'NULL';
+	}
+}

--- a/includes/Generator/OrderBulkInserter.php
+++ b/includes/Generator/OrderBulkInserter.php
@@ -18,6 +18,8 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
  * - Tax calculation  (all tax amounts stored as zero)
  * - Coupon application
  * - Refund creation
+ * - WooCommerce Analytics lookup tables (wc_order_stats etc.) — use
+ *   `wp wc sync analytics` or the "Sync Analytics" button in the UI
  * - Billing/shipping addresses are freshly generated fake data rather than
  *   being loaded from existing WC_Customer records
  *
@@ -25,8 +27,6 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
  * - All six HPOS tables (wp_posts, wc_orders, wc_order_addresses,
  *   wc_order_operational_data, wc_orders_meta, woocommerce_order_items +
  *   woocommerce_order_itemmeta)
- * - Analytics lookup tables (wc_customer_lookup, wc_order_stats,
- *   wc_order_product_lookup) populated inline via INSERT…SELECT
  * - Full order attribution meta (same data as the ORM path)
  * - Realistic billing + shipping addresses (Faker-generated)
  * - Weighted random order statuses (or a fixed status via --status)
@@ -219,7 +219,6 @@ class OrderBulkInserter {
 		self::insert_operational_data( $order_ids, $data );
 		self::insert_meta( $order_ids, $data );
 		self::insert_order_items( $order_ids, $data );
-		self::sync_analytics_tables( $order_ids );
 
 		return $order_ids;
 	}
@@ -624,165 +623,6 @@ class OrderBulkInserter {
 				. implode( ',', $meta_rows )
 			);
 		}
-	}
-
-	// -------------------------------------------------------------------------
-	// Analytics sync
-	// -------------------------------------------------------------------------
-
-	/**
-	 * Populate WooCommerce Analytics lookup tables for a completed sub-batch.
-	 *
-	 * Three INSERT…SELECT statements replace per-order ORM calls:
-	 *   1. wc_customer_lookup  — one row per unique WP user seen in the batch.
-	 *   2. wc_order_stats      — one row per order; references customer_id from (1).
-	 *   3. wc_order_product_lookup — one row per line item; also references customer_id.
-	 *
-	 * wc_order_coupon_lookup and wc_order_tax_lookup are intentionally skipped:
-	 * the bulk path does not create coupon or tax line items.
-	 *
-	 * @param int[] $order_ids IDs of the orders that were just inserted.
-	 * @return void
-	 */
-	private static function sync_analytics_tables( array $order_ids ): void {
-		global $wpdb;
-
-		if ( empty( $order_ids ) ) {
-			return;
-		}
-
-		$in = implode( ',', array_fill( 0, count( $order_ids ), '%d' ) );
-
-		// ------------------------------------------------------------------
-		// 1. wc_customer_lookup
-		//    Insert one row per unique WP user. INSERT IGNORE skips users who
-		//    already have a customer record. MIN() aggregates satisfy
-		//    ONLY_FULL_GROUP_BY without distorting the data for test purposes.
-		// ------------------------------------------------------------------
-		$wpdb->query(
-			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"INSERT IGNORE INTO {$wpdb->prefix}wc_customer_lookup
-				     (user_id, username, first_name, last_name, email,
-				      date_last_active, date_registered, country, postcode, city, state)
-				 SELECT
-				     o.customer_id,
-				     MIN( COALESCE( u.user_login, '' ) ),
-				     MIN( COALESCE( a.first_name, '' ) ),
-				     MIN( COALESCE( a.last_name, '' ) ),
-				     MIN( a.email ),
-				     MAX( o.date_created_gmt ),
-				     MIN( u.user_registered ),
-				     MIN( COALESCE( a.country, '' ) ),
-				     MIN( COALESCE( a.postcode, '' ) ),
-				     MIN( COALESCE( a.city, '' ) ),
-				     MIN( COALESCE( a.state, '' ) )
-				 FROM {$wpdb->prefix}wc_orders o
-				 LEFT JOIN {$wpdb->users} u ON u.ID = o.customer_id
-				 LEFT JOIN {$wpdb->prefix}wc_order_addresses a
-				        ON a.order_id = o.id AND a.address_type = 'billing'
-				 WHERE o.id IN ( $in )
-				 GROUP BY o.customer_id",
-				...$order_ids
-			)
-		);
-
-		// ------------------------------------------------------------------
-		// 2. wc_order_stats
-		//    date_paid / date_completed come from wc_order_operational_data.
-		//    num_items_sold is summed from order item meta (_qty).
-		//    status strips the 'wc-' prefix stored in wc_orders.status.
-		//    returning_customer is left NULL (requires cross-order analysis
-		//    that would negate the throughput benefit of bulk insert).
-		// ------------------------------------------------------------------
-		$wpdb->query(
-			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"INSERT IGNORE INTO {$wpdb->prefix}wc_order_stats
-				     (order_id, parent_id, date_created, date_created_gmt,
-				      date_paid, date_completed, num_items_sold,
-				      total_sales, tax_total, shipping_total, net_total,
-				      returning_customer, status, customer_id)
-				 SELECT
-				     o.id,
-				     COALESCE( o.parent_order_id, 0 ),
-				     o.date_created_gmt,
-				     o.date_created_gmt,
-				     od.date_paid_gmt,
-				     od.date_completed_gmt,
-				     COALESCE( ic.num_items, 0 ),
-				     o.total_amount,
-				     o.tax_amount,
-				     0,
-				     o.total_amount - o.tax_amount,
-				     NULL,
-				     IF( o.status LIKE 'wc-%%', SUBSTR( o.status, 4 ), o.status ),
-				     COALESCE( cl.customer_id, 0 )
-				 FROM {$wpdb->prefix}wc_orders o
-				 LEFT JOIN {$wpdb->prefix}wc_order_operational_data od ON od.order_id = o.id
-				 LEFT JOIN {$wpdb->prefix}wc_customer_lookup cl ON cl.user_id = o.customer_id
-				 LEFT JOIN (
-				     SELECT oi.order_id,
-				            SUM( CAST( oim.meta_value AS UNSIGNED ) ) AS num_items
-				     FROM {$wpdb->prefix}woocommerce_order_items oi
-				     JOIN {$wpdb->prefix}woocommerce_order_itemmeta oim
-				          ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_qty'
-				     WHERE oi.order_item_type = 'line_item'
-				       AND oi.order_id IN ( $in )
-				     GROUP BY oi.order_id
-				 ) ic ON ic.order_id = o.id
-				 WHERE o.id IN ( $in )",
-				...$order_ids,
-				...$order_ids
-			)
-		);
-
-		// ------------------------------------------------------------------
-		// 3. wc_order_product_lookup
-		//    One row per line item. Shipping and coupon amounts are zero
-		//    because the bulk path does not generate those line item types.
-		// ------------------------------------------------------------------
-		$wpdb->query(
-			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"INSERT IGNORE INTO {$wpdb->prefix}wc_order_product_lookup
-				     (order_item_id, order_id, product_id, variation_id, customer_id,
-				      date_created, product_qty, product_net_revenue,
-				      product_gross_revenue, coupon_amount, tax_amount,
-				      shipping_amount, shipping_tax_amount)
-				 SELECT
-				     oi.order_item_id,
-				     oi.order_id,
-				     COALESCE( CAST( pid.meta_value AS UNSIGNED ), 0 ),
-				     COALESCE( CAST( vid.meta_value AS UNSIGNED ), 0 ),
-				     COALESCE( cl.customer_id, 0 ),
-				     o.date_created_gmt,
-				     COALESCE( CAST( qty.meta_value AS UNSIGNED ), 0 ),
-				     COALESCE( CAST( tot.meta_value AS DECIMAL(20,6) ), 0 ),
-				     COALESCE( CAST( tot.meta_value AS DECIMAL(20,6) ), 0 )
-				         + COALESCE( CAST( tax.meta_value AS DECIMAL(20,6) ), 0 ),
-				     0,
-				     COALESCE( CAST( tax.meta_value AS DECIMAL(20,6) ), 0 ),
-				     0,
-				     0
-				 FROM {$wpdb->prefix}woocommerce_order_items oi
-				 JOIN {$wpdb->prefix}wc_orders o ON o.id = oi.order_id
-				 LEFT JOIN {$wpdb->prefix}wc_customer_lookup cl ON cl.user_id = o.customer_id
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta pid
-				        ON pid.order_item_id = oi.order_item_id AND pid.meta_key = '_product_id'
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta vid
-				        ON vid.order_item_id = oi.order_item_id AND vid.meta_key = '_variation_id'
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta qty
-				        ON qty.order_item_id = oi.order_item_id AND qty.meta_key = '_qty'
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta tot
-				        ON tot.order_item_id = oi.order_item_id AND tot.meta_key = '_line_total'
-				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta tax
-				        ON tax.order_item_id = oi.order_item_id AND tax.meta_key = '_line_tax'
-				 WHERE oi.order_item_type = 'line_item'
-				   AND oi.order_id IN ( $in )",
-				...$order_ids
-			)
-		);
 	}
 
 	// -------------------------------------------------------------------------

--- a/includes/Generator/OrderBulkInserter.php
+++ b/includes/Generator/OrderBulkInserter.php
@@ -153,13 +153,22 @@ class OrderBulkInserter {
 				return $ids;
 			}
 
-			$all_ids   = array_merge( $all_ids, $ids );
+			$all_ids    = array_merge( $all_ids, $ids );
 			$remaining -= $batch_size;
 
 			// Fire the progress action once per inserted order.
 			// Note: the order parameter is null in bulk mode — the action is used
 			// solely for progress tracking (ticking the CLI progress bar).
 			foreach ( $ids as $unused ) {
+				/**
+				 * Action: Order generator returned a new order.
+				 * In bulk-insert mode the order parameter is always null;
+				 * the action is used solely for progress tracking.
+				 *
+				 * @since 1.2.0
+				 *
+				 * @param null $order Always null in bulk-insert mode.
+				 */
 				do_action( 'smoothgenerator_order_generated', null );
 			}
 		}
@@ -343,12 +352,25 @@ class OrderBulkInserter {
 				$rate       = self::$tax_rate_pool[ array_rand( self::$tax_rate_pool ) ];
 				$taxable    = $total - $discount_amount + $shipping_amount;
 				$tax_amount = round( $taxable * (float) $rate->tax_rate / 100, 2 );
-				$tax_line   = array(
-					'tax_rate_id'   => (int) $rate->tax_rate_id,
-					'tax_rate'      => (float) $rate->tax_rate,
-					'tax_rate_name' => $rate->tax_rate_name ?: 'Tax',
-					'tax_amount'    => $tax_amount,
-					'shipping_tax'  => 0.0,
+
+				// Build the rate code the same way WC_Tax::get_rate_code() does:
+				// COUNTRY-STATE-NAME-PRIORITY, uppercased, empty segments filtered out,
+				// 'TAX' substituted when tax_rate_name is empty.
+				$code_parts = array_filter( array(
+					$rate->tax_rate_country,
+					$rate->tax_rate_state,
+					! empty( $rate->tax_rate_name ) ? $rate->tax_rate_name : 'TAX',
+					absint( $rate->tax_rate_priority ),
+				) );
+				$rate_code  = strtoupper( implode( '-', $code_parts ) );
+
+				$tax_line = array(
+					'tax_rate_id'  => (int) $rate->tax_rate_id,
+					'rate_code'    => $rate_code,           // Stored as order_item_name.
+					'label'        => $rate->tax_rate_name, // Stored as 'label' meta (may be empty).
+					'rate_percent' => (float) $rate->tax_rate,
+					'tax_amount'   => $tax_amount,
+					'shipping_tax' => 0.0,
 				);
 			}
 
@@ -373,7 +395,7 @@ class OrderBulkInserter {
 	/**
 	 * Bulk-insert rows into wp_posts and return the assigned IDs.
 	 *
-	 * wp_posts provides the canonical IDs that all other HPOS tables reference.
+	 * The wp_posts table provides the canonical IDs that all other HPOS tables reference.
 	 * After the INSERT we read the IDs back to handle MySQL 8.0's non-consecutive
 	 * auto-increment behaviour (innodb_autoinc_lock_mode=2).
 	 *
@@ -393,27 +415,27 @@ class OrderBulkInserter {
 
 			$rows[] = $wpdb->prepare(
 				'(%d, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %d, %s, %d, %s, %s, %d)',
-				$row['customer_id'],   // post_author
-				$row['date_gmt'],      // post_date
-				$row['date_gmt'],      // post_date_gmt
-				'',                    // post_content
-				'',                    // post_title
-				'',                    // post_excerpt
-				$post_status,          // post_status
-				'open',                // comment_status
-				'closed',              // ping_status
-				'',                    // post_name
-				'',                    // to_ping
-				'',                    // pinged
-				$row['date_gmt'],      // post_modified
-				$row['date_gmt'],      // post_modified_gmt
-				'',                    // post_content_filtered
-				0,                     // post_parent
-				'',                    // guid
-				0,                     // menu_order
-				$post_type,            // post_type
-				'',                    // post_mime_type
-				0                      // comment_count
+				$row['customer_id'],   // post_author.
+				$row['date_gmt'],      // post_date.
+				$row['date_gmt'],      // post_date_gmt.
+				'',                    // post_content.
+				'',                    // post_title.
+				'',                    // post_excerpt.
+				$post_status,          // post_status.
+				'open',                // comment_status.
+				'closed',              // ping_status.
+				'',                    // post_name.
+				'',                    // to_ping.
+				'',                    // pinged.
+				$row['date_gmt'],      // post_modified.
+				$row['date_gmt'],      // post_modified_gmt.
+				'',                    // post_content_filtered.
+				0,                     // post_parent.
+				'',                    // guid.
+				0,                     // menu_order.
+				$post_type,            // post_type.
+				'',                    // post_mime_type.
+				0                      // comment_count.
 			);
 		}
 
@@ -423,7 +445,7 @@ class OrderBulkInserter {
 		          post_content_filtered, post_parent, guid, menu_order,
 		          post_type, post_mime_type, comment_count)';
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- rows are individually prepared above
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- rows are individually prepared above
 		$result = $wpdb->query( "INSERT INTO {$wpdb->posts} {$cols} VALUES " . implode( ',', $rows ) );
 
 		if ( false === $result ) {
@@ -563,17 +585,17 @@ class OrderBulkInserter {
 			$date_paid  = self::nullable_datetime( $row['date_paid_gmt'] );
 			$date_compl = self::nullable_datetime( $row['date_compl_gmt'] );
 
-			$base   = $wpdb->prepare(
+			$base     = $wpdb->prepare(
 				'(%d, %s, %s, %d, %d, %d, %d, %s, %d',
 				$order_ids[ $i ],
 				'smooth-generator',
 				$wc_version,
-				0,   // prices_include_tax
-				1,   // coupon_usages_are_counted
-				0,   // download_permission_granted
-				0,   // new_order_email_sent
+				0,   // prices_include_tax.
+				1,   // coupon_usages_are_counted.
+				0,   // download_permission_granted.
+				0,   // new_order_email_sent.
 				$row['order_key'],
-				0    // order_stock_reduced
+				0    // order_stock_reduced.
 			);
 			$discount = sprintf( '%.8F', $row['discount_amount'] ?? 0.0 );
 			$shipping = sprintf( '%.8F', $row['shipping_amount'] ?? 0.0 );
@@ -621,7 +643,7 @@ class OrderBulkInserter {
 	/**
 	 * Bulk-insert order line items and their meta.
 	 *
-	 * woocommerce_order_items has AUTO_INCREMENT, so we do the same
+	 * The woocommerce_order_items table has AUTO_INCREMENT, so we do the same
 	 * read-back trick as insert_posts to get the real item IDs.
 	 *
 	 * @param int[]   $order_ids Ordered list of order IDs.
@@ -648,11 +670,12 @@ class OrderBulkInserter {
 			return;
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$wpdb->query(
 			"INSERT INTO {$items_table} (order_item_name, order_item_type, order_id) VALUES "
 			. implode( ',', $item_rows )
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		$first_item_id = (int) $wpdb->insert_id;
 		$total_items   = count( $item_rows );
@@ -661,6 +684,7 @@ class OrderBulkInserter {
 			'intval',
 			$wpdb->get_col(
 				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					"SELECT order_item_id FROM {$items_table}
 					 WHERE order_item_id >= %d
 					 ORDER BY order_item_id ASC LIMIT %d",
@@ -674,13 +698,17 @@ class OrderBulkInserter {
 		$meta_table = $wpdb->prefix . 'woocommerce_order_itemmeta';
 		$meta_idx   = 0;
 
-		$line_tax_data = serialize( array( 'total' => array(), 'subtotal' => array() ) );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- WooCommerce stores _line_tax_data as serialized PHP.
+		$line_tax_data = serialize( array(
+			'total'    => array(),
+			'subtotal' => array(),
+		) );
 
 		foreach ( $data as $row ) {
 			foreach ( $row['items'] as $item ) {
 				$item_id = $item_ids[ $meta_idx ] ?? null;
 				if ( null === $item_id ) {
-					$meta_idx++;
+					++$meta_idx;
 					continue;
 				}
 
@@ -700,16 +728,17 @@ class OrderBulkInserter {
 					$meta_rows[] = $wpdb->prepare( '(%d, %s, %s)', $item_id, $meta_key, $meta_val );
 				}
 
-				$meta_idx++;
+				++$meta_idx;
 			}
 		}
 
 		if ( ! empty( $meta_rows ) ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$wpdb->query(
 				"INSERT INTO {$meta_table} (order_item_id, meta_key, meta_value) VALUES "
 				. implode( ',', $meta_rows )
 			);
+			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 	}
 
@@ -757,12 +786,13 @@ class OrderBulkInserter {
 			if ( isset( $row['tax_line'] ) ) {
 				$items[] = array(
 					'order_id' => $order_ids[ $i ],
-					'name'     => $row['tax_line']['tax_rate_name'],
+					'name'     => $row['tax_line']['rate_code'],  // e.g. NL-TAX-1.
 					'type'     => 'tax',
 					'meta'     => array(
 						'rate_id'             => $row['tax_line']['tax_rate_id'],
-						'label'               => $row['tax_line']['tax_rate_name'],
+						'label'               => $row['tax_line']['label'],
 						'compound'            => 0,
+						'rate_percent'        => $row['tax_line']['rate_percent'],
 						'tax_amount'          => $row['tax_line']['tax_amount'],
 						'shipping_tax_amount' => $row['tax_line']['shipping_tax'],
 					),
@@ -787,11 +817,12 @@ class OrderBulkInserter {
 			);
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$wpdb->query(
 			"INSERT INTO {$items_table} (order_item_name, order_item_type, order_id) VALUES "
 			. implode( ',', $item_rows )
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		$first_item_id = (int) $wpdb->insert_id;
 		$total_items   = count( $items );
@@ -800,6 +831,7 @@ class OrderBulkInserter {
 			'intval',
 			$wpdb->get_col(
 				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					"SELECT order_item_id FROM {$items_table}
 					 WHERE order_item_id >= %d
 					 ORDER BY order_item_id ASC LIMIT %d",
@@ -821,11 +853,12 @@ class OrderBulkInserter {
 		}
 
 		if ( ! empty( $meta_rows ) ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$wpdb->query(
 				"INSERT INTO {$meta_table} (order_item_id, meta_key, meta_value) VALUES "
 				. implode( ',', $meta_rows )
 			);
+			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 	}
 
@@ -867,7 +900,7 @@ class OrderBulkInserter {
 			$pool = $fetch();
 		}
 
-		return $pool ?: array();
+		return ! empty( $pool ) ? $pool : array();
 	}
 
 	/**
@@ -916,10 +949,12 @@ class OrderBulkInserter {
 	private static function fetch_tax_rate_pool(): array {
 		global $wpdb;
 
-		return $wpdb->get_results(
-			"SELECT tax_rate_id, tax_rate, tax_rate_name, tax_rate_compound
+		$results = $wpdb->get_results(
+			"SELECT tax_rate_id, tax_rate, tax_rate_name, tax_rate_compound,
+			        tax_rate_country, tax_rate_state, tax_rate_priority
 			 FROM {$wpdb->prefix}woocommerce_tax_rates"
-		) ?: array();
+		);
+		return ! empty( $results ) ? $results : array();
 	}
 
 	// -------------------------------------------------------------------------

--- a/includes/Generator/OrderBulkInserter.php
+++ b/includes/Generator/OrderBulkInserter.php
@@ -15,8 +15,9 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
  * WC_Order ORM entirely for maximum throughput.
  *
  * What this path skips vs the ORM path:
- * - Tax calculation  (all tax amounts stored as zero)
- * - Coupon application
+ * - Tax calculation   (enable via --taxes flag or UI checkbox; applies a random existing tax rate)
+ * - Coupon application (enable via --coupons flag or UI checkbox; applies a random existing coupon)
+ * - Shipping lines    (enable via --shipping flag or UI checkbox; applies a random enabled shipping method)
  * - Refund creation
  * - WooCommerce Analytics lookup tables (wc_order_stats etc.) — use
  *   `wp wc sync analytics` or the "Sync Analytics" button in the UI
@@ -76,6 +77,30 @@ class OrderBulkInserter {
 	 */
 	private static $email_counter = 0;
 
+	/**
+	 * Pre-fetched coupon pool (stdObjects with id, code, discount_type, coupon_amount).
+	 * Loaded on first run when --coupons is active.
+	 *
+	 * @var object[]|null
+	 */
+	private static $coupon_pool = null;
+
+	/**
+	 * Pre-fetched shipping pool (arrays with instance_id, method_id, cost, title).
+	 * Loaded on first run when --shipping is active.
+	 *
+	 * @var array[]|null
+	 */
+	private static $shipping_pool = null;
+
+	/**
+	 * Pre-fetched tax rate pool (stdObjects with tax_rate_id, tax_rate, tax_rate_name).
+	 * Loaded on first run when --taxes is active.
+	 *
+	 * @var object[]|null
+	 */
+	private static $tax_rate_pool = null;
+
 	// -------------------------------------------------------------------------
 	// Public API
 	// -------------------------------------------------------------------------
@@ -108,7 +133,7 @@ class OrderBulkInserter {
 			);
 		}
 
-		self::init();
+		self::init( $args );
 
 		if ( empty( self::$product_pool ) ) {
 			return new \WP_Error(
@@ -149,9 +174,10 @@ class OrderBulkInserter {
 	/**
 	 * Load shared data that stays constant for the full generation run.
 	 *
+	 * @param array $args CLI / UI args — used to determine which optional pools to load.
 	 * @return void
 	 */
-	private static function init(): void {
+	private static function init( array $args = array() ): void {
 		global $wpdb;
 
 		// Disable WC email sending and ensure SERVER_NAME is set
@@ -193,6 +219,18 @@ class OrderBulkInserter {
 				? 'shop_order'
 				: DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE;
 		}
+
+		if ( ! empty( $args['coupons'] ) && null === self::$coupon_pool ) {
+			self::$coupon_pool = self::fetch_coupon_pool();
+		}
+
+		if ( ! empty( $args['shipping'] ) && null === self::$shipping_pool ) {
+			self::$shipping_pool = self::fetch_shipping_pool();
+		}
+
+		if ( ! empty( $args['taxes'] ) && null === self::$tax_rate_pool ) {
+			self::$tax_rate_pool = self::fetch_tax_rate_pool();
+		}
 	}
 
 	// -------------------------------------------------------------------------
@@ -219,6 +257,7 @@ class OrderBulkInserter {
 		self::insert_operational_data( $order_ids, $data );
 		self::insert_meta( $order_ids, $data );
 		self::insert_order_items( $order_ids, $data );
+		self::insert_extra_order_items( $order_ids, $data );
 
 		return $order_ids;
 	}
@@ -271,10 +310,56 @@ class OrderBulkInserter {
 				$attribution = OrderAttribution::generate_meta_array( $date_gmt );
 			}
 
+			// Optional: coupon discount.
+			$coupon_line     = null;
+			$discount_amount = 0.0;
+			if ( ! empty( $args['coupons'] ) && ! empty( self::$coupon_pool ) ) {
+				$coupon = self::$coupon_pool[ array_rand( self::$coupon_pool ) ];
+				if ( 'percent' === $coupon->discount_type ) {
+					$discount_amount = round( $total * (float) $coupon->coupon_amount / 100, 2 );
+				} else {
+					$discount_amount = min( (float) $coupon->coupon_amount, $total );
+				}
+				$coupon_line = array(
+					'id'       => (int) $coupon->id,
+					'code'     => $coupon->code,
+					'discount' => $discount_amount,
+				);
+			}
+
+			// Optional: shipping line item.
+			$shipping_line   = null;
+			$shipping_amount = 0.0;
+			if ( ! empty( $args['shipping'] ) && ! empty( self::$shipping_pool ) ) {
+				$method          = self::$shipping_pool[ array_rand( self::$shipping_pool ) ];
+				$shipping_amount = (float) $method['cost'];
+				$shipping_line   = $method;
+			}
+
+			// Optional: tax on (subtotal - discount + shipping).
+			$tax_line   = null;
+			$tax_amount = 0.0;
+			if ( ! empty( $args['taxes'] ) && ! empty( self::$tax_rate_pool ) ) {
+				$rate       = self::$tax_rate_pool[ array_rand( self::$tax_rate_pool ) ];
+				$taxable    = $total - $discount_amount + $shipping_amount;
+				$tax_amount = round( $taxable * (float) $rate->tax_rate / 100, 2 );
+				$tax_line   = array(
+					'tax_rate_id'   => (int) $rate->tax_rate_id,
+					'tax_rate'      => (float) $rate->tax_rate,
+					'tax_rate_name' => $rate->tax_rate_name ?: 'Tax',
+					'tax_amount'    => $tax_amount,
+					'shipping_tax'  => 0.0,
+				);
+			}
+
+			$order_total = round( $total - $discount_amount + $shipping_amount + $tax_amount, 2 );
+
 			$data[] = compact(
 				'status', 'date_gmt', 'date_paid_gmt', 'date_compl_gmt',
-				'total', 'items', 'billing', 'shipping',
-				'customer_id', 'order_key', 'attribution'
+				'total', 'order_total', 'items', 'billing', 'shipping',
+				'customer_id', 'order_key', 'attribution',
+				'discount_amount', 'shipping_amount', 'tax_amount',
+				'coupon_line', 'shipping_line', 'tax_line'
 			);
 		}
 
@@ -403,8 +488,8 @@ class OrderBulkInserter {
 				'wc-' . $row['status'],
 				get_woocommerce_currency(),
 				'shop_order',
-				0.0,
-				$row['total'],
+				$row['tax_amount'],
+				$row['order_total'],
 				$row['customer_id'],
 				$row['billing']['email'],
 				$row['date_gmt'],
@@ -471,7 +556,8 @@ class OrderBulkInserter {
 		$cols       = '(order_id, created_via, woocommerce_version, prices_include_tax,
 		                coupon_usages_are_counted, download_permission_granted,
 		                new_order_email_sent, order_key, order_stock_reduced,
-		                date_paid_gmt, date_completed_gmt)';
+		                date_paid_gmt, date_completed_gmt,
+		                discount_total_amount, shipping_total_amount)';
 
 		foreach ( $data as $i => $row ) {
 			$date_paid  = self::nullable_datetime( $row['date_paid_gmt'] );
@@ -489,7 +575,9 @@ class OrderBulkInserter {
 				$row['order_key'],
 				0    // order_stock_reduced
 			);
-			$rows[] = $base . ', ' . $date_paid . ', ' . $date_compl . ')';
+			$discount = sprintf( '%.8F', $row['discount_amount'] ?? 0.0 );
+			$shipping = sprintf( '%.8F', $row['shipping_amount'] ?? 0.0 );
+			$rows[]   = $base . ', ' . $date_paid . ', ' . $date_compl . ', ' . $discount . ', ' . $shipping . ')';
 		}
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -623,6 +711,215 @@ class OrderBulkInserter {
 				. implode( ',', $meta_rows )
 			);
 		}
+	}
+
+	/**
+	 * Bulk-insert coupon, shipping, and tax line items produced by the optional
+	 * --coupons / --shipping / --taxes flags.
+	 *
+	 * Nothing is inserted for orders that have no extra items (e.g. when none of
+	 * the flags are active, or when a pool was empty at init time).
+	 *
+	 * @param int[]   $order_ids Ordered list of order IDs.
+	 * @param array[] $data      Batch data aligned with $order_ids.
+	 */
+	private static function insert_extra_order_items( array $order_ids, array $data ): void {
+		global $wpdb;
+
+		// Build the flat list of items to insert.
+		$items = array();
+
+		foreach ( $data as $i => $row ) {
+			if ( isset( $row['coupon_line'] ) ) {
+				$items[] = array(
+					'order_id' => $order_ids[ $i ],
+					'name'     => $row['coupon_line']['code'],
+					'type'     => 'coupon',
+					'meta'     => array(
+						'coupon_id'       => $row['coupon_line']['id'],
+						'discount_amount' => $row['coupon_line']['discount'],
+					),
+				);
+			}
+			if ( isset( $row['shipping_line'] ) ) {
+				$items[] = array(
+					'order_id' => $order_ids[ $i ],
+					'name'     => $row['shipping_line']['title'],
+					'type'     => 'shipping',
+					'meta'     => array(
+						'method_id'   => $row['shipping_line']['method_id'],
+						'instance_id' => $row['shipping_line']['instance_id'],
+						'cost'        => $row['shipping_line']['cost'],
+						'total_tax'   => 0,
+					),
+				);
+			}
+			if ( isset( $row['tax_line'] ) ) {
+				$items[] = array(
+					'order_id' => $order_ids[ $i ],
+					'name'     => $row['tax_line']['tax_rate_name'],
+					'type'     => 'tax',
+					'meta'     => array(
+						'rate_id'             => $row['tax_line']['tax_rate_id'],
+						'label'               => $row['tax_line']['tax_rate_name'],
+						'compound'            => 0,
+						'tax_amount'          => $row['tax_line']['tax_amount'],
+						'shipping_tax_amount' => $row['tax_line']['shipping_tax'],
+					),
+				);
+			}
+		}
+
+		if ( empty( $items ) ) {
+			return;
+		}
+
+		$items_table = $wpdb->prefix . 'woocommerce_order_items';
+		$meta_table  = $wpdb->prefix . 'woocommerce_order_itemmeta';
+
+		$item_rows = array();
+		foreach ( $items as $item ) {
+			$item_rows[] = $wpdb->prepare(
+				'(%s, %s, %d)',
+				$item['name'],
+				$item['type'],
+				$item['order_id']
+			);
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query(
+			"INSERT INTO {$items_table} (order_item_name, order_item_type, order_id) VALUES "
+			. implode( ',', $item_rows )
+		);
+
+		$first_item_id = (int) $wpdb->insert_id;
+		$total_items   = count( $items );
+
+		$item_ids = array_map(
+			'intval',
+			$wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT order_item_id FROM {$items_table}
+					 WHERE order_item_id >= %d
+					 ORDER BY order_item_id ASC LIMIT %d",
+					$first_item_id,
+					$total_items
+				)
+			)
+		);
+
+		$meta_rows = array();
+		foreach ( $items as $idx => $item ) {
+			$item_id = $item_ids[ $idx ] ?? null;
+			if ( null === $item_id ) {
+				continue;
+			}
+			foreach ( $item['meta'] as $key => $val ) {
+				$meta_rows[] = $wpdb->prepare( '(%d, %s, %s)', $item_id, $key, (string) $val );
+			}
+		}
+
+		if ( ! empty( $meta_rows ) ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query(
+				"INSERT INTO {$meta_table} (order_item_id, meta_key, meta_value) VALUES "
+				. implode( ',', $meta_rows )
+			);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Pool fetch helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Fetch all published coupons from the database.
+	 *
+	 * If no coupons exist, seeds 6 (3 fixed_cart, 3 percent) using the Coupon
+	 * generator so there is always something to pick from.
+	 *
+	 * @return object[]
+	 */
+	private static function fetch_coupon_pool(): array {
+		global $wpdb;
+
+		$fetch = static function () use ( $wpdb ): array {
+			return $wpdb->get_results(
+				"SELECT p.ID AS id,
+				        p.post_title AS code,
+				        dt.meta_value AS discount_type,
+				        CAST( ca.meta_value AS DECIMAL(10,2) ) AS coupon_amount
+				 FROM {$wpdb->posts} p
+				 JOIN {$wpdb->postmeta} dt ON dt.post_id = p.ID AND dt.meta_key = 'discount_type'
+				 JOIN {$wpdb->postmeta} ca ON ca.post_id = p.ID AND ca.meta_key = 'coupon_amount'
+				 WHERE p.post_type = 'shop_coupon'
+				   AND p.post_status = 'publish'
+				 LIMIT 200"
+			);
+		};
+
+		$pool = $fetch();
+
+		if ( empty( $pool ) ) {
+			// Seed coupons the same way the ORM path does.
+			Coupon::batch( 6, array() );
+			$pool = $fetch();
+		}
+
+		return $pool ?: array();
+	}
+
+	/**
+	 * Fetch all enabled shipping zone methods, resolving each method's cost and
+	 * display title from its wp_options settings record.
+	 *
+	 * @return array[]
+	 */
+	private static function fetch_shipping_pool(): array {
+		global $wpdb;
+
+		$methods = $wpdb->get_results(
+			"SELECT instance_id, method_id
+			 FROM {$wpdb->prefix}woocommerce_shipping_zone_methods
+			 WHERE is_enabled = 1"
+		);
+
+		if ( empty( $methods ) ) {
+			return array();
+		}
+
+		$pool = array();
+		foreach ( $methods as $method ) {
+			$option_key = "woocommerce_{$method->method_id}_{$method->instance_id}_settings";
+			$settings   = get_option( $option_key, array() );
+			$cost       = isset( $settings['cost'] ) ? (float) $settings['cost'] : 5.0;
+			$title      = isset( $settings['title'] ) && '' !== $settings['title']
+				? $settings['title']
+				: ucwords( str_replace( '_', ' ', $method->method_id ) );
+			$pool[]     = array(
+				'instance_id' => (int) $method->instance_id,
+				'method_id'   => $method->method_id,
+				'cost'        => $cost,
+				'title'       => $title,
+			);
+		}
+
+		return $pool;
+	}
+
+	/**
+	 * Fetch all defined tax rates.
+	 *
+	 * @return object[]
+	 */
+	private static function fetch_tax_rate_pool(): array {
+		global $wpdb;
+
+		return $wpdb->get_results(
+			"SELECT tax_rate_id, tax_rate, tax_rate_name, tax_rate_compound
+			 FROM {$wpdb->prefix}woocommerce_tax_rates"
+		) ?: array();
 	}
 
 	// -------------------------------------------------------------------------

--- a/includes/Router.php
+++ b/includes/Router.php
@@ -10,11 +10,12 @@ class Router {
 	 * @const array Associative array of available generator classes.
 	 */
 	const GENERATORS = array(
-		'coupons'   => Generator\Coupon::class,
-		'customers' => Generator\Customer::class,
-		'orders'    => Generator\Order::class,
-		'products'  => Generator\Product::class,
-		'terms'     => Generator\Term::class,
+		'analytics-sync' => Generator\OrderAnalyticsSync::class,
+		'coupons'        => Generator\Coupon::class,
+		'customers'      => Generator\Customer::class,
+		'orders'         => Generator\Order::class,
+		'products'       => Generator\Product::class,
+		'terms'          => Generator\Term::class,
 	);
 
 	/**

--- a/tests/Unit/Generator/CouponTest.php
+++ b/tests/Unit/Generator/CouponTest.php
@@ -16,6 +16,14 @@ use WP_UnitTestCase;
 class CouponTest extends WP_UnitTestCase {
 
 	/**
+	 * Reset the coupon ID cache before each test so DB roll-backs don't leave stale IDs.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		Coupon::invalidate_cache();
+	}
+
+	/**
 	 * Test generating a coupon.
 	 */
 	public function test_generate_coupon() {

--- a/tests/Unit/Generator/GeneratorTest.php
+++ b/tests/Unit/Generator/GeneratorTest.php
@@ -19,7 +19,7 @@ class GeneratorTest extends WP_UnitTestCase {
 	 * Test MAX_BATCH_SIZE constant.
 	 */
 	public function test_max_batch_size_constant() {
-		$this->assertEquals( 100, Product::MAX_BATCH_SIZE );
+		$this->assertEquals( 1000, Product::MAX_BATCH_SIZE );
 	}
 
 	/**

--- a/tests/Unit/Generator/OrderTest.php
+++ b/tests/Unit/Generator/OrderTest.php
@@ -23,6 +23,10 @@ class OrderTest extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
+		// Invalidate static caches so DB roll-backs between tests don't leave stale IDs.
+		Order::invalidate_caches();
+		\WC\SmoothGenerator\Generator\Coupon::invalidate_cache();
+
 		// Create some products for orders to use.
 		Product::batch( 5, array( 'type' => 'simple' ) );
 	}

--- a/tests/Unit/Generator/ProductTest.php
+++ b/tests/Unit/Generator/ProductTest.php
@@ -155,7 +155,7 @@ class ProductTest extends WP_UnitTestCase {
 	 * Test batch validation with amount too large.
 	 */
 	public function test_batch_validation_amount_too_large() {
-		$result = Product::batch( 150 );
+		$result = Product::batch( 1001 );
 
 		$this->assertWPError( $result );
 		$this->assertEquals( 'smoothgenerator_batch_invalid_amount', $result->get_error_code() );


### PR DESCRIPTION
## Summary

- Adds a **bulk-insert mode** for order generation that writes directly into HPOS tables via raw SQL, bypassing the WC_Order ORM for maximum throughput (1M+ orders in under an hour).
- Adds a **Sync Analytics** section to the Settings UI and a `wp wc sync analytics` CLI command to populate WooCommerce Analytics lookup tables after bulk generation — as a separate step from generation.
- Adds optional **coupons, shipping, and taxes** support to bulk-insert mode, each off by default, picking from existing store data (coupons, shipping zones, tax rates).
- Adds in-memory caching for the ORM-based generation path to reduce per-order overhead.

> **Note:** The bulk-insert options and Sync Analytics section are marked as _experimental_ in the UI.

## What's included

### Bulk-insert mode (`--bulk-insert`)
Writes directly to all six HPOS tables (`wc_orders`, `wc_order_addresses`, `wc_order_operational_data`, `wc_orders_meta`, `woocommerce_order_items`, `woocommerce_order_itemmeta`, plus `wp_posts`) in batches of 500, with no ORM overhead. Skips refunds. Available via the Settings UI checkbox or `wp wc generate orders --bulk-insert`.

### Optional bulk-insert flags
Each is disabled by default and only applies when `--bulk-insert` is active:
- `--coupons` — applies a random existing coupon per order; seeds 6 coupons (3 fixed, 3 percent) if none exist.
- `--shipping` — adds a shipping line item using a random enabled shipping zone method.
- `--taxes` — adds a tax line item using a random defined tax rate; updates `tax_amount` and `total_amount` accordingly.

### Analytics sync
After bulk-inserting orders, run `wp wc sync analytics` (or click the button in the UI) to populate `wc_order_stats`, `wc_order_product_lookup`, `wc_order_coupon_lookup`, `wc_order_tax_lookup`, and `wc_customer_lookup` via direct `INSERT … SELECT` SQL (no per-order `WC_Order` loading). Clears the Analytics cache on completion.

## Test plan

### Prerequisites
- WooCommerce with HPOS enabled (WooCommerce > Settings > Advanced > Features).
- At least one published product with a price > 0.

### 1. ORM path — no regression
- [ ] Generate a small batch via `wp wc generate orders 10` and confirm orders appear correctly in WooCommerce > Orders.

### 2. Bulk-insert — basic
- [ ] Run `wp wc generate orders 100 --bulk-insert` and confirm 100 orders appear in WooCommerce > Orders with realistic statuses, dates, and line items.
- [ ] Confirm the Settings UI "Use bulk insert" checkbox generates orders when submitted.

### 3. Bulk-insert — coupons
- [ ] With at least one published coupon in the store, run `wp wc generate orders 10 --bulk-insert --coupons`. Open an order and confirm a coupon line item is present with a non-zero discount amount.
- [ ] Run the same command on a store with **no** coupons and confirm it seeds 6 coupons automatically before generating.

### 4. Bulk-insert — shipping
- [ ] Define at least one enabled shipping zone and method (WooCommerce > Settings > Shipping).
- [ ] Run `wp wc generate orders 10 --bulk-insert --shipping`. Open an order and confirm a shipping line item is present with the correct method name and cost.
- [ ] Run on a store with **no** enabled shipping methods and confirm orders generate without error (shipping simply omitted).

### 5. Bulk-insert — taxes
- [ ] Define at least one tax rate (WooCommerce > Settings > Tax).
- [ ] Run `wp wc generate orders 10 --bulk-insert --taxes`. Open an order and confirm a tax line item is present and the order total reflects the tax.
- [ ] Run on a store with **no** tax rates and confirm orders generate without error (tax simply omitted).

### 6. Bulk-insert — all three combined
- [ ] Run `wp wc generate orders 50 --bulk-insert --coupons --shipping --taxes` and verify all three line item types appear on orders, and the order total = subtotal − discount + shipping + tax.

### 7. Analytics sync — unsynced orders
- [ ] After bulk-inserting orders, confirm the Settings UI shows a non-zero unsynced count.
- [ ] Click "Sync unsynced orders" and wait for completion.
- [ ] Confirm the unsynced count drops to zero and WooCommerce Analytics > Orders reflects the new orders.

### 8. Analytics sync — re-sync all
- [ ] Check "Re-sync all N orders" and click "Re-sync all orders". Confirm it completes and Analytics data is up to date.
- [ ] Run `wp wc sync analytics --all` and confirm the same via CLI.

### 9. Coupon/tax lookup table accuracy (after sync)
- [ ] After syncing a bulk-insert run with `--coupons`, confirm rows exist in `wp_wc_order_coupon_lookup`.
- [ ] After syncing a bulk-insert run with `--taxes`, confirm rows exist in `wp_wc_order_tax_lookup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)