### PR TITLE
Show error message when trying to generate orders without products

### DIFF
--- a/includes/Admin/BatchProcessor.php
+++ b/includes/Admin/BatchProcessor.php
@@ -202,7 +202,7 @@ class BatchProcessor implements BatchProcessorInterface {
 
 		if ( $amount > 0 && count( $result ) === 0 ) {
 			throw new \Exception(
-				sprintf( 'Batch of %d item(s) could not be generated. Check error logs for details.', $amount )
+				sprintf( 'Batch of %d item(s) could not be generated. Check error logs for details.', absint( $amount ) )
 			);
 		}
 

--- a/includes/Admin/BatchProcessor.php
+++ b/includes/Admin/BatchProcessor.php
@@ -200,6 +200,12 @@ class BatchProcessor implements BatchProcessorInterface {
 			throw new \Exception( $result->get_error_message() );
 		}
 
+		if ( $amount > 0 && count( $result ) === 0 ) {
+			throw new \Exception(
+				sprintf( 'Batch of %d item(s) could not be generated. Check error logs for details.', $amount )
+			);
+		}
+
 		self::update_current_job( count( $result ) );
 	}
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -48,6 +48,14 @@ class Settings {
 		$generate_button_atts = $current_job instanceof AsyncJob ? array( 'disabled' => true ) : array();
 		$cancel_button_atts   = ! $current_job instanceof AsyncJob ? array( 'disabled' => true ) : array();
 
+		$has_products               = (bool) wc_get_products( array( 'limit' => 1, 'return' => 'ids', 'status' => 'publish' ) );
+		$orders_button_atts         = $generate_button_atts;
+		$orders_disabled_by_missing = false;
+		if ( ! $has_products ) {
+			$orders_button_atts['disabled'] = true;
+			$orders_disabled_by_missing     = true;
+		}
+
 		?>
 		<h1>WooCommerce Smooth Generator</h1>
 		<p class="description">
@@ -113,6 +121,11 @@ class Settings {
 			</p>
 
 			<h2>Generate orders</h2>
+			<?php if ( $orders_disabled_by_missing ) : ?>
+				<p class="description" style="color: #d63638;">
+					<?php esc_html_e( 'No published products found. Please generate products before generating orders.', 'wc-smooth-generator' ); ?>
+				</p>
+			<?php endif; ?>
 			<p>
 				<label for="generate_orders_input" class="screen-reader-text">Number of orders to generate</label>
 				<input
@@ -121,7 +134,8 @@ class Settings {
 					name="num_orders_to_generate"
 					value="<?php echo esc_attr( self::DEFAULT_NUM_ORDERS ); ?>"
 					min="1"
-					<?php disabled( $current_job instanceof AsyncJob ); ?>
+					<?php disabled( $current_job instanceof AsyncJob || $orders_disabled_by_missing ); ?>
+
 				/>
 				<?php
 				submit_button(
@@ -129,7 +143,7 @@ class Settings {
 					'primary',
 					'generate_orders',
 					false,
-					$generate_button_atts
+					$orders_button_atts
 				);
 				?>
 			</p>

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -48,7 +48,13 @@ class Settings {
 		$generate_button_atts = $current_job instanceof AsyncJob ? array( 'disabled' => true ) : array();
 		$cancel_button_atts   = ! $current_job instanceof AsyncJob ? array( 'disabled' => true ) : array();
 
-		$has_products               = (bool) wc_get_products( array( 'limit' => 1, 'return' => 'ids', 'status' => 'publish' ) );
+		$has_products               = (bool) wc_get_products(
+			array(
+				'limit'  => 1,
+				'return' => 'ids',
+				'status' => 'publish',
+			)
+		);
 		$orders_button_atts         = $generate_button_atts;
 		$orders_disabled_by_missing = false;
 		if ( ! $has_products ) {

--- a/includes/Generator/Order.php
+++ b/includes/Generator/Order.php
@@ -278,6 +278,18 @@ class Order extends Generator {
 			return $amount;
 		}
 
+		$existing_products = wc_get_products( array(
+			'limit'  => 1,
+			'return' => 'ids',
+			'status' => 'publish',
+		) );
+		if ( empty( $existing_products ) ) {
+			return new \WP_Error(
+				'smoothgenerator_no_products',
+				'Order generation requires at least one published product. Please generate products first.'
+			);
+		}
+
 		// Initialize dynamic counters for exact ratio distribution (O(1) memory)
 		// Using "selection without replacement" algorithm for exact counts
 		$coupons_remaining = 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fix order generation getting stuck (infinite async loop / silent CLI hang) when no published products exist in the store.

Root cause: 
Order::batch() returned an empty array when all individual generate() calls failed due to no products. BatchProcessor::process_batch() then called update_current_job(0), so pending never decreased and the BatchProcessingController kept re-queuing the processor indefinitely.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Set up a WooCommerce store with no published products.
2. Navigate to Tools → Smooth Generator — verify the "Generate orders" input and button are disabled and the notice is shown. The "Generate products" section should remain fully functional.
3. Generate some products, then reload the page — verify the "Generate orders" section is now enabled.
4. Delete all products again. Via WP-CLI run wp smooth-generator orders 5 — verify it exits immediately with the error "Order generation requires at least one published product." instead of hanging.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix order generation issues when no products were available

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
