### PR TITLE
Add coupons customers generation to Settings page

### DIFF
--- a/includes/Admin/BatchProcessor.php
+++ b/includes/Admin/BatchProcessor.php
@@ -200,12 +200,6 @@ class BatchProcessor implements BatchProcessorInterface {
 			throw new \Exception( $result->get_error_message() );
 		}
 
-		if ( $amount > 0 && count( $result ) === 0 ) {
-			throw new \Exception(
-				sprintf( 'Batch of %d item(s) could not be generated. Check error logs for details.', $amount )
-			);
-		}
-
 		self::update_current_job( count( $result ) );
 	}
 

--- a/includes/Admin/BatchProcessor.php
+++ b/includes/Admin/BatchProcessor.php
@@ -200,6 +200,12 @@ class BatchProcessor implements BatchProcessorInterface {
 			throw new \Exception( $result->get_error_message() );
 		}
 
+		if ( $amount > 0 && count( $result ) === 0 ) {
+			throw new \Exception(
+				sprintf( 'Batch of %d item(s) could not be generated. Check error logs for details.', $amount )
+			);
+		}
+
 		self::update_current_job( count( $result ) );
 	}
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -12,11 +12,11 @@ namespace WC\SmoothGenerator\Admin;
  */
 class Settings {
 
-	const DEFAULT_NUM_PRODUCTS   = 10;
-	const DEFAULT_NUM_ORDERS     = 10;
-	const DEFAULT_NUM_BOOKINGS   = 10;
-	const DEFAULT_NUM_CUSTOMERS  = 10;
-	const DEFAULT_NUM_COUPONS    = 10;
+	const DEFAULT_NUM_PRODUCTS  = 10;
+	const DEFAULT_NUM_ORDERS    = 10;
+	const DEFAULT_NUM_BOOKINGS  = 10;
+	const DEFAULT_NUM_CUSTOMERS = 10;
+	const DEFAULT_NUM_COUPONS   = 10;
 
 	/**
 	 *  Set up hooks.

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -12,9 +12,11 @@ namespace WC\SmoothGenerator\Admin;
  */
 class Settings {
 
-	const DEFAULT_NUM_PRODUCTS = 10;
-	const DEFAULT_NUM_ORDERS   = 10;
-	const DEFAULT_NUM_BOOKINGS = 10;
+	const DEFAULT_NUM_PRODUCTS   = 10;
+	const DEFAULT_NUM_ORDERS     = 10;
+	const DEFAULT_NUM_BOOKINGS   = 10;
+	const DEFAULT_NUM_CUSTOMERS  = 10;
+	const DEFAULT_NUM_COUPONS    = 10;
 
 	/**
 	 *  Set up hooks.
@@ -161,6 +163,50 @@ class Settings {
 				WooCommerce Bookings extension is not active. Install and activate it to generate bookings.
 			</p>
 			<?php endif; ?>
+
+			<h2>Generate customers</h2>
+			<p>
+				<label for="generate_customers_input" class="screen-reader-text">Number of customers to generate</label>
+				<input
+					id="generate_customers_input"
+					type="number"
+					name="num_customers_to_generate"
+					value="<?php echo esc_attr( self::DEFAULT_NUM_CUSTOMERS ); ?>"
+					min="1"
+					<?php disabled( $current_job instanceof AsyncJob ); ?>
+				/>
+				<?php
+				submit_button(
+					'Generate',
+					'primary',
+					'generate_customers',
+					false,
+					$generate_button_atts
+				);
+				?>
+			</p>
+
+			<h2>Generate coupons</h2>
+			<p>
+				<label for="generate_coupons_input" class="screen-reader-text">Number of coupons to generate</label>
+				<input
+					id="generate_coupons_input"
+					type="number"
+					name="num_coupons_to_generate"
+					value="<?php echo esc_attr( self::DEFAULT_NUM_COUPONS ); ?>"
+					min="1"
+					<?php disabled( $current_job instanceof AsyncJob ); ?>
+				/>
+				<?php
+				submit_button(
+					'Generate',
+					'primary',
+					'generate_coupons',
+					false,
+					$generate_button_atts
+				);
+				?>
+			</p>
 
 			<h2>Advanced Options</h2>
 			<p>
@@ -331,6 +377,14 @@ class Settings {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			$num_to_generate = absint( $_POST['num_bookings_to_generate'] );
 			BatchProcessor::create_new_job( 'bookings', $num_to_generate, $args );
+		} elseif ( ! empty( $_POST['generate_customers'] ) && ! empty( $_POST['num_customers_to_generate'] ) ) {
+			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
+			$num_to_generate = absint( $_POST['num_customers_to_generate'] );
+			BatchProcessor::create_new_job( 'customers', $num_to_generate );
+		} elseif ( ! empty( $_POST['generate_coupons'] ) && ! empty( $_POST['num_coupons_to_generate'] ) ) {
+			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
+			$num_to_generate = absint( $_POST['num_coupons_to_generate'] );
+			BatchProcessor::create_new_job( 'coupons', $num_to_generate );
 		} else if ( ! empty( $_POST['cancel_job'] ) ) {
 			check_admin_referer( 'generate', 'smoothgenerator_nonce' );
 			BatchProcessor::delete_current_job();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

---

### Changes proposed in this Pull Request:

Customers and coupons can currently only be generated via WP-CLI (`wc generate customers` / `wc generate coupons`). This PR exposes both generators in the admin UI, on par with products and orders.

Changes are limited to `includes/Admin/Settings.php`:
- Added `DEFAULT_NUM_CUSTOMERS` and `DEFAULT_NUM_COUPONS` constants (default: 10)
- Added "Generate customers" and "Generate coupons" form sections to the settings page
- Added the corresponding `process_page_submit()` branches that call `BatchProcessor::create_new_job()`

No other files required changes — Router.php and BatchProcessor.php already supported both slugs. The date-range Advanced Options are intentionally not passed to customers/coupons, as neither generator uses them.

Closes # .

---

### How to test the changes in this Pull Request:

1. Navigate to **Tools → Smooth Generator** in wp-admin.
2. Verify "Generate customers" and "Generate coupons" sections appear with a number input and a Generate button each.
3. Enter a number, click **Generate**, and confirm the progress bar runs and the correct number of customers/coupons is created in WooCommerce.

---

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

---

### Changelog entry

> Expose customer and coupon generation in the admin UI. Both generators were previously available via WP-CLI only; they can now be triggered directly from the Smooth Generator settings page.

---

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.