### PR TITLE
fix(products): honor --sku flag when generating products

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -343,8 +343,14 @@ WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'p
 			'description' => 'Only apply existing categories and tags to products, rather than generating new ones.',
 			'optional'    => true,
 		),
+		array(
+			'name'        => 'sku',
+			'type'        => 'assoc',
+			'description' => 'Base SKU for generated products. A counter is appended in batch mode to keep SKUs unique.',
+			'optional'    => true,
+		),
 	),
-	'longdesc'  => "## EXAMPLES\n\nwc generate products 10\n\nwc generate products 20 --type=variable --use-existing-terms\n\nwc generate products 5 --type=booking\n\nwc generate products 5 --type=bookable-service\n\nwc generate products 5 --type=bookable-event",
+	'longdesc'  => "## EXAMPLES\n\nwc generate products 10\n\nwc generate products 20 --type=variable --use-existing-terms\n\nwc generate products 5 --type=booking\n\nwc generate products 5 --type=bookable-service\n\nwc generate products 5 --type=bookable-event\n\nwc generate products 5 --sku=PROD",
 ) );
 
 WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'orders' ), array(

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -67,6 +67,20 @@ class Product extends Generator {
 	);
 
 	/**
+	 * Counter used to append a suffix to a custom SKU so each generated product stays unique.
+	 *
+	 * @var int
+	 */
+	protected static $custom_sku_counter = 0;
+
+	/**
+	 * Base SKU passed via CLI, used when a custom SKU is requested.
+	 *
+	 * @var string|null
+	 */
+	protected static $custom_sku_base = null;
+
+	/**
 	 * Return a new product.
 	 *
 	 * @param bool  $save Save the object before returning or not.
@@ -75,6 +89,8 @@ class Product extends Generator {
 	 */
 	public static function generate( $save = true, $assoc_args = array() ) {
 		parent::maybe_initialize_generators();
+
+		self::$custom_sku_base = ! empty( $assoc_args['sku'] ) ? sanitize_text_field( $assoc_args['sku'] ) : null;
 
 		$type = self::get_product_type( $assoc_args );
 		switch ( $type ) {
@@ -149,6 +165,8 @@ class Product extends Generator {
 		if ( is_wp_error( $amount ) ) {
 			return $amount;
 		}
+
+		self::$custom_sku_counter = 0;
 
 		$use_existing_terms = ! empty( $args['use-existing-terms'] );
 		if ( ! $use_existing_terms ) {
@@ -348,6 +366,24 @@ class Product extends Generator {
 	}
 
 	/**
+	 * Get the SKU to assign to a generated product.
+	 *
+	 * When a custom base SKU is set via CLI, a counter suffix is appended so each
+	 * product in a batch gets a unique SKU. Otherwise a random SKU is returned.
+	 *
+	 * @param string $name Product name, used to build the random SKU fallback.
+	 * @return string
+	 */
+	protected static function get_custom_sku( $name ) {
+		if ( null === self::$custom_sku_base ) {
+			return sanitize_title( $name ) . '-' . self::$faker->ean8;
+		}
+
+		++self::$custom_sku_counter;
+		return self::$custom_sku_base . '-' . self::$custom_sku_counter;
+	}
+
+	/**
 	 * Generate a variable product and return it.
 	 *
 	 * @return \WC_Product_Variable|\WP_Error Product object or WP_Error on failure.
@@ -368,7 +404,7 @@ class Product extends Generator {
 		$product->set_props( array(
 			'name'              => $name,
 			'featured'          => self::$faker->boolean( 10 ),
-			'sku'               => sanitize_title( $name ) . '-' . self::$faker->ean8,
+			'sku'               => self::get_custom_sku( $name ),
 			'global_unique_id'  => self::$faker->randomElement( array( self::$faker->ean13, self::$faker->isbn10 ) ),
 			'attributes'        => $attributes,
 			'tax_status'        => self::$faker->randomElement( array( 'taxable', 'shipping', 'none' ) ),
@@ -406,6 +442,7 @@ class Product extends Generator {
 			$variation->set_props( array(
 				'parent_id'         => $product->get_id(),
 				'attributes'        => $possible_attribute,
+				'sku'               => self::get_custom_sku( $name ),
 				'regular_price'     => $price,
 				'sale_price'        => $sale_price,
 				'date_on_sale_from' => $date_on_sale_from,
@@ -463,7 +500,7 @@ class Product extends Generator {
 			'catalog_visibility' => 'visible',
 			'description'        => self::$faker->paragraphs( self::$faker->numberBetween( 1, 5 ), true ),
 			'short_description'  => self::$faker->text(),
-			'sku'                => sanitize_title( $name ) . '-' . self::$faker->ean8,
+			'sku'                => self::get_custom_sku( $name ),
 			'global_unique_id'   => self::$faker->randomElement( array( self::$faker->ean13, self::$faker->isbn10 ) ),
 			'regular_price'      => $price,
 			'sale_price'         => $sale_price,
@@ -608,7 +645,7 @@ class Product extends Generator {
 			'catalog_visibility' => 'visible',
 			'description'        => self::$faker->paragraphs( self::$faker->numberBetween( 1, 3 ), true ),
 			'short_description'  => self::$faker->sentence(),
-			'sku'                => sanitize_title( $name ) . '-' . self::$faker->ean8,
+			'sku'                => self::get_custom_sku( $name ),
 			'regular_price'      => $cost,
 			'image_id'           => $image_id,
 			'category_ids'       => self::get_term_ids( 'product_cat', self::$faker->numberBetween( 0, 2 ) ),
@@ -683,7 +720,7 @@ class Product extends Generator {
 			'catalog_visibility' => 'visible',
 			'description'        => self::$faker->paragraphs( self::$faker->numberBetween( 1, 2 ), true ),
 			'short_description'  => self::$faker->sentence(),
-			'sku'                => sanitize_title( $name ) . '-' . self::$faker->ean8,
+			'sku'                => self::get_custom_sku( $name ),
 			'regular_price'      => $cost,
 			'image_id'           => $image_id,
 			'category_ids'       => self::get_term_ids( 'product_cat', self::$faker->numberBetween( 0, 2 ) ),
@@ -738,7 +775,7 @@ class Product extends Generator {
 			'catalog_visibility' => 'visible',
 			'description'        => self::$faker->paragraphs( self::$faker->numberBetween( 1, 3 ), true ),
 			'short_description'  => self::$faker->sentence(),
-			'sku'                => sanitize_title( $name ) . '-' . self::$faker->ean8,
+			'sku'                => self::get_custom_sku( $name ),
 			'regular_price'      => $cost,
 			'image_id'           => $image_id,
 			'category_ids'       => self::get_term_ids( 'product_cat', self::$faker->numberBetween( 0, 2 ) ),

--- a/tests/Unit/Generator/ProductTest.php
+++ b/tests/Unit/Generator/ProductTest.php
@@ -30,6 +30,47 @@ class ProductTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test generating a product with a custom SKU.
+	 */
+	public function test_generate_simple_product_with_custom_sku() {
+		$product = Product::generate(
+			true,
+			array(
+				'type' => 'simple',
+				'sku'  => 'CUSTOM-SKU',
+			)
+		);
+
+		$this->assertInstanceOf( \WC_Product::class, $product );
+		$this->assertEquals( 'CUSTOM-SKU-1', $product->get_sku() );
+	}
+
+	/**
+	 * Test that batch generation with a custom SKU produces unique SKUs.
+	 */
+	public function test_batch_with_custom_sku() {
+		$product_ids = Product::batch(
+			5,
+			array(
+				'type' => 'simple',
+				'sku'  => 'BATCH-SKU',
+			)
+		);
+
+		$this->assertIsArray( $product_ids );
+		$this->assertCount( 5, $product_ids );
+
+		$skus = array();
+		foreach ( $product_ids as $product_id ) {
+			$skus[] = wc_get_product( $product_id )->get_sku();
+		}
+
+		$this->assertContains( 'BATCH-SKU-1', $skus );
+		$this->assertContains( 'BATCH-SKU-5', $skus );
+		$this->assertEquals( $skus, array_unique( $skus ), 'Custom SKUs should be unique within a batch' );
+	}
+
+	/**
 	 * Test generating a variable product.
 	 */
 	public function test_generate_variable_product() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `--sku` flag passed to `wp wc generate products` was silently ignored and random SKUs were generated instead. The flag was never registered in the WP-CLI synopsis, and the SKU was hardcoded to a random value in every product type.

This change registers `--sku` in the command synopsis and routes it through a `get_custom_sku()` helper. A single product gets the exact SKU (e.g. `TEST-SKU-1`); in batch mode a counter is appended so each product stays unique (e.g. `BATCH-1`, `BATCH-2`, ...). All five product types (simple, variable + variations, booking, bookable-service, bookable-event) now respect the flag.

Closes #3.

### How to test the changes in this Pull Request:

1. Run `wp wc generate products 1 --sku=TEST-SKU`.
2. Run `wp wc generate products 5 --sku=BATCH`.
3. Check the generated products' SKUs (Products > All Products, or via `wp wc product get <id> --field=sku`).

Expected: the single product has SKU `TEST-SKU-1`; the batch has `BATCH-1` through `BATCH-5`. Without the flag, behavior is unchanged (random SKUs).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Add `--sku` support to `wp wc generate products` so a custom base SKU can be set; a counter is appended in batch mode to keep SKUs unique.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
