### PR TITLE
fix(customer): add first and last name for company customers

### DIFF
--- a/includes/Generator/Customer.php
+++ b/includes/Generator/Customer.php
@@ -67,9 +67,15 @@ class Customer extends Generator {
 				break;
 
 			case 'company':
-				$customer_data       = array_merge( $customer_data, CustomerInfo::generate_company( $country ) );
-				$other_customer_data = CustomerInfo::generate_company( $country );
-				$keys_for_address[]  = 'company';
+				$company_data                = CustomerInfo::generate_company( $country );
+				$contact                     = CustomerInfo::generate_person( $country );
+				$customer_data               = array_merge( $customer_data, $company_data );
+				$customer_data['first_name'] = $contact['first_name'];
+				$customer_data['last_name']  = $contact['last_name'];
+				$other_customer_data         = $contact;
+				$keys_for_address[]          = 'first_name';
+				$keys_for_address[]          = 'last_name';
+				$keys_for_address[]          = 'company';
 				break;
 		}
 
@@ -144,7 +150,7 @@ class Customer extends Generator {
 		$customer_ids = array();
 
 		for ( $i = 1; $i <= $amount; $i++ ) {
-			$customer       = self::generate( true, $args );
+			$customer = self::generate( true, $args );
 			if ( is_wp_error( $customer ) ) {
 				return $customer;
 			}

--- a/tests/Unit/Generator/CustomerTest.php
+++ b/tests/Unit/Generator/CustomerTest.php
@@ -77,6 +77,8 @@ class CustomerTest extends WP_UnitTestCase {
 		$customer = Customer::generate( true, array( 'type' => 'company' ) );
 
 		$this->assertNotEmpty( $customer->get_billing_company() );
+		$this->assertNotEmpty( $customer->get_billing_first_name() );
+		$this->assertNotEmpty( $customer->get_billing_last_name() );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #162

Company-type customers were generated without a first name or last name, so saving them through WooCommerce's customer data store failed with `WC_Data_Exception: First name is a required field.` Order generation creates customers as part of building an order, so `wp wc generate orders` crashed for affected users.

The fix generates a contact person name for company customers and includes it in both billing and shipping data, so the customer saves correctly. Person-type customers were already correct.

### How to test the changes in this Pull Request:

1. With WooCommerce and Smooth Generator active on a default theme, run `wp wc generate orders 10`.
2. Run `wp wc generate customers 10 --type=company`.
3. Open one generated company customer and confirm the first and last name fields are populated.

Expected: orders and company customers generate without errors, and company customers have a contact name.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Fix fatal error when generating orders caused by company customers missing a first and last name.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.