### PR TITLE
feat(products): add image generation modes

### DIFF
--- a/includes/CLI.php
+++ b/includes/CLI.php
@@ -36,7 +36,8 @@ class CLI extends WP_CLI_Command {
 		WP_CLI::line( 'Initializing...' );
 
 		// Pre-generate images. Min 20, max 100.
-		Generator\Product::seed_images( min( $amount + 19, 100 ) );
+		$image_mode = $assoc_args['images'] ?? 'existing';
+		Generator\Product::seed_images( min( $amount + 19, 100 ), $image_mode );
 
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating products', $amount );
 
@@ -318,6 +319,37 @@ class CLI extends WP_CLI_Command {
 
 		WP_CLI::success( $generated . ' terms generated in ' . $display_time );
 	}
+
+	/**
+	 * Generate product images.
+	 *
+	 * @param array $args Arguments specified.
+	 * @param array $assoc_args Associative arguments specified.
+	 */
+	public static function images( $args, $assoc_args ) {
+		list( $amount ) = $args;
+		$amount = absint( $amount );
+
+		$mode = $assoc_args['type'] ?? 'abstract';
+
+		$time_start = microtime( true );
+
+		WP_CLI::line( "Generating {$amount} {$mode} images..." );
+
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Generating images', $amount );
+
+		Generator\Product::seed_images( $amount, $mode );
+
+		$progress->finish();
+
+		$count = Generator\Product::get_image_count();
+
+		$time_end       = microtime( true );
+		$execution_time = round( ( $time_end - $time_start ), 2 );
+		$display_time   = $execution_time < 60 ? $execution_time . ' seconds' : human_time_diff( $time_start, $time_end );
+
+		WP_CLI::success( $count . ' images generated in ' . $display_time );
+	}
 }
 
 WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'products' ), array(
@@ -343,8 +375,16 @@ WP_CLI::add_command( 'wc generate products', array( 'WC\SmoothGenerator\CLI', 'p
 			'description' => 'Only apply existing categories and tags to products, rather than generating new ones.',
 			'optional'    => true,
 		),
+		array(
+			'name'        => 'images',
+			'type'        => 'assoc',
+			'description' => 'Image generation mode. "abstract" generates Jdenticon images. "realistic" downloads from Lorem Picsum. "existing" uses media library images. "none" skips images.',
+			'optional'    => true,
+			'options'     => array( 'abstract', 'realistic', 'existing', 'none' ),
+			'default'     => 'existing',
+		),
 	),
-	'longdesc'  => "## EXAMPLES\n\nwc generate products 10\n\nwc generate products 20 --type=variable --use-existing-terms\n\nwc generate products 5 --type=booking\n\nwc generate products 5 --type=bookable-service\n\nwc generate products 5 --type=bookable-event",
+	'longdesc'  => "## EXAMPLES\n\nwc generate products 10\n\nwc generate products 20 --type=variable --use-existing-terms\n\nwc generate products 5 --type=booking\n\nwc generate products 5 --type=bookable-service\n\nwc generate products 5 --type=bookable-event\n\nwc generate products 10 --images=none",
 ) );
 
 WP_CLI::add_command( 'wc generate orders', array( 'WC\SmoothGenerator\CLI', 'orders' ), array(
@@ -551,4 +591,26 @@ WP_CLI::add_command( 'wc generate terms', array( 'WC\SmoothGenerator\CLI', 'term
 		),
 	),
 	'longdesc' => "## EXAMPLES\n\nwc generate terms product_tag 10\n\nwc generate terms product_cat 50 --max-depth=3",
+) );
+
+WP_CLI::add_command( 'wc generate images', array( 'WC\SmoothGenerator\CLI', 'images' ), array(
+	'shortdesc' => 'Generate product images.',
+	'synopsis'  => array(
+		array(
+			'name'        => 'amount',
+			'type'        => 'positional',
+			'description' => 'The number of images to generate.',
+			'optional'    => true,
+			'default'     => 10,
+		),
+		array(
+			'name'        => 'type',
+			'type'        => 'assoc',
+			'description' => 'Image type. "abstract" generates Jdenticon images. "realistic" downloads from Lorem Picsum. "existing" uses media library images.',
+			'optional'    => true,
+			'options'     => array( 'abstract', 'realistic', 'existing' ),
+			'default'     => 'abstract',
+		),
+	),
+	'longdesc'  => "## EXAMPLES\n\nwc generate images 20\n\nwc generate images 50 --type=realistic\n\nwc generate images 100 --type=existing",
 ) );

--- a/includes/Generator/Generator.php
+++ b/includes/Generator/Generator.php
@@ -52,6 +52,13 @@ abstract class Generator {
 	protected static $images = array();
 
 	/**
+	 * Current image generation mode.
+	 *
+	 * @var string Image mode: abstract, realistic, existing, or none.
+	 */
+	protected static $image_mode = 'existing';
+
+	/**
 	 * Return a new object of this object type.
 	 *
 	 * @param bool $save Save the object before returning or not.
@@ -251,8 +258,49 @@ abstract class Generator {
 	 * Create/retrieve a set of random images to assign to products.
 	 *
 	 * @param integer $amount Number of images required.
+	 * @param string  $mode   Image generation mode: abstract, realistic, existing, or none.
 	 */
-	public static function seed_images( $amount = 10 ) {
+	public static function seed_images( $amount = 10, $mode = 'existing' ) {
+		self::$image_mode = $mode;
+
+		switch ( $mode ) {
+			case 'none':
+				self::$images = array();
+				break;
+			case 'abstract':
+				self::seed_images_abstract( $amount );
+				break;
+			case 'realistic':
+				self::seed_images_realistic( $amount );
+				break;
+			case 'existing':
+			default:
+				self::seed_images_existing( $amount );
+				break;
+		}
+	}
+
+	/**
+	 * Generate abstract Jdenticon images.
+	 *
+	 * @param int $amount Number of images to generate.
+	 */
+	protected static function seed_images_abstract( $amount ) {
+		self::$images = array();
+		for ( $i = 0; $i < $amount; $i++ ) {
+			$id = self::generate_image();
+			if ( $id ) {
+				self::$images[] = $id;
+			}
+		}
+	}
+
+	/**
+	 * Query existing media library images, fill gaps with generated images.
+	 *
+	 * @param int $amount Number of images required.
+	 */
+	protected static function seed_images_existing( $amount ) {
 		self::$images = get_posts(
 			array(
 				'post_type'      => 'attachment',
@@ -266,20 +314,91 @@ abstract class Generator {
 		$found_count = count( self::$images );
 
 		for ( $i = 1; $i <= ( $amount - $found_count ); $i++ ) {
-			self::$images[] = self::generate_image();
+			$id = self::generate_image();
+			if ( $id ) {
+				self::$images[] = $id;
+			}
 		}
+	}
+
+	/**
+	 * Download realistic placeholder images from Lorem Picsum.
+	 *
+	 * @param int $amount Number of images to download.
+	 */
+	protected static function seed_images_realistic( $amount ) {
+		self::init_faker();
+		self::$images = array();
+
+		$amount = min( $amount, 100 );
+
+		for ( $i = 0; $i < $amount; $i++ ) {
+			$seed = self::$faker->word();
+			$url  = 'https://picsum.photos/seed/' . rawurlencode( $seed ) . '/' . self::IMAGE_SIZE . '/' . self::IMAGE_SIZE . '.jpg';
+
+			$id = self::sideload_image( $url, $seed );
+			if ( $id ) {
+				self::$images[] = $id;
+			}
+		}
+	}
+
+	/**
+	 * Download an image from a URL and add to media library.
+	 *
+	 * @param string $url      Image URL.
+	 * @param string $filename Filename without extension.
+	 * @return int Attachment ID on success, 0 on failure.
+	 */
+	protected static function sideload_image( $url, $filename ) {
+		if ( ! function_exists( 'media_handle_sideload' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/media.php';
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+		}
+
+		$temp_file = download_url( $url );
+
+		if ( is_wp_error( $temp_file ) ) {
+			return 0;
+		}
+
+		$file_array = array(
+			'name'     => sanitize_title( $filename ) . '.jpg',
+			'tmp_name' => $temp_file,
+		);
+
+		$attachment_id = media_handle_sideload( $file_array, 0 );
+
+		if ( is_wp_error( $attachment_id ) ) {
+			if ( file_exists( $temp_file ) ) {
+				wp_delete_file( $temp_file );
+			}
+			return 0;
+		}
+
+		return $attachment_id;
 	}
 
 	/**
 	 * Get an image at random from our seeded data.
 	 *
-	 * @return int
+	 * @return int Attachment ID, or 0 if no images available.
 	 */
 	protected static function get_image() {
-		if ( ! self::$images ) {
-			self::seed_images();
+		if ( empty( self::$images ) ) {
+			return 0;
 		}
 		return self::$images[ array_rand( self::$images ) ];
+	}
+
+	/**
+	 * Get count of seeded images.
+	 *
+	 * @return int Number of images in the pool.
+	 */
+	public static function get_image_count() {
+		return count( self::$images );
 	}
 
 	/**

--- a/includes/Generator/Product.php
+++ b/includes/Generator/Product.php
@@ -927,7 +927,10 @@ class Product extends Generator {
 		$image_count = wp_rand( 0, 3 );
 
 		for ( $i = 0; $i < $image_count; $i++ ) {
-			$gallery[] = self::get_image();
+			$image_id = self::get_image();
+			if ( $image_id ) {
+				$gallery[] = $image_id;
+			}
 		}
 
 		return $gallery;

--- a/tests/Unit/Generator/ImageModeTest.php
+++ b/tests/Unit/Generator/ImageModeTest.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Tests for image mode functionality.
+ *
+ * @package WC\SmoothGenerator\Tests\Generator
+ */
+
+namespace WC\SmoothGenerator\Tests\Generator;
+
+use ReflectionClass;
+use WC\SmoothGenerator\Generator\Product;
+use WP_UnitTestCase;
+
+/**
+ * Image mode test case.
+ */
+class ImageModeTest extends WP_UnitTestCase {
+
+	/**
+	 * Reset image state before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->reset_images();
+	}
+
+	/**
+	 * Clean up image state after each test.
+	 */
+	public function tear_down() {
+		$this->reset_images();
+		parent::tear_down();
+	}
+
+	/**
+	 * Reset the static images array.
+	 */
+	protected function reset_images() {
+		$reflection = new ReflectionClass( Product::class );
+		$property   = $reflection->getProperty( 'images' );
+		$property->setAccessible( true );
+		$property->setValue( null, array() );
+	}
+
+	/**
+	 * Get the static images array for assertions.
+	 *
+	 * @return array
+	 */
+	protected function get_images() {
+		$reflection = new ReflectionClass( Product::class );
+		$property   = $reflection->getProperty( 'images' );
+		$property->setAccessible( true );
+		return $property->getValue();
+	}
+
+	/**
+	 * Call protected get_image() method.
+	 *
+	 * @return int
+	 */
+	protected function call_get_image() {
+		$reflection = new ReflectionClass( Product::class );
+		$method     = $reflection->getMethod( 'get_image' );
+		$method->setAccessible( true );
+		return $method->invoke( null );
+	}
+
+	/**
+	 * Test seed_images with none mode returns empty array.
+	 */
+	public function test_seed_images_none_returns_empty() {
+		Product::seed_images( 10, 'none' );
+		$this->assertEmpty( $this->get_images() );
+	}
+
+	/**
+	 * Test get_image returns 0 when no images available.
+	 */
+	public function test_get_image_returns_zero_when_empty() {
+		$this->reset_images();
+		$this->assertEquals( 0, $this->call_get_image() );
+	}
+
+	/**
+	 * Test seed_images with abstract mode generates Jdenticon images.
+	 */
+	public function test_seed_images_abstract_generates_images() {
+		Product::seed_images( 5, 'abstract' );
+		$images = $this->get_images();
+
+		$this->assertCount( 5, $images );
+
+		foreach ( $images as $id ) {
+			$this->assertGreaterThan( 0, $id, 'Each image should have a valid attachment ID' );
+			$this->assertEquals( 'attachment', get_post_type( $id ) );
+		}
+	}
+
+	/**
+	 * Test seed_images with existing mode queries media library.
+	 */
+	public function test_seed_images_existing_queries_media_library() {
+		// Create 3 test attachments.
+		$attachment_ids = $this->factory->attachment->create_many( 3, array(
+			'post_parent' => 0,
+		) );
+
+		Product::seed_images( 5, 'existing' );
+		$images = $this->get_images();
+
+		// Should have 3 existing + 2 generated = 5.
+		$this->assertCount( 5, $images );
+
+		// Verify the 3 existing attachments are included.
+		foreach ( $attachment_ids as $id ) {
+			$this->assertContains( $id, $images, 'Existing attachment should be in the image pool' );
+		}
+	}
+
+	/**
+	 * Test seed_images with existing mode fills gaps when not enough media library images.
+	 */
+	public function test_seed_images_existing_fills_gaps() {
+		// Create only 2 test attachments.
+		$this->factory->attachment->create_many( 2, array(
+			'post_parent' => 0,
+		) );
+
+		Product::seed_images( 5, 'existing' );
+		$images = $this->get_images();
+
+		// Should have 2 existing + 3 generated = 5.
+		$this->assertCount( 5, $images );
+	}
+
+	/**
+	 * Test get_image_count returns correct count.
+	 */
+	public function test_get_image_count_returns_correct_count() {
+		Product::seed_images( 7, 'abstract' );
+		$this->assertEquals( 7, Product::get_image_count() );
+	}
+
+	/**
+	 * Test get_image_count returns 0 for none mode.
+	 */
+	public function test_get_image_count_zero_for_none() {
+		Product::seed_images( 10, 'none' );
+		$this->assertEquals( 0, Product::get_image_count() );
+	}
+
+	/**
+	 * Test seed_images default mode is existing.
+	 */
+	public function test_seed_images_default_mode_is_existing() {
+		// Create 2 test attachments.
+		$this->factory->attachment->create_many( 2, array(
+			'post_parent' => 0,
+		) );
+
+		// Call without mode parameter.
+		Product::seed_images( 4 );
+		$images = $this->get_images();
+
+		// Should have 2 existing + 2 generated = 4.
+		$this->assertCount( 4, $images );
+	}
+
+	/**
+	 * Test get_image returns valid attachment ID when images are seeded.
+	 */
+	public function test_get_image_returns_valid_id_when_seeded() {
+		Product::seed_images( 3, 'abstract' );
+
+		$image_id = $this->call_get_image();
+		$this->assertGreaterThan( 0, $image_id );
+		$this->assertEquals( 'attachment', get_post_type( $image_id ) );
+	}
+
+	/**
+	 * Test realistic mode caps at 100 images.
+	 */
+	public function test_realistic_mode_caps_at_100() {
+		// Stub HTTP layer to avoid live network calls.
+		add_filter( 'pre_http_request', '__return_true', 99 );
+		add_filter( 'pre_media_handle_sideload', function () {
+			return $this->factory->attachment->create( array( 'post_parent' => 0 ) );
+		} );
+
+		// Request 150, should cap at 100.
+		Product::seed_images( 150, 'realistic' );
+		$this->assertLessThanOrEqual( 100, Product::get_image_count() );
+
+		// Clean up.
+		remove_filter( 'pre_http_request', '__return_true', 99 );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/woocommerce/wc-smooth-generator/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/wc-smooth-generator/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #159

Add `--images` parameter to `wp wc generate products` command with four modes:
- `abstract` — Jdenticon-generated images (no media library query)
- `realistic` — Lorem Picsum placeholder photos (HTTP download, capped at 100)
- `existing` — Query media library, fill gaps with Jdenticon (default, backward compatible)
- `none` — No images generated

Also add standalone `wp wc generate images {amount} --type=abstract|realistic|existing` command for generating images independently.

**Why:** Issue #159 requested control over image generation. Useful for testing without waiting for image processing, or for generating realistic placeholder content for demos.

### How to test the changes in this Pull Request:

1. Run `wp wc generate products 5` — should work as before (backward compatible)
2. Run `wp wc generate products 10 --images=none` — products created with no images
3. Run `wp wc generate products 10 --images=abstract` — products with Jdenticon images
4. Run `wp wc generate products 5 --images=realistic` — products with Lorem Picsum JPGs (slower, makes HTTP requests)
5. Run `wp wc generate images 20` — 20 Jdenticon images added to media library
6. Run `wp wc generate images 10 --type=realistic` — 10 realistic JPGs downloaded
7. Run `wp wc generate products --help` — verify `--images` flag documented

**Expected:** All modes work correctly. Default behavior unchanged. Gallery images respect mode (filtered out when `none`).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Add image generation modes to products command. New `--images` flag supports abstract (Jdenticon), realistic (Lorem Picsum), existing (media library), and none modes. Standalone `wp wc generate images` command added.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.